### PR TITLE
fix: tag v9 releases with `legacy9` and `next9`

### DIFF
--- a/scripts/release-edge.sh
+++ b/scripts/release-edge.sh
@@ -24,7 +24,7 @@ for PKG in packages/* ; do
     fi
     pushd $PKG
     echo "⚡ Publishing $PKG with edge tag"
-    pnpm publish --access public --no-git-checks --tag edge
+    pnpm publish --access public --no-git-checks --tag edge9
     popd
   fi
 done

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -23,7 +23,7 @@ for PKG in packages/* ; do
       continue
     fi
     pushd $PKG
-    TAG="latest"
+    TAG="legacy9"
     echo "⚡ Publishing $PKG with tag $TAG"
     pnpm publish --access public --no-git-checks --tag $TAG
     popd > /dev/null


### PR DESCRIPTION
It looks like the previous releases for v9 have been tagged with `latest`, so users installing these packages are not getting v10.

Not sure if you want v9 releases to be tagged as `legacy9` and `next9`, feel free to change it. Also not sure if these are the only spots where the tags are being set 🤔

Perhaps the v10 version tags can be fixed by rerunning the release action.