### PR TITLE
feat: supports selecting the overwrite order of merge messages

### DIFF
--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -2,7 +2,7 @@ import { isArray, isObject } from './utils'
 
 const isNotObjectOrIsArray = (val: unknown) => !isObject(val) || isArray(val)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function deepCopy(src: any, des: any): void {
+export function deepCopy(src: any, des: any, isRetainExistMessage?: boolean): void {
   // src and des should both be objects, and none of them can be a array
   if (isNotObjectOrIsArray(src) || isNotObjectOrIsArray(des)) {
     throw new Error('Invalid value')
@@ -17,7 +17,9 @@ export function deepCopy(src: any, des: any): void {
         // replace with src[key] when:
         // src[key] or des[key] is not an object, or
         // src[key] or des[key] is an array
-        des[key] = src[key]
+        // if you need to keep the existing message on the i18n instance when merging, 
+        // you do not need to perform the following replacement
+        !isRetainExistMessage && (des[key] = src[key])
       } else {
         // src[key] and des[key] are both objects, merge them
         stack.push({ src: src[key], des: des[key] })

--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -2458,7 +2458,8 @@ export function createComposer(options: any = {}): any {
   // mergeLocaleMessage
   function mergeLocaleMessage(
     locale: Locale,
-    message: LocaleMessageDictionary<Message>
+    message: LocaleMessageDictionary<Message>,
+    isRetainExistMessage: boolean = false
   ): void {
     _messages.value[locale] = _messages.value[locale] || {}
     const _message = { [locale]: message }
@@ -2470,7 +2471,7 @@ export function createComposer(options: any = {}): any {
       }
     }
     message = _message[locale]
-    deepCopy(message, _messages.value[locale])
+    deepCopy(message, _messages.value[locale], isRetainExistMessage)
     _context.messages = _messages.value as typeof _context.messages
   }
 


### PR DESCRIPTION
Hello, I added this code to provide users facing this situation with more options: whether to replace the existing message on the i18n instance with the passed message.
And this way of writing can keep the function calls in the vue-i18n npm package unaffected.
The background reason is that I have an npm package and a Vue3 code base. When app.use this npm package, I passed the i18n instance of the Vue3 code base to the install function of the npm package, and then called mergeLocaleMessage, which caused the message of the npm package to overwrite the value of the same key in the Vue3 code base, but I hope that the message in the Vue3 code base has a higher priority, so I thought of this way.
I hope it can be adopted, thank you.