### PR TITLE
docx(pluralization.md): Correct spelling from 'gloal' to 'global'

### DIFF
--- a/docs/guide/essentials/pluralization.md
+++ b/docs/guide/essentials/pluralization.md
@@ -34,7 +34,7 @@ Vue I18n offers some ways to support pluralization. Here we’ll use the `$t`.
 :::tip NOTE
 Some ways to support pluralization are:
 
-- injected gloal `$t`
+- injected global `$t`
 - `v-t` custom directive
 - built-in Translation component (`i18n-t`)
 - exported `t` from `useI18n` (for Composition API mode)


### PR DESCRIPTION
While browsing documents, I found the word `gloal` that seems to have a spelling error. It appears to express the meaning of `global`, so I made the correction in this PR.

- File: docs/guide/essentials/pluralization.md
- Line: 37

**Before:**
```
- injected gloal `$t`
```

**After:**
```
- injected global `$t`
```