### PR TITLE
fix(types): `$t` types

### DIFF
--- a/packages/core-base/src/types/utils.ts
+++ b/packages/core-base/src/types/utils.ts
@@ -30,6 +30,14 @@ export type LocaleRecord<T extends any[], R> = {
 
 export type First<T extends readonly any[]> = T[0]
 
+export declare type JsonPaths<T, Key extends keyof T = keyof T> = Key extends string ? 
+  T[Key] extends Record<string, any> ?
+    `${Key}.${JsonPaths<T[Key]>}`
+  : `${Key}`
+: never;
+export declare type TranslationsPaths<T extends object, K extends keyof T = keyof T> = K extends string
+  ? JsonPaths<T[K]> : never;
+
 export type __ResourcePath<T, Key extends keyof T> = Key extends string
   ? T[Key] extends Record<string, any>
     ?

--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -102,13 +102,14 @@ import type {
   ResourceValue,
   ResourcePath,
   ResourceNode,
-  PickupPaths,
   PickupFormatPathKeys,
   RemoveIndexSignature,
   RemovedIndexResources,
   IsNever,
   IsEmptyObject,
-  CoreMissingType
+  CoreMissingType,
+  JsonPaths,
+  TranslationsPaths
 } from '@intlify/core-base'
 import type { VueDevToolsEmitter } from '@intlify/devtools-types'
 
@@ -640,11 +641,13 @@ export interface ComposerTranslation<
   DefinedLocaleMessage extends
     RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
   C = IsEmptyObject<DefinedLocaleMessage> extends false
-    ? PickupPaths<{
+    ? JsonPaths<{
         [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
       }>
     : never,
-  M = IsEmptyObject<Messages> extends false ? PickupKeys<Messages> : never,
+  M = IsEmptyObject<Messages> extends false
+    ? TranslationsPaths<Messages>
+    : never,
   ResourceKeys extends C | M = IsNever<C> extends false
     ? IsNever<M> extends false
       ? C | M

--- a/packages/vue-i18n/src/vue.d.ts
+++ b/packages/vue-i18n/src/vue.d.ts
@@ -1,4 +1,4 @@
-import type { Path, NamedValue } from '@intlify/core-base'
+import type { NamedValue, JsonPaths } from '@intlify/core-base'
 import type {
   Locale,
   LocaleMessageValue,
@@ -8,7 +8,6 @@ import type {
   NumberOptions,
   IsNever,
   IsEmptyObject,
-  PickupPaths,
   PickupKeys,
   PickupFormatPathKeys
 } from '@intlify/core-base'
@@ -98,13 +97,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path
+      key: Key | ResourceKeys
     ): TranslateResult
     /**
      * Locale message translation
@@ -122,13 +121,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       plural: number
     ): TranslateResult
     /**
@@ -148,13 +147,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       plural: number,
       options: TranslateOptions
     ): TranslateResult
@@ -174,13 +173,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       defaultMsg: string
     ): TranslateResult
     /**
@@ -200,13 +199,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       defaultMsg: string,
       options: TranslateOptions
     ): TranslateResult
@@ -226,13 +225,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       list: unknown[]
     ): TranslateResult
     /**
@@ -252,13 +251,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       list: unknown[],
       plural: number
     ): TranslateResult
@@ -279,13 +278,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       list: unknown[],
       defaultMsg: string
     ): TranslateResult
@@ -306,13 +305,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       list: unknown[],
       options: TranslateOptions
     ): TranslateResult
@@ -332,13 +331,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       named: NamedValue
     ): TranslateResult
     /**
@@ -358,13 +357,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       named: NamedValue,
       plural: number
     ): TranslateResult
@@ -385,13 +384,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       named: NamedValue,
       defaultMsg: string
     ): TranslateResult
@@ -412,13 +411,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       named: NamedValue,
       options: TranslateOptions
     ): TranslateResult
@@ -508,13 +507,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path
+      key: Key | ResourceKeys
     ): TranslateResult
     /**
      * Locale message pluralization
@@ -533,13 +532,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       locale: Locale
     ): TranslateResult
     /**
@@ -559,13 +558,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       list: unknown[]
     ): TranslateResult
     /**
@@ -586,13 +585,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       named: Record<string, unknown>
     ): TranslateResult
     /**
@@ -613,13 +612,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       choice: number
     ): TranslateResult
     /**
@@ -641,13 +640,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       choice: number,
       locale: Locale
     ): TranslateResult
@@ -670,13 +669,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       choice: number,
       list: unknown[]
     ): TranslateResult
@@ -699,13 +698,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       choice: number,
       named: Record<string, unknown>
     ): TranslateResult
@@ -725,13 +724,13 @@ declare module '@vue/runtime-core' {
       DefinedLocaleMessage extends
         RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
-        ? PickupPaths<{
+        ? JsonPaths<{
             [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
           }>
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | Path,
+      key: Key | ResourceKeys,
       locale?: Locale
     ): boolean
     /**


### PR DESCRIPTION
This PR addresses 2 problems with Typescript types:

- #1215: By removing the type `Path` from the `key: Key | ResourceKeys | Path`, we get type inference to work again and suggest valid translations when using globally injected `$t`. Since the type `Key extends string` already extends from `string`, it shouldn't cause any regression. For the type inference to work when using `$t`, you have to extend the module types:
	```ts
	import en from '@src/assets/locales/en.json';
	
	type Messages = typeof en;
	
	declare module 'vue-i18n' {
	  export interface DefineLocaleMessage extends Messages {}
	}
	```
- When fixing the first issue, I found that nested keys are treated as translations by themselves. For example:
	```json
	{
	  "this": {
	    "is": {
	      "a": {
	        "nested": {
	          "key": "This is a nested key"
	        }
	      }
	    }
	  }
	}
	```
	When having this `en.json` locale file, type inference will suggest a combination of all keys:
	![image](https://github.com/intlify/vue-i18n/assets/7190600/ca482498-c75e-43d3-ae5a-5d114af40a0e)
	But this is not correct, only `this.is.a.nested.key` should be suggested. I've created two new types to solve this:

1. `JsonPaths`: Will return leaf keys only, and not suggest in-between keys from a JSON or Javascript object. I've called it Json because this should be used when extracting translations from JSON files.

2. `TranslationsPaths`: This will simply remove the first level of a JSON or JS object and return the `JsonPaths` from the second level onwards. This is used for translations coming directly from the composer, where the top-level key is the language.

I've tried not to modify existing types to avoid breaking something, and I just created these 2 new types. Here're two images of the new behavior both in `$t` and when using the composer:
![image](https://github.com/intlify/vue-i18n/assets/7190600/b3af5eea-d62c-4806-9246-b501f9fd5971)
![image](https://github.com/intlify/vue-i18n/assets/7190600/7a5fefcd-75ce-4507-88f8-0a8874643d46)

