### PR TITLE
fix: `tm` function should accept `DefineLocaleMessage` key type

### DIFF
--- a/packages/vue-i18n/src/vue.d.ts
+++ b/packages/vue-i18n/src/vue.d.ts
@@ -8,7 +8,6 @@ import type {
   NumberOptions,
   IsNever,
   IsEmptyObject,
-  PickupKeys,
   PickupFormatPathKeys
 } from '@intlify/core-base'
 import type {
@@ -1107,8 +1106,14 @@ declare module 'vue' {
      */
     $tm<
       Key extends string,
-      Messages extends object = {},
-      ResourceKeys extends PickupKeys<Messages> = PickupKeys<Messages>
+      DefinedLocaleMessage extends
+        RemovedIndexResources<DefineLocaleMessage> = RemovedIndexResources<DefineLocaleMessage>,
+      Keys = IsEmptyObject<DefinedLocaleMessage> extends false
+        ? JsonPaths<{
+            [K in keyof DefinedLocaleMessage]: DefinedLocaleMessage[K]
+          }>
+        : never,
+      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
       key: Key | ResourceKeys
     ): LocaleMessageValue<VueMessageType> | {}


### PR DESCRIPTION
It looks like the `$tm` function on `ComponentCustomProperties` does not use the `DefineLocaleMessage` type for the key parameter. This is a simple copy paste of the type parameters used for `$t`, which I think should be the same for the keys.