### PR TITLE
Change verbosity of Not found parent scope use global scope

### DIFF
--- a/packages/vue-i18n-core/src/i18n.ts
+++ b/packages/vue-i18n-core/src/i18n.ts
@@ -4,8 +4,7 @@ import {
   isBoolean,
   isEmptyObject,
   isPlainObject,
-  makeSymbol,
-  warn
+  makeSymbol
 } from '@intlify/shared'
 import {
   InjectionKey,
@@ -727,8 +726,8 @@ export function useI18n<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let composer = getComposer(i18n, instance, (options as any).__useComponent)
     if (composer == null) {
-      if (__DEV__) {
-        warn(getWarnMessage(I18nWarnCodes.NOT_FOUND_PARENT_SCOPE))
+      if (__DEV__ && console && console.debug) {
+        console.debug(getWarnMessage(I18nWarnCodes.NOT_FOUND_PARENT_SCOPE))
       }
       composer = gl as unknown as Composer
     }


### PR DESCRIPTION
This warning has been annoying everyone for more than 5 years now. As a first step, let's switch it to a debug message at least
https://github.com/intlify/vue-i18n/discussions/851