### PR TITLE
feat!: deprecate Legacy API mode

### DIFF
--- a/e2e/fallback/basic.spec.ts
+++ b/e2e/fallback/basic.spec.ts
@@ -5,7 +5,10 @@ import { getText } from '../helper'
     beforeAll(async () => {
       page.on('console', msg => {
         if (msg.type() === 'warning') {
-          warnings.push(msg.text())
+          const text = msg.text()
+          if (!text.match(/^\[intlify\] Legacy API mode has been/)) {
+            warnings.push(msg.text())
+          }
         }
       })
       await page.goto(

--- a/e2e/fallback/format.spec.ts
+++ b/e2e/fallback/format.spec.ts
@@ -5,7 +5,10 @@ import { getText } from '../helper'
     beforeAll(async () => {
       page.on('console', msg => {
         if (msg.type() === 'warning') {
-          warnings.push(msg.text())
+          const text = msg.text()
+          if (!text.match(/^\[intlify\] Legacy API mode has been/)) {
+            warnings.push(msg.text())
+          }
         }
       })
       await page.goto(

--- a/e2e/fallback/option.spec.ts
+++ b/e2e/fallback/option.spec.ts
@@ -5,7 +5,10 @@ import { getText } from '../helper'
     beforeAll(async () => {
       page.on('console', msg => {
         if (msg.type() === 'warning') {
-          warnings.push(msg.text())
+          const text = msg.text()
+          if (!text.match(/^\[intlify\] Legacy API mode has been/)) {
+            warnings.push(msg.text())
+          }
         }
       })
       await page.goto(

--- a/e2e/fallback/suppress.spec.ts
+++ b/e2e/fallback/suppress.spec.ts
@@ -5,7 +5,10 @@ import { getText } from '../helper'
     beforeAll(async () => {
       page.on('console', msg => {
         if (msg.type() === 'warning') {
-          warnings.push(msg.text())
+          const text = msg.text()
+          if (!text.match(/^\[intlify\] Legacy API mode has been/)) {
+            warnings.push(msg.text())
+          }
         }
       })
       await page.goto(

--- a/e2e/missing/handler.spec.ts
+++ b/e2e/missing/handler.spec.ts
@@ -5,7 +5,10 @@ import { getText } from '../helper'
     beforeAll(async () => {
       page.on('console', msg => {
         if (msg.type() === 'warning') {
-          warnings.push(msg.text())
+          const text = msg.text()
+          if (!text.match(/^\[intlify\] Legacy API mode has been/)) {
+            warnings.push(msg.text())
+          }
         }
       })
       await page.goto(

--- a/e2e/missing/option.spec.ts
+++ b/e2e/missing/option.spec.ts
@@ -5,7 +5,10 @@ import { getText } from '../helper'
     beforeAll(async () => {
       page.on('console', msg => {
         if (msg.type() === 'warning') {
-          warnings.push(msg.text())
+          const text = msg.text()
+          if (!text.match(/^\[intlify\] Legacy API mode has been/)) {
+            warnings.push(msg.text())
+          }
         }
       })
       await page.goto(

--- a/e2e/missing/suppress.spec.ts
+++ b/e2e/missing/suppress.spec.ts
@@ -5,7 +5,10 @@ import { getText } from '../helper'
     beforeAll(async () => {
       page.on('console', msg => {
         if (msg.type() === 'warning') {
-          warnings.push(msg.text())
+          const text = msg.text()
+          if (!text.match(/^\[intlify\] Legacy API mode has been/)) {
+            warnings.push(msg.text())
+          }
         }
       })
       await page.goto(

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@types/minimist": "^1.2.5",
     "@types/node": "^22.5.3",
     "@types/rc": "^1.2.4",
-    "@vitest/coverage-v8": "^2.0.0",
+    "@vitest/coverage-v8": "^2.1.5",
     "api-docs-gen": "^0.4.0",
     "benchmark": "^2.1.4",
     "brotli": "^1.3.2",
@@ -145,7 +145,7 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.4.0",
     "vitepress": "1.5.0",
-    "vitest": "^2.0.4",
+    "vitest": "^2.1.5",
     "vue": "3.5.12",
     "vue-i18n": "workspace:*"
   },
@@ -177,7 +177,7 @@
   "pnpm": {
     "overrides": {
       "vue": "3.5.12",
-      "vite": "^5.1.2"
+      "vite": "^5.4.11"
     }
   }
 }

--- a/packages/size-check-petite-vue-i18n/src/main.ts
+++ b/packages/size-check-petite-vue-i18n/src/main.ts
@@ -2,11 +2,69 @@ import { createApp } from 'vue'
 import { createI18n } from 'vue-i18n'
 import App from './App.vue'
 
+const ast = {
+  type: 0,
+  start: 0,
+  end: 6,
+  loc: {
+    start: {
+      line: 1,
+      column: 1,
+      offset: 0
+    },
+    end: {
+      line: 1,
+      column: 7,
+      offset: 6
+    },
+    source: 'hello!'
+  },
+  body: {
+    type: 2,
+    start: 0,
+    end: 6,
+    loc: {
+      start: {
+        line: 1,
+        column: 1,
+        offset: 0
+      },
+      end: {
+        line: 1,
+        column: 7,
+        offset: 6
+      }
+    },
+    items: [
+      {
+        type: 3,
+        start: 0,
+        end: 6,
+        loc: {
+          start: {
+            line: 1,
+            column: 1,
+            offset: 0
+          },
+          end: {
+            line: 1,
+            column: 7,
+            offset: 6
+          }
+        },
+        value: 'hello!'
+      }
+    ],
+    static: 'hello!'
+  },
+  cacheKey: '{"l":"en","k":"hello","s":"hello!"}'
+}
+
 const i18n = createI18n({
   locale: 'en',
   messages: {
     en: {
-      hello: 'hello!'
+      hello: ast
     }
   }
 })

--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -1,118 +1,118 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ref, computed, getCurrentInstance, watch, shallowRef } from 'vue'
 import {
-  warn,
-  isArray,
-  isFunction,
-  isNumber,
-  isString,
-  isRegExp,
-  isBoolean,
-  isPlainObject,
-  isObject,
-  assign,
-  inBrowser,
-  deepCopy,
-  hasOwn
-} from '@intlify/shared'
-import {
+  DEFAULT_LOCALE,
+  MISSING_RESOLVE_VALUE,
+  MessageFunction,
+  NOT_REOSLVED,
+  clearDateTimeFormat,
+  clearNumberFormat,
+  createCoreContext,
+  datetime,
+  fallbackWithLocaleChain,
+  getFallbackContext,
+  isMessageAST,
+  isMessageFunction,
   isTranslateFallbackWarn,
   isTranslateMissingWarn,
-  createCoreContext,
-  MISSING_RESOLVE_VALUE,
-  updateFallbackLocale,
-  translate,
-  parseTranslateArgs,
-  datetime,
-  parseDateTimeArgs,
-  clearDateTimeFormat,
   number,
+  parseDateTimeArgs,
   parseNumberArgs,
-  clearNumberFormat,
-  fallbackWithLocaleChain,
-  NOT_REOSLVED,
-  MessageFunction,
+  parseTranslateArgs,
   setAdditionalMeta,
-  getFallbackContext,
   setFallbackContext,
-  DEFAULT_LOCALE,
-  isMessageAST,
-  isMessageFunction
+  translate,
+  updateFallbackLocale
 } from '@intlify/core-base'
-import { I18nWarnCodes, getWarnMessage } from './warnings'
-import { I18nErrorCodes, createI18nError } from './errors'
 import {
-  TranslateVNodeSymbol,
+  assign,
+  deepCopy,
+  hasOwn,
+  inBrowser,
+  isArray,
+  isBoolean,
+  isFunction,
+  isNumber,
+  isObject,
+  isPlainObject,
+  isRegExp,
+  isString,
+  warn
+} from '@intlify/shared'
+import { computed, getCurrentInstance, ref, shallowRef, watch } from 'vue'
+import { I18nErrorCodes, createI18nError } from './errors'
+import { VERSION } from './misc'
+import {
   DatetimePartsSymbol,
-  NumberPartsSymbol,
-  EnableEmitter,
   DisableEmitter,
+  EnableEmitter,
+  InejctWithOptionSymbol,
+  NumberPartsSymbol,
   SetPluralRulesSymbol,
-  InejctWithOptionSymbol
+  TranslateVNodeSymbol
 } from './symbols'
 import {
-  getLocaleMessages,
-  getComponentOptions,
   createTextNode,
+  getComponentOptions,
+  getLocaleMessages,
   handleFlatJson
 } from './utils'
-import { VERSION } from './misc'
+import { I18nWarnCodes, getWarnMessage } from './warnings'
 
 import type {
-  ComponentInternalInstance,
-  VNode,
-  VNodeArrayChildren,
-  WritableComputedRef,
-  ComputedRef
-} from 'vue'
-import type {
-  Path,
-  MessageResolver,
-  MessageCompiler,
+  CoreContext,
+  CoreInternalContext,
+  CoreMissingHandler,
+  CoreMissingType,
+  DateTimeFormat,
+  DateTimeFormats as DateTimeFormatsType,
+  DateTimeOptions,
+  FallbackLocale,
+  FallbackLocales,
+  GeneratedLocale,
+  IsEmptyObject,
+  IsNever,
+  JsonPaths,
   LinkedModifiers,
-  PluralizationRules,
-  NamedValue,
+  Locale,
+  LocaleMessage,
+  LocaleMessageDictionary,
+  LocaleMessageValue,
+  LocaleMessages,
+  LocaleParams,
+  MessageCompiler,
   MessageFunctions,
   MessageProcessor,
+  MessageResolver,
   MessageType,
-  Locale,
-  LocaleMessageValue,
-  LocaleMessage,
-  LocaleMessages,
-  CoreContext,
-  CoreMissingHandler,
-  LocaleMessageDictionary,
-  PostTranslationHandler,
-  FallbackLocale,
-  CoreInternalContext,
-  TranslateOptions,
-  DateTimeOptions,
-  NumberOptions,
-  DateTimeFormats as DateTimeFormatsType,
-  NumberFormats as NumberFormatsType,
-  DateTimeFormat,
-  NumberFormat,
   MetaInfo,
-  PickupLocales,
-  PickupKeys,
+  NamedValue,
+  NumberFormat,
+  NumberFormats as NumberFormatsType,
+  NumberOptions,
+  Path,
   PickupFormatKeys,
-  FallbackLocales,
-  SchemaParams,
-  LocaleParams,
-  ResourceValue,
-  ResourcePath,
-  ResourceNode,
   PickupFormatPathKeys,
+  PickupKeys,
+  PickupLocales,
+  PluralizationRules,
+  PostTranslationHandler,
   RemoveIndexSignature,
   RemovedIndexResources,
-  IsNever,
-  IsEmptyObject,
-  CoreMissingType,
-  JsonPaths,
-  TranslationsPaths,
-  GeneratedLocale
+  ResourceNode,
+  ResourcePath,
+  ResourceValue,
+  SchemaParams,
+  TranslateOptions,
+  TranslationsPaths
 } from '@intlify/core-base'
 import type { VueDevToolsEmitter } from '@intlify/devtools-types'
+import type {
+  ComponentInternalInstance,
+  ComputedRef,
+  VNode,
+  VNodeArrayChildren,
+  WritableComputedRef
+} from 'vue'
 
 export { DEFAULT_LOCALE } from '@intlify/core-base'
 
@@ -1889,10 +1889,7 @@ export function createComposer<
   > = Options['numberFormats'] extends Record<string, any>
     ? Options['numberFormats']
     : {}
->(
-  options: Options,
-  VueI18nLegacy?: any
-): Composer<Messages, DateTimeFormats, NumberFormats>
+>(options: Options): Composer<Messages, DateTimeFormats, NumberFormats>
 
 export function createComposer<
   Schema extends object = DefaultLocaleMessageSchema,
@@ -1919,10 +1916,7 @@ export function createComposer<
   > extends Record<string, any>
     ? NonNullable<Options['numberFormats']>
     : {}
->(
-  options: Options,
-  VueI18nLegacy?: any
-): Composer<Messages, DateTimeFormats, NumberFormats>
+>(options: Options): Composer<Messages, DateTimeFormats, NumberFormats>
 
 /**
  * Create composer interface factory

--- a/packages/vue-i18n-core/src/legacy.ts
+++ b/packages/vue-i18n-core/src/legacy.ts
@@ -1,82 +1,109 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { createComposer, DefineLocaleMessage } from './composer'
-import { createI18nError, I18nErrorCodes } from './errors'
-import { I18nWarnCodes, getWarnMessage } from './warnings'
-import { EnableEmitter, DisableEmitter } from './symbols'
 import { DEFAULT_LOCALE } from '@intlify/core-base'
 import {
-  isString,
+  assign,
   isArray,
-  isPlainObject,
-  isNumber,
   isBoolean,
   isFunction,
+  isNumber,
+  isPlainObject,
   isRegExp,
-  assign,
+  isString,
   warnOnce
 } from '@intlify/shared'
+import { createComposer, DefineLocaleMessage } from './composer'
+import { createI18nError, I18nErrorCodes } from './errors'
+import { DisableEmitter, EnableEmitter } from './symbols'
+import { getWarnMessage, I18nWarnCodes } from './warnings'
 
 import type {
-  Path,
-  MessageResolver,
-  PluralizationRule,
-  PluralizationRules,
-  LinkedModifiers,
-  NamedValue,
-  Locale,
-  LocaleMessage,
-  LocaleMessages,
-  LocaleMessageDictionary,
-  PostTranslationHandler,
-  FallbackLocale,
-  LocaleMessageValue,
-  TranslateOptions,
-  DateTimeFormats as DateTimeFormatsType,
-  NumberFormats as NumberFormatsType,
   DateTimeFormat,
-  NumberFormat,
-  PickupKeys,
-  PickupFormatKeys,
-  PickupLocales,
-  SchemaParams,
-  LocaleParams,
-  RemoveIndexSignature,
-  RemovedIndexResources,
+  DateTimeFormats as DateTimeFormatsType,
+  FallbackLocale,
   FallbackLocales,
-  PickupPaths,
-  PickupFormatPathKeys,
+  GeneratedLocale,
   IsEmptyObject,
   IsNever,
-  GeneratedLocale
+  LinkedModifiers,
+  Locale,
+  LocaleMessage,
+  LocaleMessageDictionary,
+  LocaleMessages,
+  LocaleMessageValue,
+  LocaleParams,
+  MessageResolver,
+  NamedValue,
+  NumberFormat,
+  NumberFormats as NumberFormatsType,
+  Path,
+  PickupFormatKeys,
+  PickupFormatPathKeys,
+  PickupKeys,
+  PickupLocales,
+  PickupPaths,
+  PluralizationRule,
+  PluralizationRules,
+  PostTranslationHandler,
+  RemovedIndexResources,
+  RemoveIndexSignature,
+  SchemaParams,
+  TranslateOptions
 } from '@intlify/core-base'
 import type { VueDevToolsEmitter } from '@intlify/devtools-types'
 import type {
-  VueMessageType,
-  DefaultLocaleMessageSchema,
-  DefineDateTimeFormat,
-  DefaultDateTimeFormatSchema,
-  DefineNumberFormat,
-  DefaultNumberFormatSchema,
-  MissingHandler,
   Composer,
-  ComposerOptions,
   ComposerInternalOptions,
-  ComposerResolveLocaleMessageTranslation
+  ComposerOptions,
+  ComposerResolveLocaleMessageTranslation,
+  DefaultDateTimeFormatSchema,
+  DefaultLocaleMessageSchema,
+  DefaultNumberFormatSchema,
+  DefineDateTimeFormat,
+  DefineNumberFormat,
+  MissingHandler,
+  VueMessageType
 } from './composer'
 import type { Disposer } from './types'
 
-/** @VueI18nLegacy */
+/**
+ * @deprecated will be removed at vue-i18n v12
+ * @VueI18nLegacy
+ */
 export type TranslateResult = string
+/**
+ * @deprecated will be removed at vue-i18n v12
+ * @VueI18nLegacy
+ */
 export type Choice = number
-/** @VueI18nLegacy */
+/**
+ * @deprecated will be removed at vue-i18n v12
+ * @VueI18nLegacy
+ */
 export type LocaleMessageObject<Message = string> =
   LocaleMessageDictionary<Message>
+/**
+ * @deprecated will be removed at vue-i18n v12
+ * @VueI18nLegacy
+ */
 export type PluralizationRulesMap = { [locale: string]: PluralizationRule }
+/**
+ * @deprecated will be removed at vue-i18n v12
+ * @VueI18nLegacy
+ */
 export type WarnHtmlInMessageLevel = 'off' | 'warn' | 'error'
-/** @VueI18nLegacy */
+/**
+ * @deprecated will be removed at vue-i18n v12
+ * @VueI18nLegacy
+ */
 export type DateTimeFormatResult = string
-/** @VueI18nLegacy */
+/**
+ * @deprecated will be removed at vue-i18n v12
+ * @VueI18nLegacy
+ */
 export type NumberFormatResult = string
+/**
+ * @deprecated will be removed at vue-i18n v12
+ */
 export type VueI18nExtender = (vueI18n: VueI18n) => Disposer | undefined
 
 /**
@@ -84,6 +111,8 @@ export type VueI18nExtender = (vueI18n: VueI18n) => Disposer | undefined
  *
  *  @remarks
  *  This option is compatible with `VueI18n` class constructor options (offered with Vue I18n v8.x)
+ *
+ * @deprecated will be removed at vue-i18n v12
  *
  *  @VueI18nLegacy
  */
@@ -368,6 +397,8 @@ export interface VueI18nOptions<
 
 /**
  * @internal
+ *
+ * @deprecated will be removed at vue-i18n v12
  */
 export interface VueI18nInternalOptions {
   __extender?: VueI18nExtender
@@ -378,6 +409,8 @@ export interface VueI18nInternalOptions {
  *
  * @remarks
  * This is the interface for {@link VueI18n}
+ *
+ * @deprecated will be removed at vue-i18n v12
  *
  * @VueI18nLegacy
  */
@@ -677,6 +710,8 @@ export interface VueI18nTranslation<
 /**
  * Resolve locale message translation functions for VueI18n legacy interfaces
  *
+ * @deprecated will be removed at vue-i18n v12
+ *
  * @remarks
  * This is the interface for {@link VueI18n}. This interface is an alias of {@link ComposerResolveLocaleMessageTranslation}.
  *
@@ -690,6 +725,8 @@ export type VueI18nResolveLocaleMessageTranslation<Locales = 'en-US'> =
  *
  * @remarks
  * This is the interface for {@link VueI18n}
+ *
+ * @deprecated will be removed at vue-i18n v12
  *
  * @VueI18nLegacy
  */
@@ -847,6 +884,8 @@ export interface VueI18nTranslationChoice<
  * @remarks
  * This is the interface for {@link VueI18n}
  *
+ * @deprecated will be removed at vue-i18n v12
+ *
  * @VueI18nLegacy
  */
 export interface VueI18nDateTimeFormatting<
@@ -942,6 +981,8 @@ export interface VueI18nDateTimeFormatting<
  * @remarks
  * This is the interface for {@link VueI18n}
  *
+ * @deprecated will be removed at vue-i18n v12
+ *
  * @VueI18nLegacy
  */
 export interface VueI18nNumberFormatting<
@@ -1036,6 +1077,8 @@ export interface VueI18nNumberFormatting<
  *
  *  @remarks
  *  This interface is compatible with interface of `VueI18n` class (offered with Vue I18n v8.x).
+ *
+ * @deprecated will be removed at vue-i18n v12
  *
  *  @VueI18nLegacy
  */
@@ -1411,6 +1454,8 @@ export interface VueI18n<
 
 /**
  * @internal
+ *
+ * @deprecated will be removed at vue-i18n v12
  */
 export interface VueI18nInternal<
   Messages extends Record<string, any> = {},
@@ -1536,10 +1581,7 @@ export function createVueI18n<
   > = Options['numberFormats'] extends Record<string, any>
     ? Options['numberFormats']
     : {}
->(
-  options?: Options,
-  VueI18nLegacy?: any
-): VueI18n<Messages, DateTimeFormats, NumberFormats>
+>(options?: Options): VueI18n<Messages, DateTimeFormats, NumberFormats>
 
 export function createVueI18n<
   Schema extends object = DefaultLocaleMessageSchema,
@@ -1566,15 +1608,14 @@ export function createVueI18n<
   > extends Record<string, any>
     ? NonNullable<Options['numberFormats']>
     : {}
->(
-  options?: Options,
-  VueI18nLegacy?: any
-): VueI18n<Messages, DateTimeFormats, NumberFormats>
+>(options?: Options): VueI18n<Messages, DateTimeFormats, NumberFormats>
 
 /**
  * create VueI18n interface factory
  *
  * @internal
+ *
+ * @deprecated will be removed at vue-i18n v12
  */
 
 export function createVueI18n(options: any = {}): any {

--- a/packages/vue-i18n-core/src/warnings.ts
+++ b/packages/vue-i18n-core/src/warnings.ts
@@ -1,11 +1,15 @@
-import { format } from '@intlify/shared'
 import { CORE_WARN_CODES_EXTEND_POINT } from '@intlify/core-base'
+import { format } from '@intlify/shared'
 
 export const I18nWarnCodes = {
   FALLBACK_TO_ROOT: CORE_WARN_CODES_EXTEND_POINT, // 8
   NOT_FOUND_PARENT_SCOPE: 9,
   IGNORE_OBJ_FLATTEN: 10,
-  DEPRECATE_TC: 11
+  DEPRECATE_TC: 11,
+  /**
+   * @deprecated will be removed at vue-i18n v12
+   */
+  DEPRECATE_LEGACY_MODE: 12
 } as const
 
 type I18nWarnCodes = (typeof I18nWarnCodes)[keyof typeof I18nWarnCodes]
@@ -14,7 +18,11 @@ export const warnMessages: { [code: number]: string } = {
   [I18nWarnCodes.FALLBACK_TO_ROOT]: `Fall back to {type} '{key}' with root locale.`,
   [I18nWarnCodes.NOT_FOUND_PARENT_SCOPE]: `Not found parent scope. use the global scope.`,
   [I18nWarnCodes.IGNORE_OBJ_FLATTEN]: `Ignore object flatten: '{key}' key has an string value`,
-  [I18nWarnCodes.DEPRECATE_TC]: `'tc' and '$tc' has been deprecated in v10. Use 't' or '$t' instead. 'tc' and '$tc’ are going to remove in v11.`
+  [I18nWarnCodes.DEPRECATE_TC]: `'tc' and '$tc' has been deprecated in v10. Use 't' or '$t' instead. 'tc' and '$tc’ are going to remove in v11.`,
+  /**
+   * @deprecated will be removed at vue-i18n v12
+   */
+  [I18nWarnCodes.DEPRECATE_LEGACY_MODE]: `Legacy API mode has been deprecated in v11. Use Composition API mode instead.\nAbout how to use the Composition API mode, see https://vue-i18n.intlify.dev/guide/advanced/composition.html`
 }
 
 export function getWarnMessage(

--- a/packages/vue-i18n-core/test/directive.test.ts
+++ b/packages/vue-i18n-core/test/directive.test.ts
@@ -11,23 +11,24 @@ vi.mock('@intlify/shared', async () => {
   const actual = await vi.importActual<object>('@intlify/shared')
   return {
     ...actual,
-    warn: vi.fn()
+    warn: vi.fn(),
+    warnOnce: vi.fn()
   }
 })
 
-import { mount } from './helper'
-import { defineComponent, ref, h, withDirectives, resolveDirective } from 'vue'
-import { format } from '@intlify/shared'
 import {
   compile,
-  registerMessageCompiler,
-  resolveValue,
-  registerMessageResolver,
   fallbackWithLocaleChain,
-  registerLocaleFallbacker
+  registerLocaleFallbacker,
+  registerMessageCompiler,
+  registerMessageResolver,
+  resolveValue
 } from '@intlify/core-base'
-import { createI18n } from '../src/index'
+import { format } from '@intlify/shared'
+import { defineComponent, h, ref, resolveDirective, withDirectives } from 'vue'
 import { errorMessages, I18nErrorCodes } from '../src/errors'
+import { createI18n } from '../src/index'
+import { mount } from './helper'
 
 beforeAll(() => {
   registerMessageCompiler(compile)
@@ -141,6 +142,10 @@ test('plural', async () => {
 })
 
 test('legacy mode', async () => {
+  const mockWarn = vi.spyOn(shared, 'warnOnce')
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  mockWarn.mockImplementation(() => {})
+
   const i18n = createI18n({
     legacy: true,
     locale: 'en',

--- a/packages/vue-i18n-core/test/ssr.test.ts
+++ b/packages/vue-i18n-core/test/ssr.test.ts
@@ -1,22 +1,32 @@
 import {
-  h,
-  ref,
-  defineComponent,
-  resolveComponent,
-  resolveDirective,
-  withDirectives,
-  createSSRApp
-} from 'vue'
+  compile,
+  fallbackWithLocaleChain,
+  registerLocaleFallbacker,
+  registerMessageCompiler,
+  registerMessageResolver,
+  resolveValue
+} from '@intlify/core-base'
 import { renderToString } from '@vue/server-renderer'
 import {
-  compile,
-  registerMessageCompiler,
-  resolveValue,
-  registerMessageResolver,
-  fallbackWithLocaleChain,
-  registerLocaleFallbacker
-} from '@intlify/core-base'
+  createSSRApp,
+  defineComponent,
+  h,
+  ref,
+  resolveComponent,
+  resolveDirective,
+  withDirectives
+} from 'vue'
 import { createI18n, useI18n } from '../src/index'
+
+// utils
+import * as shared from '@intlify/shared'
+vi.mock('@intlify/shared', async () => {
+  const actual = await vi.importActual<object>('@intlify/shared')
+  return {
+    ...actual,
+    warnOnce: vi.fn()
+  }
+})
 
 beforeAll(() => {
   registerMessageCompiler(compile)
@@ -51,6 +61,10 @@ test('composition mode', async () => {
 })
 
 test('legacy mode', async () => {
+  const mockWarn = vi.spyOn(shared, 'warnOnce')
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  mockWarn.mockImplementation(() => {})
+
   const i18n = createI18n({
     locale: 'ja',
     messages: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   vue: 3.5.12
-  vite: ^5.1.2
+  vite: ^5.4.11
 
 importers:
 
@@ -67,8 +67,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4
       '@vitest/coverage-v8':
-        specifier: ^2.0.0
-        version: 2.0.0(vitest@2.0.4(@types/node@22.5.3)(jsdom@24.0.0)(terser@5.27.0))
+        specifier: ^2.1.5
+        version: 2.1.5(vitest@2.1.5(@types/node@22.5.3)(jsdom@24.0.0)(terser@5.27.0))
       api-docs-gen:
         specifier: ^0.4.0
         version: 0.4.0(@types/node@22.5.3)
@@ -238,8 +238,8 @@ importers:
         specifier: 1.5.0
         version: 1.5.0(@algolia/client-search@4.23.2)(@types/node@22.5.3)(@vue/composition-api@1.7.2(vue@3.5.12(typescript@5.5.4)))(postcss@8.4.47)(search-insights@2.13.0)(terser@5.27.0)(typescript@5.5.4)
       vitest:
-        specifier: ^2.0.4
-        version: 2.0.4(@types/node@22.5.3)(jsdom@24.0.0)(terser@5.27.0)
+        specifier: ^2.1.5
+        version: 2.1.5(@types/node@22.5.3)(jsdom@24.0.0)(terser@5.27.0)
       vue:
         specifier: 3.5.12
         version: 3.5.12(typescript@5.5.4)
@@ -270,7 +270,7 @@ importers:
         version: 4.17.21
       '@vitejs/plugin-vue':
         specifier: ^4.2.3
-        version: 4.6.2(vite@5.2.14(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.3.3))
+        version: 4.6.2(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.3.3))
       body-parser:
         specifier: ^1.19.1
         version: 1.20.2(supports-color@6.1.0)
@@ -290,8 +290,8 @@ importers:
         specifier: ^5.0.2
         version: 5.3.3
       vite:
-        specifier: ^5.1.2
-        version: 5.2.14(@types/node@22.5.3)(terser@5.27.0)
+        specifier: ^5.4.11
+        version: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
       vue-tsc:
         specifier: ^1.8.5
         version: 1.8.27(typescript@5.3.3)
@@ -313,13 +313,13 @@ importers:
         version: 0.12.3(petite-vue-i18n@10.0.4(vue@3.5.12(typescript@5.3.3)))(rollup@4.24.0)(vue-i18n@packages+vue-i18n)
       '@vitejs/plugin-vue':
         specifier: ^4.2.3
-        version: 4.6.2(vite@5.2.14(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.3.3))
+        version: 4.6.2(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.3.3))
       typescript:
         specifier: ^5.0.2
         version: 5.3.3
       vite:
-        specifier: ^5.1.2
-        version: 5.2.14(@types/node@22.5.3)(terser@5.27.0)
+        specifier: ^5.4.11
+        version: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
       vue-tsc:
         specifier: ^1.8.5
         version: 1.8.27(typescript@5.3.3)
@@ -381,13 +381,13 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^4.2.3
-        version: 4.6.2(vite@5.2.14(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.3.3))
+        version: 4.6.2(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.3.3))
       typescript:
         specifier: ^5.0.2
         version: 5.3.3
       vite:
-        specifier: ^5.1.2
-        version: 5.2.14(@types/node@22.5.3)(terser@5.27.0)
+        specifier: ^5.4.11
+        version: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
       vue-tsc:
         specifier: ^1.8.5
         version: 1.8.27(typescript@5.3.3)
@@ -407,16 +407,16 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^4.2.3
-        version: 4.6.2(vite@5.2.14(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))
+        version: 4.6.2(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))
       '@vitejs/plugin-vue-jsx':
         specifier: ^3.0.2
-        version: 3.1.0(vite@5.2.14(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))
+        version: 3.1.0(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.4.19
       vite:
-        specifier: ^5.1.2
-        version: 5.2.14(@types/node@22.5.3)(terser@5.27.0)
+        specifier: ^5.4.11
+        version: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
       vue-tsc:
         specifier: ^1.8.5
         version: 1.8.27(typescript@5.5.4)
@@ -432,7 +432,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^4.2.3
-        version: 4.6.2(vite@5.2.14(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.3.3))
+        version: 4.6.2(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.3.3))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.4.19
@@ -440,8 +440,8 @@ importers:
         specifier: ^5.0.2
         version: 5.3.3
       vite:
-        specifier: ^5.1.2
-        version: 5.2.14(@types/node@22.5.3)(terser@5.27.0)
+        specifier: ^5.4.11
+        version: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
       vue-tsc:
         specifier: ^1.8.5
         version: 1.8.27(typescript@5.3.3)
@@ -457,7 +457,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^4.2.3
-        version: 4.6.2(vite@5.2.14(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.3.3))
+        version: 4.6.2(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.3.3))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.4.19
@@ -465,8 +465,8 @@ importers:
         specifier: ^5.0.2
         version: 5.3.3
       vite:
-        specifier: ^5.1.2
-        version: 5.2.14(@types/node@22.5.3)(terser@5.27.0)
+        specifier: ^5.4.11
+        version: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
       vue-tsc:
         specifier: ^1.8.5
         version: 1.8.27(typescript@5.3.3)
@@ -485,13 +485,13 @@ importers:
         version: 0.12.3(petite-vue-i18n@10.0.4(vue@3.5.12(typescript@5.3.3)))(rollup@4.24.0)(vue-i18n@packages+vue-i18n)
       '@vitejs/plugin-vue':
         specifier: ^4.2.3
-        version: 4.6.2(vite@5.2.14(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.3.3))
+        version: 4.6.2(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.3.3))
       typescript:
         specifier: ^5.0.2
         version: 5.3.3
       vite:
-        specifier: ^5.1.2
-        version: 5.2.14(@types/node@22.5.3)(terser@5.27.0)
+        specifier: ^5.4.11
+        version: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
       vue-tsc:
         specifier: ^1.8.5
         version: 1.8.27(typescript@5.3.3)
@@ -541,13 +541,13 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^5.0.0
-        version: 5.0.4(vite@5.2.14(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))
+        version: 5.0.4(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.4.19
       vite:
-        specifier: ^5.1.2
-        version: 5.2.14(@types/node@22.5.3)(terser@5.27.0)
+        specifier: ^5.4.11
+        version: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
       vue-tsc:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.5.4)
@@ -589,8 +589,8 @@ importers:
         version: link:../core
     devDependencies:
       vite:
-        specifier: ^5.1.2
-        version: 5.2.14(@types/node@22.5.3)(terser@5.27.0)
+        specifier: ^5.4.11
+        version: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
 
   packages/size-check-petite-vue-i18n:
     dependencies:
@@ -603,13 +603,13 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^5.0.0
-        version: 5.0.4(vite@5.2.14(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))
+        version: 5.0.4(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.4.19
       vite:
-        specifier: ^5.1.2
-        version: 5.2.14(@types/node@22.5.3)(terser@5.27.0)
+        specifier: ^5.4.11
+        version: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
       vue-tsc:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.5.4)
@@ -625,13 +625,13 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^5.0.0
-        version: 5.0.4(vite@5.2.14(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))
+        version: 5.0.4(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.4.19
       vite:
-        specifier: ^5.1.2
-        version: 5.2.14(@types/node@22.5.3)(terser@5.27.0)
+        specifier: ^5.4.11
+        version: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
       vue-tsc:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.5.4)
@@ -860,10 +860,6 @@ packages:
     resolution: {integrity: sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.24.7':
-    resolution: {integrity: sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.24.8':
     resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
     engines: {node: '>=6.9.0'}
@@ -890,11 +886,6 @@ packages:
 
   '@babel/parser@7.23.9':
     resolution: {integrity: sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.24.7':
-    resolution: {integrity: sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -931,10 +922,6 @@ packages:
 
   '@babel/types@7.23.9':
     resolution: {integrity: sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.24.7':
-    resolution: {integrity: sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.25.6':
@@ -2204,52 +2191,67 @@ packages:
     resolution: {integrity: sha512-w9M6F3LSEU5kszVb9An2/MmXNxocAnUb3WhRr8bHlimhDrXNt6n6D2nJQR3UXpGlZHh/EsgouOHCsM8V3Ln+WA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^5.1.2
+      vite: ^5.4.11
       vue: 3.5.12
 
   '@vitejs/plugin-vue@4.6.2':
     resolution: {integrity: sha512-kqf7SGFoG+80aZG6Pf+gsZIVvGSCKE98JbiWqcCV9cThtg91Jav0yvYFC9Zb+jKetNGF6ZKeoaxgZfND21fWKw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^5.1.2
+      vite: ^5.4.11
       vue: 3.5.12
 
   '@vitejs/plugin-vue@5.0.4':
     resolution: {integrity: sha512-WS3hevEszI6CEVEx28F8RjTX97k3KsrcY6kvTg7+Whm5y3oYvcqzVeGCU3hxSAn4uY2CLCkeokkGKpoctccilQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
-      vite: ^5.1.2
+      vite: ^5.4.11
       vue: 3.5.12
 
   '@vitejs/plugin-vue@5.1.4':
     resolution: {integrity: sha512-N2XSI2n3sQqp5w7Y/AN/L2XDjBIRGqXko+eDp42sydYSBeJuSm5a1sLf8zakmo8u7tA8NmBgoDLA1HeOESjp9A==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
-      vite: ^5.1.2
+      vite: ^5.4.11
       vue: 3.5.12
 
-  '@vitest/coverage-v8@2.0.0':
-    resolution: {integrity: sha512-k2OgMH8e4AyUVsmLk2P3vT++VVaUQbvVaP5NJQDgXgv1q4lG56Z4nb26QNcxgk4ZLypmOrfultAShMo+okIOYw==}
+  '@vitest/coverage-v8@2.1.5':
+    resolution: {integrity: sha512-/RoopB7XGW7UEkUndRXF87A9CwkoZAJW01pj8/3pgmDVsjMH2IKy6H1A38po9tmUlwhSyYs0az82rbKd9Yaynw==}
     peerDependencies:
-      vitest: 2.0.0
+      '@vitest/browser': 2.1.5
+      vitest: 2.1.5
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
 
-  '@vitest/expect@2.0.4':
-    resolution: {integrity: sha512-39jr5EguIoanChvBqe34I8m1hJFI4+jxvdOpD7gslZrVQBKhh8H9eD7J/LJX4zakrw23W+dITQTDqdt43xVcJw==}
+  '@vitest/expect@2.1.5':
+    resolution: {integrity: sha512-nZSBTW1XIdpZvEJyoP/Sy8fUg0b8od7ZpGDkTUcfJ7wz/VoZAFzFfLyxVxGFhUjJzhYqSbIpfMtl/+k/dpWa3Q==}
 
-  '@vitest/pretty-format@2.0.4':
-    resolution: {integrity: sha512-RYZl31STbNGqf4l2eQM1nvKPXE0NhC6Eq0suTTePc4mtMQ1Fn8qZmjV4emZdEdG2NOWGKSCrHZjmTqDCDoeFBw==}
+  '@vitest/mocker@2.1.5':
+    resolution: {integrity: sha512-XYW6l3UuBmitWqSUXTNXcVBUCRytDogBsWuNXQijc00dtnU/9OqpXWp4OJroVrad/gLIomAq9aW8yWDBtMthhQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.4.11
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
-  '@vitest/runner@2.0.4':
-    resolution: {integrity: sha512-Gk+9Su/2H2zNfNdeJR124gZckd5st4YoSuhF1Rebi37qTXKnqYyFCd9KP4vl2cQHbtuVKjfEKrNJxHHCW8thbQ==}
+  '@vitest/pretty-format@2.1.5':
+    resolution: {integrity: sha512-4ZOwtk2bqG5Y6xRGHcveZVr+6txkH7M2e+nPFd6guSoN638v/1XQ0K06eOpi0ptVU/2tW/pIU4IoPotY/GZ9fw==}
 
-  '@vitest/snapshot@2.0.4':
-    resolution: {integrity: sha512-or6Mzoz/pD7xTvuJMFYEtso1vJo1S5u6zBTinfl+7smGUhqybn6VjzCDMhmTyVOFWwkCMuNjmNNxnyXPgKDoPw==}
+  '@vitest/runner@2.1.5':
+    resolution: {integrity: sha512-pKHKy3uaUdh7X6p1pxOkgkVAFW7r2I818vHDthYLvUyjRfkKOU6P45PztOch4DZarWQne+VOaIMwA/erSSpB9g==}
 
-  '@vitest/spy@2.0.4':
-    resolution: {integrity: sha512-uTXU56TNoYrTohb+6CseP8IqNwlNdtPwEO0AWl+5j7NelS6x0xZZtP0bDWaLvOfUbaYwhhWp1guzXUxkC7mW7Q==}
+  '@vitest/snapshot@2.1.5':
+    resolution: {integrity: sha512-zmYw47mhfdfnYbuhkQvkkzYroXUumrwWDGlMjpdUr4jBd3HZiV2w7CQHj+z7AAS4VOtWxI4Zt4bWt4/sKcoIjg==}
 
-  '@vitest/utils@2.0.4':
-    resolution: {integrity: sha512-Zc75QuuoJhOBnlo99ZVUkJIuq4Oj0zAkrQ2VzCqNCx6wAwViHEh5Fnp4fiJTE9rA+sAoXRf00Z9xGgfEzV6fzQ==}
+  '@vitest/spy@2.1.5':
+    resolution: {integrity: sha512-aWZF3P0r3w6DiYTVskOYuhBc7EMc3jvn1TkBg8ttylFFRqNN2XGD7V5a4aQdk6QiUzZQ4klNBSpCLJgWNdIiNw==}
+
+  '@vitest/utils@2.1.5':
+    resolution: {integrity: sha512-yfj6Yrp0Vesw2cwJbP+cl04OC+IHFsuQsrsJBL9pyGeQXE56v1UAOQco+SR55Vf1nQzfV0QJg1Qum7AaWUwwYg==}
 
   '@volar/language-core@1.11.1':
     resolution: {integrity: sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==}
@@ -2932,8 +2934,8 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
-  chai@5.1.1:
-    resolution: {integrity: sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==}
+  chai@5.1.2:
+    resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
     engines: {node: '>=12'}
 
   chalk@1.1.3:
@@ -3519,6 +3521,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.5.4:
+    resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
+
   es-set-tostringtag@2.0.2:
     resolution: {integrity: sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==}
     engines: {node: '>= 0.4'}
@@ -3717,6 +3722,10 @@ packages:
   expand-tilde@2.0.2:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.1.0:
+    resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
+    engines: {node: '>=12.0.0'}
 
   express@4.19.2:
     resolution: {integrity: sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==}
@@ -4716,9 +4725,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-tokens@9.0.0:
-    resolution: {integrity: sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==}
-
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
@@ -4943,6 +4949,9 @@ packages:
   loupe@3.1.1:
     resolution: {integrity: sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==}
 
+  loupe@3.1.2:
+    resolution: {integrity: sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==}
+
   lru-cache@10.2.0:
     resolution: {integrity: sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==}
     engines: {node: 14 || >=16.14}
@@ -4964,18 +4973,18 @@ packages:
   magic-string@0.22.5:
     resolution: {integrity: sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==}
 
-  magic-string@0.30.10:
-    resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
-
   magic-string@0.30.11:
     resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
+
+  magic-string@0.30.12:
+    resolution: {integrity: sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==}
 
   magic-string@0.30.7:
     resolution: {integrity: sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==}
     engines: {node: '>=12'}
 
-  magicast@0.3.4:
-    resolution: {integrity: sha512-TyDF/Pn36bBji9rWKHlZe+PZb6Mx5V8IHCSxk7X4aljM4e/vyDvZZYwHewdVaqiA0nb3ghfHU/6AUpDxWoER2Q==}
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
 
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -5728,9 +5737,6 @@ packages:
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
-  picocolors@1.0.1:
-    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
-
   picocolors@1.1.0:
     resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
 
@@ -6441,10 +6447,6 @@ packages:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
 
-  source-map-js@1.2.0:
-    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
-    engines: {node: '>=0.10.0'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -6532,6 +6534,9 @@ packages:
 
   std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
+
+  std-env@3.8.0:
+    resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
 
   stream-browserify@2.0.2:
     resolution: {integrity: sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==}
@@ -6657,9 +6662,6 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
-
-  strip-literal@2.1.0:
-    resolution: {integrity: sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==}
 
   structured-source@3.0.2:
     resolution: {integrity: sha512-Ap7JHfKgmH40SUjumqyKTHYHNZ8GvGQskP34ks0ElHCDEig+bYGpmXVksxPSrgcY9rkJqhVMzfeg5GIpZelfpQ==}
@@ -6836,23 +6838,26 @@ packages:
   timsort@0.3.0:
     resolution: {integrity: sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==}
 
-  tinybench@2.8.0:
-    resolution: {integrity: sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==}
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.1:
+    resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}
 
   tinyglobby@0.2.10:
     resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.0.0:
-    resolution: {integrity: sha512-KIKExllK7jp3uvrNtvRBYBWBOAXSX8ZvoaD8T+7KB/QHIuoJW3Pmr60zucywjAlMb5TeXUkcs/MWeWLu0qvuAQ==}
+  tinypool@1.0.1:
+    resolution: {integrity: sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
     engines: {node: '>=14.0.0'}
 
-  tinyspy@3.0.0:
-    resolution: {integrity: sha512-q5nmENpTHgiPVd1cJDDc9cVoYN5x4vCvwT3FMilvKPKneCBZAxn2YWQjDF0UMcE9k0Cay1gBiDfTMU0g+mPMQA==}
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   to-arraybuffer@1.0.1:
@@ -7241,41 +7246,13 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite-node@2.0.4:
-    resolution: {integrity: sha512-ZpJVkxcakYtig5iakNeL7N3trufe3M6vGuzYAr4GsbCTwobDeyPJpE4cjDhhPluv8OvQCFzu2LWp6GkoKRITXA==}
+  vite-node@2.1.5:
+    resolution: {integrity: sha512-rd0QIgx74q4S1Rd56XIiL2cYEdyWn13cunYBIuqh9mpmQr7gGS0IxXoP8R6OaZtNQQLyXSWbd4rXKYUbhFpK5w==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
-  vite@5.2.14:
-    resolution: {integrity: sha512-TFQLuwWLPms+NBNlh0D9LZQ+HXW471COABxw/9TEUBrjuHMo9BrYBPrN/SYAwIuVL+rLerycxiLT41t4f5MZpA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-
-  vite@5.4.8:
-    resolution: {integrity: sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==}
+  vite@5.4.11:
+    resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -7317,15 +7294,15 @@ packages:
       postcss:
         optional: true
 
-  vitest@2.0.4:
-    resolution: {integrity: sha512-luNLDpfsnxw5QSW4bISPe6tkxVvv5wn2BBs/PuDRkhXZ319doZyLOBr1sjfB5yCEpTiU7xCAdViM8TNVGPwoog==}
+  vitest@2.1.5:
+    resolution: {integrity: sha512-P4ljsdpuzRTPI/kbND2sDZ4VmieerR2c9szEZpjc+98Z9ebvnXmM5+0tHEKqYZumXqlvnmfWsjeFOjXVriDG7A==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.0.4
-      '@vitest/ui': 2.0.4
+      '@vitest/browser': 2.1.5
+      '@vitest/ui': 2.1.5
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -7930,8 +7907,6 @@ snapshots:
 
   '@babel/helper-string-parser@7.23.4': {}
 
-  '@babel/helper-string-parser@7.24.7': {}
-
   '@babel/helper-string-parser@7.24.8': {}
 
   '@babel/helper-validator-identifier@7.22.20': {}
@@ -7957,10 +7932,6 @@ snapshots:
   '@babel/parser@7.23.9':
     dependencies:
       '@babel/types': 7.23.9
-
-  '@babel/parser@7.24.7':
-    dependencies:
-      '@babel/types': 7.24.7
 
   '@babel/parser@7.25.6':
     dependencies:
@@ -8009,12 +7980,6 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.23.4
       '@babel/helper-validator-identifier': 7.22.20
-      to-fast-properties: 2.0.0
-
-  '@babel/types@7.24.7':
-    dependencies:
-      '@babel/helper-string-parser': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
 
   '@babel/types@7.25.6':
@@ -8391,7 +8356,7 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
       '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/resolve-uri@3.1.1': {}
@@ -8417,7 +8382,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   '@jsdevtools/ez-spawn@3.0.4':
     dependencies:
@@ -8996,7 +8961,7 @@ snapshots:
   '@textlint/ast-tester@12.6.1':
     dependencies:
       '@textlint/ast-node-types': 12.6.1
-      debug: 4.3.5
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -9094,7 +9059,7 @@ snapshots:
   '@textlint/markdown-to-ast@12.6.1':
     dependencies:
       '@textlint/ast-node-types': 12.6.1
-      debug: 4.3.4(supports-color@6.1.0)
+      debug: 4.3.7
       mdast-util-gfm-autolink-literal: 0.1.3
       remark-footnotes: 3.0.0
       remark-frontmatter: 3.0.0
@@ -9121,7 +9086,7 @@ snapshots:
   '@textlint/source-code-fixer@12.6.1':
     dependencies:
       '@textlint/types': 12.6.1
-      debug: 4.3.5
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -9357,86 +9322,92 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.2.14(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))':
+  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))':
     dependencies:
       '@babel/core': 7.23.9
       '@babel/plugin-transform-typescript': 7.23.6(@babel/core@7.23.9)
       '@vue/babel-plugin-jsx': 1.2.1(@babel/core@7.23.9)
-      vite: 5.2.14(@types/node@22.5.3)(terser@5.27.0)
+      vite: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
       vue: 3.5.12(typescript@5.5.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@4.6.2(vite@5.2.14(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.3.3))':
+  '@vitejs/plugin-vue@4.6.2(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.3.3))':
     dependencies:
-      vite: 5.2.14(@types/node@22.5.3)(terser@5.27.0)
+      vite: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
       vue: 3.5.12(typescript@5.3.3)
 
-  '@vitejs/plugin-vue@4.6.2(vite@5.2.14(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))':
+  '@vitejs/plugin-vue@4.6.2(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))':
     dependencies:
-      vite: 5.2.14(@types/node@22.5.3)(terser@5.27.0)
+      vite: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
       vue: 3.5.12(typescript@5.5.4)
 
-  '@vitejs/plugin-vue@5.0.4(vite@5.2.14(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))':
+  '@vitejs/plugin-vue@5.0.4(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))':
     dependencies:
-      vite: 5.2.14(@types/node@22.5.3)(terser@5.27.0)
+      vite: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
       vue: 3.5.12(typescript@5.5.4)
 
-  '@vitejs/plugin-vue@5.1.4(vite@5.4.8(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))':
+  '@vitejs/plugin-vue@5.1.4(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))':
     dependencies:
-      vite: 5.4.8(@types/node@22.5.3)(terser@5.27.0)
+      vite: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
       vue: 3.5.12(typescript@5.5.4)
 
-  '@vitest/coverage-v8@2.0.0(vitest@2.0.4(@types/node@22.5.3)(jsdom@24.0.0)(terser@5.27.0))':
+  '@vitest/coverage-v8@2.1.5(vitest@2.1.5(@types/node@22.5.3)(jsdom@24.0.0)(terser@5.27.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
-      debug: 4.3.5
+      debug: 4.3.7
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.1.7
-      magic-string: 0.30.10
-      magicast: 0.3.4
-      picocolors: 1.0.1
-      std-env: 3.7.0
-      strip-literal: 2.1.0
+      magic-string: 0.30.12
+      magicast: 0.3.5
+      std-env: 3.8.0
       test-exclude: 7.0.1
-      vitest: 2.0.4(@types/node@22.5.3)(jsdom@24.0.0)(terser@5.27.0)
+      tinyrainbow: 1.2.0
+      vitest: 2.1.5(@types/node@22.5.3)(jsdom@24.0.0)(terser@5.27.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@2.0.4':
+  '@vitest/expect@2.1.5':
     dependencies:
-      '@vitest/spy': 2.0.4
-      '@vitest/utils': 2.0.4
-      chai: 5.1.1
+      '@vitest/spy': 2.1.5
+      '@vitest/utils': 2.1.5
+      chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/pretty-format@2.0.4':
+  '@vitest/mocker@2.1.5(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))':
     dependencies:
-      tinyrainbow: 1.2.0
-
-  '@vitest/runner@2.0.4':
-    dependencies:
-      '@vitest/utils': 2.0.4
-      pathe: 1.1.2
-
-  '@vitest/snapshot@2.0.4':
-    dependencies:
-      '@vitest/pretty-format': 2.0.4
-      magic-string: 0.30.10
-      pathe: 1.1.2
-
-  '@vitest/spy@2.0.4':
-    dependencies:
-      tinyspy: 3.0.0
-
-  '@vitest/utils@2.0.4':
-    dependencies:
-      '@vitest/pretty-format': 2.0.4
+      '@vitest/spy': 2.1.5
       estree-walker: 3.0.3
-      loupe: 3.1.1
+      magic-string: 0.30.12
+    optionalDependencies:
+      vite: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
+
+  '@vitest/pretty-format@2.1.5':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.5':
+    dependencies:
+      '@vitest/utils': 2.1.5
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.5':
+    dependencies:
+      '@vitest/pretty-format': 2.1.5
+      magic-string: 0.30.12
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.5':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.5':
+    dependencies:
+      '@vitest/pretty-format': 2.1.5
+      loupe: 3.1.2
       tinyrainbow: 1.2.0
 
   '@volar/language-core@1.11.1':
@@ -9553,7 +9524,7 @@ snapshots:
       '@vue/compiler-ssr': 3.5.11
       '@vue/shared': 3.5.11
       estree-walker: 2.0.2
-      magic-string: 0.30.11
+      magic-string: 0.30.12
       postcss: 8.4.47
       source-map-js: 1.2.1
 
@@ -10333,7 +10304,7 @@ snapshots:
 
   ccount@2.0.1: {}
 
-  chai@5.1.1:
+  chai@5.1.2:
     dependencies:
       assertion-error: 2.0.1
       check-error: 2.1.1
@@ -10969,6 +10940,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@1.5.4: {}
+
   es-set-tostringtag@2.0.2:
     dependencies:
       get-intrinsic: 1.2.4
@@ -11266,6 +11239,8 @@ snapshots:
   expand-tilde@2.0.2:
     dependencies:
       homedir-polyfill: 1.0.3
+
+  expect-type@1.1.0: {}
 
   express@4.19.2(supports-color@6.1.0):
     dependencies:
@@ -12308,7 +12283,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.3.5
+      debug: 4.3.7
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -12340,8 +12315,6 @@ snapshots:
   jju@1.4.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-tokens@9.0.0: {}
 
   js-yaml@3.14.1:
     dependencies:
@@ -12649,6 +12622,8 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
+  loupe@3.1.2: {}
+
   lru-cache@10.2.0: {}
 
   lru-cache@11.0.0: {}
@@ -12667,11 +12642,11 @@ snapshots:
     dependencies:
       vlq: 0.2.3
 
-  magic-string@0.30.10:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
-
   magic-string@0.30.11:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  magic-string@0.30.12:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
@@ -12679,11 +12654,11 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  magicast@0.3.4:
+  magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.24.7
-      '@babel/types': 7.24.7
-      source-map-js: 1.2.0
+      '@babel/parser': 7.25.6
+      '@babel/types': 7.25.6
+      source-map-js: 1.2.1
 
   make-dir@2.1.0:
     dependencies:
@@ -12696,7 +12671,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.3
 
   map-cache@0.2.2: {}
 
@@ -12920,7 +12895,7 @@ snapshots:
 
   micromark@2.11.4:
     dependencies:
-      debug: 4.3.4(supports-color@6.1.0)
+      debug: 4.3.7
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -13525,8 +13500,6 @@ snapshots:
 
   picocolors@1.0.0: {}
 
-  picocolors@1.0.1: {}
-
   picocolors@1.1.0: {}
 
   picomatch@2.3.1: {}
@@ -13783,7 +13756,7 @@ snapshots:
 
   rc-config-loader@4.1.3:
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.7
       js-yaml: 4.1.0
       json5: 2.2.3
       require-from-string: 2.0.2
@@ -14400,8 +14373,6 @@ snapshots:
 
   source-map-js@1.0.2: {}
 
-  source-map-js@1.2.0: {}
-
   source-map-js@1.2.1: {}
 
   source-map-resolve@0.5.3:
@@ -14490,6 +14461,8 @@ snapshots:
   statuses@2.0.1: {}
 
   std-env@3.7.0: {}
+
+  std-env@3.8.0: {}
 
   stream-browserify@2.0.2:
     dependencies:
@@ -14626,10 +14599,6 @@ snapshots:
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
-
-  strip-literal@2.1.0:
-    dependencies:
-      js-tokens: 9.0.0
 
   structured-source@3.0.2:
     dependencies:
@@ -14879,18 +14848,20 @@ snapshots:
 
   timsort@0.3.0: {}
 
-  tinybench@2.8.0: {}
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.1: {}
 
   tinyglobby@0.2.10:
     dependencies:
       fdir: 6.4.2(picomatch@4.0.2)
       picomatch: 4.0.2
 
-  tinypool@1.0.0: {}
+  tinypool@1.0.1: {}
 
   tinyrainbow@1.2.0: {}
 
-  tinyspy@3.0.0: {}
+  tinyspy@3.0.2: {}
 
   to-arraybuffer@1.0.1: {}
 
@@ -15283,13 +15254,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@2.0.4(@types/node@22.5.3)(terser@5.27.0):
+  vite-node@2.1.5(@types/node@22.5.3)(terser@5.27.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.5
+      debug: 4.3.7
+      es-module-lexer: 1.5.4
       pathe: 1.1.2
-      tinyrainbow: 1.2.0
-      vite: 5.4.8(@types/node@22.5.3)(terser@5.27.0)
+      vite: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -15301,17 +15272,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.2.14(@types/node@22.5.3)(terser@5.27.0):
-    dependencies:
-      esbuild: 0.20.2
-      postcss: 8.4.47
-      rollup: 4.24.0
-    optionalDependencies:
-      '@types/node': 22.5.3
-      fsevents: 2.3.3
-      terser: 5.27.0
-
-  vite@5.4.8(@types/node@22.5.3)(terser@5.27.0):
+  vite@5.4.11(@types/node@22.5.3)(terser@5.27.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.47
@@ -15330,7 +15291,7 @@ snapshots:
       '@shikijs/transformers': 1.22.2
       '@shikijs/types': 1.22.2
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.1.4(vite@5.4.8(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))
+      '@vitejs/plugin-vue': 5.1.4(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))(vue@3.5.12(typescript@5.5.4))
       '@vue/devtools-api': 7.6.3
       '@vue/shared': 3.5.12
       '@vueuse/core': 11.1.0(@vue/composition-api@1.7.2(vue@3.5.12(typescript@5.5.4)))(vue@3.5.12(typescript@5.5.4))
@@ -15339,7 +15300,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.1.0
       shiki: 1.22.2
-      vite: 5.4.8(@types/node@22.5.3)(terser@5.27.0)
+      vite: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
       vue: 3.5.12(typescript@5.5.4)
     optionalDependencies:
       postcss: 8.4.47
@@ -15371,26 +15332,27 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@2.0.4(@types/node@22.5.3)(jsdom@24.0.0)(terser@5.27.0):
+  vitest@2.1.5(@types/node@22.5.3)(jsdom@24.0.0)(terser@5.27.0):
     dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@vitest/expect': 2.0.4
-      '@vitest/pretty-format': 2.0.4
-      '@vitest/runner': 2.0.4
-      '@vitest/snapshot': 2.0.4
-      '@vitest/spy': 2.0.4
-      '@vitest/utils': 2.0.4
-      chai: 5.1.1
-      debug: 4.3.5
-      execa: 8.0.1
-      magic-string: 0.30.10
+      '@vitest/expect': 2.1.5
+      '@vitest/mocker': 2.1.5(vite@5.4.11(@types/node@22.5.3)(terser@5.27.0))
+      '@vitest/pretty-format': 2.1.5
+      '@vitest/runner': 2.1.5
+      '@vitest/snapshot': 2.1.5
+      '@vitest/spy': 2.1.5
+      '@vitest/utils': 2.1.5
+      chai: 5.1.2
+      debug: 4.3.7
+      expect-type: 1.1.0
+      magic-string: 0.30.12
       pathe: 1.1.2
-      std-env: 3.7.0
-      tinybench: 2.8.0
-      tinypool: 1.0.0
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.4.8(@types/node@22.5.3)(terser@5.27.0)
-      vite-node: 2.0.4(@types/node@22.5.3)(terser@5.27.0)
+      vite: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
+      vite-node: 2.1.5(@types/node@22.5.3)(terser@5.27.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.5.3
@@ -15398,6 +15360,7 @@ snapshots:
     transitivePeerDependencies:
       - less
       - lightningcss
+      - msw
       - sass
       - sass-embedded
       - stylus

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5940,6 +5940,10 @@ packages:
     resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
     engines: {node: '>=0.6'}
 
+  qs@6.11.2:
+    resolution: {integrity: sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==}
+    engines: {node: '>=0.6'}
+
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
@@ -7830,7 +7834,7 @@ snapshots:
       '@babel/traverse': 7.23.9
       '@babel/types': 7.23.9
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.4(supports-color@6.1.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -8181,7 +8185,7 @@ snapshots:
   '@eslint/config-array@0.18.0':
     dependencies:
       '@eslint/object-schema': 2.1.4
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.5
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8189,7 +8193,7 @@ snapshots:
   '@eslint/eslintrc@3.1.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.5
       espree: 10.1.0
       globals: 14.0.0
       ignore: 5.3.1
@@ -8266,7 +8270,7 @@ snapshots:
   '@intlify/bundle-utils@7.5.0(petite-vue-i18n@10.0.4(vue@3.5.12(typescript@5.3.3)))(vue-i18n@packages+vue-i18n)':
     dependencies:
       '@intlify/message-compiler': 9.10.2
-      '@intlify/shared': 9.13.1
+      '@intlify/shared': 9.11.0
       acorn: 8.11.3
       escodegen: 2.1.0
       estree-walker: 2.0.2
@@ -8978,11 +8982,7 @@ snapshots:
   '@textlint/ast-tester@12.6.1':
     dependencies:
       '@textlint/ast-node-types': 12.6.1
-<<<<<<< HEAD
-      debug: 4.3.7
-=======
       debug: 4.3.7(supports-color@6.1.0)
->>>>>>> master
     transitivePeerDependencies:
       - supports-color
 
@@ -9080,11 +9080,7 @@ snapshots:
   '@textlint/markdown-to-ast@12.6.1':
     dependencies:
       '@textlint/ast-node-types': 12.6.1
-<<<<<<< HEAD
-      debug: 4.3.7
-=======
       debug: 4.3.7(supports-color@6.1.0)
->>>>>>> master
       mdast-util-gfm-autolink-literal: 0.1.3
       remark-footnotes: 3.0.0
       remark-frontmatter: 3.0.0
@@ -9111,11 +9107,7 @@ snapshots:
   '@textlint/source-code-fixer@12.6.1':
     dependencies:
       '@textlint/types': 12.6.1
-<<<<<<< HEAD
-      debug: 4.3.7
-=======
       debug: 4.3.7(supports-color@6.1.0)
->>>>>>> master
     transitivePeerDependencies:
       - supports-color
 
@@ -9385,7 +9377,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@6.1.0)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
@@ -12064,7 +12056,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       hasown: 2.0.1
-      side-channel: 1.0.6
+      side-channel: 1.0.5
 
   interpret@1.4.0: {}
 
@@ -12333,11 +12325,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-<<<<<<< HEAD
-      debug: 4.3.7
-=======
       debug: 4.3.7(supports-color@6.1.0)
->>>>>>> master
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -12949,11 +12937,7 @@ snapshots:
 
   micromark@2.11.4:
     dependencies:
-<<<<<<< HEAD
-      debug: 4.3.7
-=======
       debug: 4.3.7(supports-color@6.1.0)
->>>>>>> master
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -13750,6 +13734,10 @@ snapshots:
     dependencies:
       side-channel: 1.0.5
 
+  qs@6.11.2:
+    dependencies:
+      side-channel: 1.0.5
+
   qs@6.13.0:
     dependencies:
       side-channel: 1.0.6
@@ -13815,11 +13803,7 @@ snapshots:
 
   rc-config-loader@4.1.3:
     dependencies:
-<<<<<<< HEAD
-      debug: 4.3.7
-=======
       debug: 4.3.7(supports-color@6.1.0)
->>>>>>> master
       js-yaml: 4.1.0
       json5: 2.2.3
       require-from-string: 2.0.2
@@ -14495,7 +14479,7 @@ snapshots:
 
   spdy@4.0.2(supports-color@6.1.0):
     dependencies:
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.4(supports-color@6.1.0)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -15263,7 +15247,7 @@ snapshots:
   url@0.11.3:
     dependencies:
       punycode: 1.4.1
-      qs: 6.13.0
+      qs: 6.11.2
 
   use@3.1.1: {}
 
@@ -15327,12 +15311,8 @@ snapshots:
   vite-node@2.1.5(@types/node@22.5.3)(terser@5.27.0):
     dependencies:
       cac: 6.7.14
-<<<<<<< HEAD
-      debug: 4.3.7
-      es-module-lexer: 1.5.4
-=======
       debug: 4.3.7(supports-color@6.1.0)
->>>>>>> master
+      es-module-lexer: 1.5.4
       pathe: 1.1.2
       vite: 5.4.11(@types/node@22.5.3)(terser@5.27.0)
     transitivePeerDependencies:
@@ -15416,7 +15396,7 @@ snapshots:
       '@vitest/spy': 2.1.5
       '@vitest/utils': 2.1.5
       chai: 5.1.2
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@6.1.0)
       expect-type: 1.1.0
       magic-string: 0.30.12
       pathe: 1.1.2
@@ -15454,7 +15434,7 @@ snapshots:
 
   vue-eslint-parser@9.4.3(eslint@9.9.1(jiti@1.21.0)):
     dependencies:
-      debug: 4.3.7(supports-color@6.1.0)
+      debug: 4.3.5
       eslint: 9.9.1(jiti@1.21.0)
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3


### PR DESCRIPTION
## summary

The Legacy API mode was the API mode compatible with vue-i18n v8 for Vue 2. When vue-i18n v9 was released, the Legacy API was provided to smooth the migration from v8 to v9.

Legacy API mode will be deprecated in vue-i18n v11, as previous vue-i18n releases have already provided the following to support migration to Composition API mode

- Migration from Legacy API mode to Composition API mode: https://vue-i18n.intlify.dev/guide/migration/vue3.html
- Composition API usage: https://vue-i18n.intlify.dev/guide/advanced/composition.html

For compatibility, Legacy API mode still works in vue-i18n v11, but will be removed entirely in vue-i18n v12, so Legacy API mode will not work after that version.

## benefits
- more simple: we will no longer need to worry about the Legacy API mode and Composition API mode. simplify API docs.
- less codes: reduce vue-i18n dist codes, making it easier to maintain of vue-i18n.
- easier to improve other issues:
  - https://github.com/intlify/vue-i18n/issues/1003
  - https://github.com/intlify/vue-i18n/issues/920
  - https://github.com/intlify/vue-i18n/issues/630
  - https://github.com/intlify/vue-i18n/issues/994
  - https://github.com/intlify/vue-i18n/issues/1025
  - https://github.com/intlify/vue-i18n/issues/1116
  - https://github.com/intlify/vue-i18n/issues/1195
  - https://github.com/intlify/vue-i18n/issues/1347
  - https://github.com/intlify/vue-i18n/issues/1349
  - https://github.com/intlify/vue-i18n/issues/1367
  - https://github.com/intlify/vue-i18n/issues/1403
  - https://github.com/intlify/vue-i18n/issues/1425
  - https://github.com/intlify/vue-i18n/issues/1574
  - https://github.com/intlify/vue-i18n/issues/1749

## misc
- The vue-i18n documentation will be renewed besed on Composition API in vue-i18n v12.
- internal API will be removed, such as `VueI18nExtender` (use case [Nuxt I18n](https://github.com/nuxt-modules/i18n))

## deprecated APIs & Types
-  Legacy API: https://vue-i18n.intlify.dev/api/legacy.html
- `legacy` options on `createI18n`: https://vue-i18n.intlify.dev/api/general.html#legacy
- `I18nMode`: https://vue-i18n.intlify.dev/api/general.html#i18nmode
