### PR TITLE
fix: messages `deepCopy` mutates `src` arguments

### DIFF
--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -12,6 +12,7 @@ export function deepCopy(src: any, des: any): void {
   while (stack.length) {
     const { src, des } = stack.pop()!
 
+    // using `Object.keys` which skips prototype properties
     Object.keys(src).forEach(key => {
       // if src[key] is an object/array, set des[key]
       // to empty object/array to prevent setting by reference
@@ -19,14 +20,14 @@ export function deepCopy(src: any, des: any): void {
         des[key] = Array.isArray(src[key]) ? [] : {}
       }
 
-      if (isObject(des[key]) && isObject(src[key])) {
-        // src[key] and des[key] are both objects, merge them
-        stack.push({ src: src[key], des: des[key] })
-      } else {
+      if (isNotObjectOrIsArray(des[key]) || isNotObjectOrIsArray(src[key])) {
         // replace with src[key] when:
         // src[key] or des[key] is not an object, or
         // src[key] or des[key] is an array
         des[key] = src[key]
+      } else {
+        // src[key] and des[key] are both objects, merge them
+        stack.push({ src: src[key], des: des[key] })
       }
     })
   }

--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -13,14 +13,20 @@ export function deepCopy(src: any, des: any): void {
     const { src, des } = stack.pop()!
 
     Object.keys(src).forEach(key => {
-      if (isNotObjectOrIsArray(src[key]) || isNotObjectOrIsArray(des[key])) {
+      // if src[key] is an object/array, set des[key]
+      // to empty object/array to prevent setting by reference
+      if (isObject(src[key]) && !isObject(des[key])) {
+        des[key] = Array.isArray(src[key]) ? [] : {}
+      }
+
+      if (isObject(des[key]) && isObject(src[key])) {
+        // src[key] and des[key] are both objects, merge them
+        stack.push({ src: src[key], des: des[key] })
+      } else {
         // replace with src[key] when:
         // src[key] or des[key] is not an object, or
         // src[key] or des[key] is an array
         des[key] = src[key]
-      } else {
-        // src[key] and des[key] are both objects, merge them
-        stack.push({ src: src[key], des: des[key] })
       }
     })
   }

--- a/packages/shared/test/messages.test.ts
+++ b/packages/shared/test/messages.test.ts
@@ -1,0 +1,50 @@
+import { deepCopy } from '../src/index'
+
+test('deepCopy merges without mutating src argument', () => {
+  const msg1 = {
+    hello: 'Greetings',
+    about: {
+      title: 'About us'
+    },
+    overwritten: 'Original text',
+    fruit: [{ name: 'Apple' }]
+  }
+  const copy1 = structuredClone(msg1)
+
+  const msg2 = {
+    bye: 'Goodbye',
+    about: {
+      content: 'Some text'
+    },
+    overwritten: 'New text',
+    fruit: [{ name: 'Strawberry' }],
+    // @ts-ignore
+    car: ({ plural }) => plural(['car', 'cars'])
+  }
+
+  const merged = {}
+
+  deepCopy(msg1, merged)
+  deepCopy(msg2, merged)
+
+  expect(merged).toMatchInlineSnapshot(`
+    {
+      "about": {
+        "content": "Some text",
+        "title": "About us",
+      },
+      "bye": "Goodbye",
+      "car": [Function],
+      "fruit": [
+        {
+          "name": "Strawberry",
+        },
+      ],
+      "hello": "Greetings",
+      "overwritten": "New text",
+    }
+  `)
+
+  // should not mutate source object
+  expect(msg1).toStrictEqual(copy1)
+})


### PR DESCRIPTION
>[!IMPORTANT]
>This has not been thoroughly tested but should demonstrate the issue with `deepCopy`

Currently during `deepCopy` if a key is unset, it will be assigned to the value of the `src[key]`, this is an issue for objects as they will be assigned by reference, meaning following calls to `deepCopy` will assign properties on these objects.

So far a simple solution seems to be to set the property value to an empty object/array, this ensures both `src[key]` and `des[key]` are objects meaning `deepCopy` will merge these as such instead of direct assignment.

I've had this saved in a git stash for some time so it has been a while since debugging this issue, I'm opening this PR so I won't forget about it again 😅

https://github.com/nuxt-modules/i18n/issues/3089
https://github.com/nuxt-modules/i18n/issues/2803