### PR TITLE
chore: fix module augmentation example comment

### DIFF
--- a/packages/core-base/src/runtime.ts
+++ b/packages/core-base/src/runtime.ts
@@ -34,7 +34,7 @@ type StringConvertable<T> = ExtractToStringKey<T> extends never
  * ```ts
  * // generated-i18n-types.d.ts (`.d.ts` file at your app)
  *
- * declare module '@intlify/core' {
+ * declare module '@intlify/core-base' {
  *   interface GeneratedTypeConfig {
  *     locale: "en" | "ja"
  *   }


### PR DESCRIPTION
The module augmentation should use `@intlify/core-base`, not `@intlify/core`, as described in https://github.com/nuxt-modules/i18n/pull/3034.