### PR TITLE
test: use random available port for `e2e` tests

### DIFF
--- a/e2e/components/datetime-format.spec.ts
+++ b/e2e/components/datetime-format.spec.ts
@@ -1,13 +1,14 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
       await page.goto(
-        `http://localhost:8080/examples/${pattern}/components/datetime-format.html`
+        url(`/examples/${pattern}/components/datetime-format.html`)
       )
     })
 
     test('rendering', async () => {
+      console.log(new Date())
       expect(await getText(page, '#app p.p1')).toMatch(
         /([1-9]|1[0-2])\/([1-9]|[12]\d|3[01])\/([12]\d{3})/
       )

--- a/e2e/components/number-format.spec.ts
+++ b/e2e/components/number-format.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/components/number-format.html`
-      )
+      await page.goto(url(`/examples/${pattern}/components/number-format.html`))
     })
 
     test('rendering', async () => {

--- a/e2e/components/translation.spec.ts
+++ b/e2e/components/translation.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/components/translation.html`
-      )
+      await page.goto(url(`/examples/${pattern}/components/translation.html`))
     })
 
     test('rendering', async () => {

--- a/e2e/datetime.spec.ts
+++ b/e2e/datetime.spec.ts
@@ -1,8 +1,8 @@
-import { getText } from './helper'
+import { getText, url } from './helper'
 ;['composition', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(`http://localhost:8080/examples/${pattern}/datetime.html`)
+      await page.goto(url(`/examples/${pattern}/datetime.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/directive/basic.spec.ts
+++ b/e2e/directive/basic.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/directive/basic.html`
-      )
+      await page.goto(url(`/examples/${pattern}/directive/basic.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/directive/object.spec.ts
+++ b/e2e/directive/object.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/directive/object.html`
-      )
+      await page.goto(url(`/examples/${pattern}/directive/object.html`))
     })
 
     test('rendering', async () => {

--- a/e2e/directive/plural.spec.ts
+++ b/e2e/directive/plural.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/directive/plural.html`
-      )
+      await page.goto(url(`/examples/${pattern}/directive/plural.html`))
     })
 
     test('rendering', async () => {

--- a/e2e/directive/preserve.spec.ts
+++ b/e2e/directive/preserve.spec.ts
@@ -1,10 +1,8 @@
-import { getText, sleep } from '../helper'
+import { getText, sleep, url } from '../helper'
 ;['composition', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/directive/preserve.html`
-      )
+      await page.goto(url(`/examples/${pattern}/directive/preserve.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/fallback/basic.spec.ts
+++ b/e2e/fallback/basic.spec.ts
@@ -1,4 +1,4 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     const warnings: string[] = []
@@ -11,9 +11,7 @@ import { getText } from '../helper'
           }
         }
       })
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/fallback/basic.html`
-      )
+      await page.goto(url(`/examples/${pattern}/fallback/basic.html`))
     })
 
     test('warning', () => {

--- a/e2e/fallback/component.spec.ts
+++ b/e2e/fallback/component.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/fallback/component.html`
-      )
+      await page.goto(url(`/examples/${pattern}/fallback/component.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/fallback/default-format.spec.ts
+++ b/e2e/fallback/default-format.spec.ts
@@ -1,4 +1,4 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite'].forEach(pattern => {
   describe(`${pattern}`, () => {
     const warnings: string[] = []
@@ -8,9 +8,7 @@ import { getText } from '../helper'
           warnings.push(msg.text())
         }
       })
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/fallback/default-format.html`
-      )
+      await page.goto(url(`/examples/${pattern}/fallback/default-format.html`))
     })
 
     test('warning', () => {

--- a/e2e/fallback/format.spec.ts
+++ b/e2e/fallback/format.spec.ts
@@ -1,4 +1,4 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     const warnings: string[] = []
@@ -11,9 +11,7 @@ import { getText } from '../helper'
           }
         }
       })
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/fallback/format.html`
-      )
+      await page.goto(url(`/examples/${pattern}/fallback/format.html`))
     })
 
     test('warning', () => {

--- a/e2e/fallback/option.spec.ts
+++ b/e2e/fallback/option.spec.ts
@@ -1,4 +1,4 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite'].forEach(pattern => {
   describe(`${pattern}`, () => {
     const warnings: string[] = []
@@ -11,9 +11,7 @@ import { getText } from '../helper'
           }
         }
       })
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/fallback/option.html`
-      )
+      await page.goto(url(`/examples/${pattern}/fallback/option.html`))
     })
 
     test('warning', () => {

--- a/e2e/fallback/suppress.spec.ts
+++ b/e2e/fallback/suppress.spec.ts
@@ -1,4 +1,4 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     const warnings: string[] = []
@@ -11,9 +11,7 @@ import { getText } from '../helper'
           }
         }
       })
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/fallback/suppress.html`
-      )
+      await page.goto(url(`/examples/${pattern}/fallback/suppress.html`))
     })
 
     test('warning', () => {

--- a/e2e/formatting/linked.spec.ts
+++ b/e2e/formatting/linked.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/formatting/linked.html`
-      )
+      await page.goto(url(`/examples/${pattern}/formatting/linked.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/formatting/list.spec.ts
+++ b/e2e/formatting/list.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/formatting/list.html`
-      )
+      await page.goto(url(`/examples/${pattern}/formatting/list.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/formatting/literal.spec.ts
+++ b/e2e/formatting/literal.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/formatting/literal.html`
-      )
+      await page.goto(url(`/examples/${pattern}/formatting/literal.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/formatting/named.spec.ts
+++ b/e2e/formatting/named.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/formatting/named.html`
-      )
+      await page.goto(url(`/examples/${pattern}/formatting/named.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/functions/linked.spec.ts
+++ b/e2e/functions/linked.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/functions/linked.html`
-      )
+      await page.goto(url(`/examples/${pattern}/functions/linked.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/functions/list.spec.ts
+++ b/e2e/functions/list.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/functions/list.html`
-      )
+      await page.goto(url(`/examples/${pattern}/functions/list.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/functions/named.spec.ts
+++ b/e2e/functions/named.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/functions/named.html`
-      )
+      await page.goto(url(`/examples/${pattern}/functions/named.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/functions/plural.spec.ts
+++ b/e2e/functions/plural.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/functions/plural.html`
-      )
+      await page.goto(url(`/examples/${pattern}/functions/plural.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/helper.ts
+++ b/e2e/helper.ts
@@ -1,4 +1,5 @@
 import { JSDOM } from 'jsdom'
+import { useTestContext } from '../scripts/test-utils'
 
 import type { Page } from 'playwright-core'
 
@@ -72,4 +73,18 @@ export function assertLocaleHeadWithDom(dom: Document, headSelector: string) {
       }
     }
   }
+}
+
+export function url(path: string) {
+  const ctx = useTestContext()
+
+  if (!ctx.url) {
+    throw new Error('url is not available (is server option enabled?)')
+  }
+
+  if (path.startsWith(ctx.url)) {
+    return path
+  }
+
+  return ctx.url + path
 }

--- a/e2e/hotfix.spec.ts
+++ b/e2e/hotfix.spec.ts
@@ -1,8 +1,8 @@
-import { getText } from './helper'
+import { getText, url } from './helper'
 
 describe('CVE-2024-52809', () => {
   beforeAll(async () => {
-    await page.goto(`http://localhost:8080/e2e/hotfix/CVE-2024-52809.html`)
+    await page.goto(url(`/e2e/hotfix/CVE-2024-52809.html`))
   })
 
   test('fix', async () => {

--- a/e2e/missing/handler.spec.ts
+++ b/e2e/missing/handler.spec.ts
@@ -1,4 +1,4 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     const warnings: string[] = []
@@ -11,9 +11,7 @@ import { getText } from '../helper'
           }
         }
       })
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/missing/handler.html`
-      )
+      await page.goto(url(`/examples/${pattern}/missing/handler.html`))
     })
 
     test('warning', () => {

--- a/e2e/missing/option.spec.ts
+++ b/e2e/missing/option.spec.ts
@@ -1,4 +1,4 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite'].forEach(pattern => {
   describe(`${pattern}`, () => {
     const warnings: string[] = []
@@ -11,9 +11,7 @@ import { getText } from '../helper'
           }
         }
       })
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/missing/option.html`
-      )
+      await page.goto(url(`/examples/${pattern}/missing/option.html`))
     })
 
     test('warning', () => {

--- a/e2e/missing/suppress.spec.ts
+++ b/e2e/missing/suppress.spec.ts
@@ -1,4 +1,4 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     const warnings: string[] = []
@@ -11,9 +11,7 @@ import { getText } from '../helper'
           }
         }
       })
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/missing/suppress.html`
-      )
+      await page.goto(url(`/examples/${pattern}/missing/suppress.html`))
     })
 
     test('warning', () => {

--- a/e2e/number.spec.ts
+++ b/e2e/number.spec.ts
@@ -1,8 +1,8 @@
-import { getText } from './helper'
+import { getText, url } from './helper'
 ;['composition', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(`http://localhost:8080/examples/${pattern}/number.html`)
+      await page.goto(url(`/examples/${pattern}/number.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/plural/basic.spec.ts
+++ b/e2e/plural/basic.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/plural/basic.html`
-      )
+      await page.goto(url(`/examples/${pattern}/plural/basic.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/plural/custom.spec.ts
+++ b/e2e/plural/custom.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/plural/custom.html`
-      )
+      await page.goto(url(`/examples/${pattern}/plural/custom.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/scope/global.spec.ts
+++ b/e2e/scope/global.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/scope/global.html`
-      )
+      await page.goto(url(`/examples/${pattern}/scope/global.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/scope/inherit-locale.spec.ts
+++ b/e2e/scope/inherit-locale.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/scope/inherit-locale.html`
-      )
+      await page.goto(url(`/examples/${pattern}/scope/inherit-locale.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/scope/local.spec.ts
+++ b/e2e/scope/local.spec.ts
@@ -1,10 +1,8 @@
-import { getText } from '../helper'
+import { getText, url } from '../helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(
-        `http://localhost:8080/examples/${pattern}/scope/local.html`
-      )
+      await page.goto(url(`/examples/${pattern}/scope/local.html`))
     })
 
     test('initial rendering', async () => {

--- a/e2e/started.spec.ts
+++ b/e2e/started.spec.ts
@@ -1,8 +1,8 @@
-import { getText } from './helper'
+import { getText, url } from './helper'
 ;['composition', 'petite', 'legacy'].forEach(pattern => {
   describe(`${pattern}`, () => {
     beforeAll(async () => {
-      await page.goto(`http://localhost:8080/examples/${pattern}/started.html`)
+      await page.goto(url(`/examples/${pattern}/started.html`))
     })
 
     test('initial rendering', async () => {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "eslint-plugin-vue": "^9.28.0",
     "execa": "^9.3.0",
     "fixpack": "^4.0.0",
+    "get-port-please": "^3.1.2",
     "globals": "^15.9.0",
     "globby": "^14.0.1",
     "js-yaml": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       fixpack:
         specifier: ^4.0.0
         version: 4.0.0
+      get-port-please:
+        specifier: ^3.1.2
+        version: 3.1.2
       globals:
         specifier: ^15.9.0
         version: 15.9.0
@@ -8306,7 +8309,7 @@ snapshots:
   '@intlify/bundle-utils@7.5.0(petite-vue-i18n@10.0.4(vue@3.5.13(typescript@5.3.3)))(vue-i18n@packages+vue-i18n)':
     dependencies:
       '@intlify/message-compiler': 9.10.2
-      '@intlify/shared': 9.11.0
+      '@intlify/shared': 9.13.1
       acorn: 8.11.3
       escodegen: 2.1.0
       estree-walker: 2.0.2

--- a/scripts/test-utils.ts
+++ b/scripts/test-utils.ts
@@ -1,0 +1,30 @@
+type TestContext = { url: string }
+
+let currentContext: TestContext | undefined
+
+export function useTestContext(): TestContext {
+  recoverContextFromEnv()
+
+  if (!currentContext) {
+    throw new Error(
+      'No context is available. (Forgot calling setup or createContext?)'
+    )
+  }
+  return currentContext
+}
+
+export function setTestContext(context?: TestContext): TestContext | undefined {
+  currentContext = context
+  return currentContext
+}
+
+export function recoverContextFromEnv() {
+  if (!currentContext && process.env.INTLIFY_TEST_CONTEXT) {
+    setTestContext(JSON.parse(process.env.INTLIFY_TEST_CONTEXT || '{}'))
+  }
+}
+
+export function exposeContextToEnv() {
+  const { url } = currentContext!
+  process.env.INTLIFY_TEST_CONTEXT = JSON.stringify({ url })
+}

--- a/scripts/vitest.globalSetup.ts
+++ b/scripts/vitest.globalSetup.ts
@@ -1,18 +1,28 @@
+import { getRandomPort } from 'get-port-please'
 import { fileURLToPath, URL } from 'node:url'
 
 import { listen } from 'listhen'
 import handler from 'serve-handler'
+import { exposeContextToEnv, setTestContext } from './test-utils'
 
 const __dirname = fileURLToPath(new URL('..', import.meta.url))
 
 export async function setup() {
+  const host = '127.0.0.1'
+  const port = await getRandomPort(host)
+  const url = `http://${host}:${port}`
+
+  setTestContext({ url })
+  exposeContextToEnv()
+
   const listener = await listen(
     (req, res) => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       handler(req, res, { public: __dirname })
     },
-    { port: 8080 }
+    { port, hostname: host }
   )
+
   return async () => {
     await listener.close()
   }


### PR DESCRIPTION
It took me a while to realize that the `e2e` tests were failing for me locally due to the `:8080` port already being in use, this PR changes the port selection to use an available port similar to how we set up tests in Nuxt projects. 