### PR TITLE
breaking: revert import.browser fileds

### DIFF
--- a/packages/core-base/package.json
+++ b/packages/core-base/package.json
@@ -55,7 +55,6 @@
     ".": {
       "import": {
         "node": "./index.mjs",
-        "browser": "./dist/core-base.esm-browser.prod.js",
         "default": "./dist/core-base.esm-bundler.js"
       },
       "require": "./index.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,6 @@
     ".": {
       "import": {
         "node": "./index.mjs",
-        "browser": "./dist/core.esm-browser.prod.js",
         "default": "./dist/core.esm-bundler.js"
       },
       "require": "./index.js"

--- a/packages/message-compiler/package.json
+++ b/packages/message-compiler/package.json
@@ -54,7 +54,6 @@
     ".": {
       "import": {
         "node": "./index.mjs",
-        "browser": "./dist/message-compiler.esm-browser.prod.js",
         "default": "./dist/message-compiler.esm-bundler.js"
       },
       "require": "./index.js"

--- a/packages/petite-vue-i18n/package.json
+++ b/packages/petite-vue-i18n/package.json
@@ -66,7 +66,6 @@
     ".": {
       "import": {
         "node": "./index.mjs",
-        "browser": "./dist/petite-vue-i18n.esm-browser.prod.js",
         "default": "./dist/petite-vue-i18n.esm-bundler.js"
       },
       "require": "./index.js"

--- a/packages/vue-i18n-bridge/package.json
+++ b/packages/vue-i18n-bridge/package.json
@@ -68,7 +68,6 @@
     ".": {
       "import": {
         "node": "./index.mjs",
-        "browser": "./dist/vue-i18n-bridge.esm-browser.prod.js",
         "default": "./dist/vue-i18n-bridge.esm-bundler.js"
       },
       "require": "./index.js"

--- a/packages/vue-i18n-core/package.json
+++ b/packages/vue-i18n-core/package.json
@@ -63,7 +63,6 @@
     ".": {
       "import": {
         "node": "./index.mjs",
-        "browser": "./dist/vue-i18n-core.esm-browser.prod.js",
         "default": "./dist/vue-i18n-core.esm-bundler.js"
       },
       "require": "./index.js"

--- a/packages/vue-i18n/package.json
+++ b/packages/vue-i18n/package.json
@@ -66,7 +66,6 @@
     ".": {
       "import": {
         "node": "./index.mjs",
-        "browser": "./dist/vue-i18n.esm-browser.prod.js",
         "default": "./dist/vue-i18n.esm-bundler.js"
       },
       "require": "./index.js"


### PR DESCRIPTION
Currently, the module for the browser provided by vue-i18n is a bit inconsistent.
For this reason, we stop supporting browser filed.