### PR TITLE
fix(docs): correct output in composition api example

### DIFF
--- a/docs/guide/advanced/composition.md
+++ b/docs/guide/advanced/composition.md
@@ -82,7 +82,7 @@ The output follows:
 
 ```vue
 <div id="app">
-  <p>こんにちは、世界</p>
+  <h1>こんにちは、世界</h1>
 </div>
 ```
 


### PR DESCRIPTION
Updated the example output in the documentation to reflect the correct HTML structure. Changed `<p>` tags to `<h1>` tags to align with the intended rendered output:

Previous output: `<p>こんにちは、世界</p>`
Corrected output: `<h1>こんにちは、世界</h1>`