### PR TITLE
feat!: change to `mangle` option name from `minify` option name

### DIFF
--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -64,7 +64,7 @@ jobs:
           if_no_artifact_found: warn
 
       - name: Prepare report
-        run: npx tsx scripts/size-report.ts > size-report.md
+        run: npx tsx scripts/report-size.ts > size-report.md
 
       - name: Read Size Report
         id: size-report

--- a/packages/core-base/test/compilation.test.ts
+++ b/packages/core-base/test/compilation.test.ts
@@ -1,5 +1,4 @@
 // utils
-import * as shared from '@intlify/shared'
 vi.mock('@intlify/shared', async () => {
   const actual = await vi.importActual<object>('@intlify/shared')
   return {
@@ -9,7 +8,7 @@ vi.mock('@intlify/shared', async () => {
 })
 
 import { baseCompile } from '@intlify/message-compiler'
-import { compile, isMessageAST, clearCompileCache } from '../src/compilation'
+import { clearCompileCache, compile, isMessageAST } from '../src/compilation'
 import { createMessageContext as context } from '../src/runtime'
 
 const DEFAULT_CONTEXT = { locale: 'en', key: 'key' }
@@ -25,7 +24,7 @@ describe('isMessageAST', () => {
     })
   })
 
-  describe('minify AST', () => {
+  describe('mangle AST', () => {
     test('should be true', () => {
       expect(isMessageAST({ type: 0, b: '' })).toBe(true)
     })
@@ -60,11 +59,11 @@ describe('compile', () => {
       expect(msg(ctx)).toBe('hello kazupon!')
     })
 
-    test('minify', () => {
+    test('mangle', () => {
       const { ast } = baseCompile('hello {name}!', {
         location: false,
         jit: true,
-        minify: true
+        mangle: true
       })
       const msg = compile(ast, DEFAULT_CONTEXT)
       const ctx = context({
@@ -78,7 +77,7 @@ describe('compile', () => {
     const { ast } = baseCompile('hello {0}!', {
       location: false,
       jit: true,
-      minify: true
+      mangle: true
     })
     const msg = compile(ast, DEFAULT_CONTEXT)
     const ctx = context({

--- a/packages/message-compiler/src/compiler.ts
+++ b/packages/message-compiler/src/compiler.ts
@@ -1,12 +1,12 @@
+import { assign } from '@intlify/shared'
+import { generate } from './generator'
+import { mangle } from './mangler'
+import { optimize } from './optimizer'
 import { createParser } from './parser'
 import { transform } from './transformer'
-import { optimize } from './optimizer'
-import { minify } from './minifier'
-import { generate } from './generator'
-import { assign } from '@intlify/shared'
 
-import type { CompileOptions } from './options'
 import type { CodeGenResult } from './generator'
+import type { CompileOptions } from './options'
 
 export type CompilerResult = CodeGenResult
 
@@ -16,8 +16,8 @@ export function baseCompile(
 ): CompilerResult {
   const assignedOptions = assign({}, options)
   const jit = !!assignedOptions.jit
-  const enalbeMinify = !!assignedOptions.minify
-  const enambeOptimize =
+  const enableMangle = !!assignedOptions.mangle
+  const enableOptimize =
     assignedOptions.optimize == null ? true : assignedOptions.optimize
 
   // parse source codes
@@ -32,10 +32,10 @@ export function baseCompile(
     return generate(ast, assignedOptions)
   } else {
     // optimize ASTs
-    enambeOptimize && optimize(ast)
+    enableOptimize && optimize(ast)
 
     // minimize ASTs
-    enalbeMinify && minify(ast)
+    enableMangle && mangle(ast)
 
     // In JIT mode, no ast transform, no code generation.
     return { ast, code: '' }

--- a/packages/message-compiler/src/mangler.ts
+++ b/packages/message-compiler/src/mangler.ts
@@ -1,31 +1,31 @@
+import { CompileErrorCodes, createCompileError } from './errors'
 import { NodeTypes } from './nodes'
-import { createCompileError, CompileErrorCodes } from './errors'
 
 import type {
-  MessageNode,
-  ResourceNode,
-  Node,
-  PluralNode,
-  TextNode,
-  LiteralNode,
-  LinkedNode,
   LinkedKeyNode,
   LinkedModifierNode,
+  LinkedNode,
   ListNode,
-  NamedNode
+  LiteralNode,
+  MessageNode,
+  NamedNode,
+  Node,
+  PluralNode,
+  ResourceNode,
+  TextNode
 } from './nodes'
 
 export const ERROR_DOMAIN = 'minifier'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export function minify(node: Node) {
+export function mangle(node: Node) {
   node.t = node.type
 
   switch (node.type) {
     case NodeTypes.Resource: {
       const resource = node as ResourceNode
-      minify(resource.body)
+      mangle(resource.body)
       resource.b = resource.body
       delete (resource as any).body
       break
@@ -34,7 +34,7 @@ export function minify(node: Node) {
       const plural = node as PluralNode
       const cases = plural.cases
       for (let i = 0; i < cases.length; i++) {
-        minify(cases[i])
+        mangle(cases[i])
       }
       plural.c = cases
       delete (plural as any).cases
@@ -44,7 +44,7 @@ export function minify(node: Node) {
       const message = node as MessageNode
       const items = message.items
       for (let i = 0; i < items.length; i++) {
-        minify(items[i])
+        mangle(items[i])
       }
       message.i = items
       delete (message as any).items
@@ -71,11 +71,11 @@ export function minify(node: Node) {
     }
     case NodeTypes.Linked: {
       const linked = node as LinkedNode
-      minify(linked.key)
+      mangle(linked.key)
       linked.k = linked.key
       delete (linked as any).key
       if (linked.modifier) {
-        minify(linked.modifier)
+        mangle(linked.modifier)
         linked.m = linked.modifier
         delete (linked as any).modifier
       }

--- a/packages/message-compiler/src/options.ts
+++ b/packages/message-compiler/src/options.ts
@@ -34,7 +34,7 @@ export interface CodeGenOptions {
 
 export type CompileOptions = {
   optimize?: boolean // default true
-  minify?: boolean // default false
+  mangle?: boolean // default false
   jit?: boolean // default false
 } & TransformOptions &
   CodeGenOptions &

--- a/packages/message-compiler/test/__snapshots__/compiler.test.ts.snap
+++ b/packages/message-compiler/test/__snapshots__/compiler.test.ts.snap
@@ -287,7 +287,7 @@ exports[`compiler options > location: false > ast 1`] = `
 }
 `;
 
-exports[`compiler options > minify: true > ast 1`] = `
+exports[`compiler options > mangle: true > ast 1`] = `
 {
   "b": {
     "i": [

--- a/packages/message-compiler/test/__snapshots__/mangler.test.ts.snap
+++ b/packages/message-compiler/test/__snapshots__/mangler.test.ts.snap
@@ -1,0 +1,47 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`mangle 1`] = `
+{
+  "b": {
+    "c": [
+      {
+        "i": [
+          {
+            "t": 3,
+          },
+        ],
+        "s": "no apples",
+        "t": 2,
+      },
+      {
+        "i": [
+          {
+            "i": 0,
+            "t": 5,
+          },
+          {
+            "t": 3,
+            "v": " apple",
+          },
+        ],
+        "t": 2,
+      },
+      {
+        "i": [
+          {
+            "k": "n",
+            "t": 4,
+          },
+          {
+            "t": 3,
+            "v": " apples",
+          },
+        ],
+        "t": 2,
+      },
+    ],
+    "t": 1,
+  },
+  "t": 0,
+}
+`;

--- a/packages/message-compiler/test/compiler.test.ts
+++ b/packages/message-compiler/test/compiler.test.ts
@@ -102,11 +102,11 @@ describe('compiler options', () => {
     expect(map).toBeUndefined()
   })
 
-  test('minify: true', () => {
+  test('mangle: true', () => {
     const { ast } = compile(`hello world`, {
       location: false,
       jit: true,
-      minify: true
+      mangle: true
     })
     expect(ast).toMatchSnapshot('ast')
   })

--- a/packages/message-compiler/test/mangler.test.ts
+++ b/packages/message-compiler/test/mangler.test.ts
@@ -1,16 +1,16 @@
 import { format } from '@intlify/shared'
-import { createParser } from '../src/parser'
-import { optimize } from '../src/optimizer'
-import { minify } from '../src/minifier'
 import { CompileErrorCodes, errorMessages } from '../src/errors'
+import { mangle } from '../src/mangler'
+import { optimize } from '../src/optimizer'
+import { createParser } from '../src/parser'
 
 import type { MessageNode, PluralNode, ResourceNode } from '../src/nodes'
 
-test('minify', () => {
+test('mangle', () => {
   const parser = createParser({ location: false })
   const msg = `no apples | {0} apple | {n} apples`
   const ast = optimize(parser.parse(msg))
-  minify(ast)
+  mangle(ast)
 
   expect(ast).toMatchSnapshot()
   const messages = (ast.b! as PluralNode)
@@ -25,7 +25,7 @@ test('unhandle error', () => {
   const ast = {
     type
   } as unknown as ResourceNode
-  expect(() => minify(ast)).toThrowError(
+  expect(() => mangle(ast)).toThrowError(
     format(errorMessages[CompileErrorCodes.UNHANDLED_MINIFIER_NODE_TYPE], type)
   )
 })


### PR DESCRIPTION
In the context of javascript code minification, especially in terser, it's used `mangle` word, so we will according to it.