### PR TITLE
fix: vue-i18n type definition for vue package

### DIFF
--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -12,8 +12,15 @@ export function deepCopy(src: any, des: any): void {
   while (stack.length) {
     const { src, des } = stack.pop()!
 
+    // using `Object.keys` which skips prototype properties
     Object.keys(src).forEach(key => {
-      if (isNotObjectOrIsArray(src[key]) || isNotObjectOrIsArray(des[key])) {
+      // if src[key] is an object/array, set des[key]
+      // to empty object/array to prevent setting by reference
+      if (isObject(src[key]) && !isObject(des[key])) {
+        des[key] = Array.isArray(src[key]) ? [] : {}
+      }
+
+      if (isNotObjectOrIsArray(des[key]) || isNotObjectOrIsArray(src[key])) {
         // replace with src[key] when:
         // src[key] or des[key] is not an object, or
         // src[key] or des[key] is an array

--- a/packages/shared/test/messages.test.ts
+++ b/packages/shared/test/messages.test.ts
@@ -1,0 +1,50 @@
+import { deepCopy } from '../src/index'
+
+test('deepCopy merges without mutating src argument', () => {
+  const msg1 = {
+    hello: 'Greetings',
+    about: {
+      title: 'About us'
+    },
+    overwritten: 'Original text',
+    fruit: [{ name: 'Apple' }]
+  }
+  const copy1 = structuredClone(msg1)
+
+  const msg2 = {
+    bye: 'Goodbye',
+    about: {
+      content: 'Some text'
+    },
+    overwritten: 'New text',
+    fruit: [{ name: 'Strawberry' }],
+    // @ts-ignore
+    car: ({ plural }) => plural(['car', 'cars'])
+  }
+
+  const merged = {}
+
+  deepCopy(msg1, merged)
+  deepCopy(msg2, merged)
+
+  expect(merged).toMatchInlineSnapshot(`
+    {
+      "about": {
+        "content": "Some text",
+        "title": "About us",
+      },
+      "bye": "Goodbye",
+      "car": [Function],
+      "fruit": [
+        {
+          "name": "Strawberry",
+        },
+      ],
+      "hello": "Greetings",
+      "overwritten": "New text",
+    }
+  `)
+
+  // should not mutate source object
+  expect(msg1).toStrictEqual(copy1)
+})


### PR DESCRIPTION
This is cherry picked from https://github.com/intlify/vue-i18n/pull/1947, hopefully the last backport for v9 😅 This would allow me to resolve the related issues downstream in Nuxt i18n v8 so users don't need to experience it before migrating to the eventual stable Nuxt i18n v9.

Related
* https://github.com/nuxt-modules/i18n/issues/3089
* https://github.com/nuxt-modules/i18n/issues/2803