### PR TITLE
Added a comment about pluralRules to the code pluralization docs

### DIFF
--- a/docs/guide/essentials/pluralization.md
+++ b/docs/guide/essentials/pluralization.md
@@ -152,7 +152,7 @@ like the the following locale:
 ```js
 const i18n = createI18n({
   locale: 'ru',
-  // the custom rules here ...
+  // use pluralRules for Composition api
   pluralizationRules: {
     ru: customRule
   },


### PR DESCRIPTION
I removed meaningless comment and replaced it with more useful comment about `pluralRules` for Composition api.
I am just looking for the code and I'm not really reading through the documentation if the code is understandable, and seems like many people do the same https://github.com/intlify/vue-i18n/issues/882. However, in the docs there is a very important note. So, there is a higher chance that people will notice it if it's put directly into the code. 

_I've actually done the same mistake in 2 different projects. Luckily, at the second time I remembered that there was something wrong with docs and it didn't take me very long, but at the first time I spent quite a lot of time_
