### PR TITLE
fix: nightly release condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,8 +198,8 @@ jobs:
     if: |
       github.event_name == 'push' &&
       !contains(github.event.head_commit.message, '[skip-release]') &&
-      !contains(github.event.head_commit.message, 'chore') &&
-      !contains(github.event.head_commit.message, 'docs')
+      !startsWith(github.event.head_commit.message, 'chore') &&
+      !startsWith(github.event.head_commit.message, 'docs')
 
     needs:
       - lint


### PR DESCRIPTION
Using `contains()` for `'chore'` and `'docs'` will prevent nightly release job from running if these words are used anywhere in the commit message, this is (especially) problematic for squashed PRs as they contain a list of all commits.

Checking with `startsWith()` instead will probably have to intended behavior.