### PR TITLE
Fix: Synchronous Watcher Issue Caused by Locale Setting Order

### DIFF
--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -2110,8 +2110,8 @@ export function createComposer(options: any = {}): any {
   const locale = computed({
     get: () => _locale.value,
     set: val => {
+      _context.locale = val
       _locale.value = val
-      _context.locale = _locale.value
     }
   })
 
@@ -2119,8 +2119,8 @@ export function createComposer(options: any = {}): any {
   const fallbackLocale = computed({
     get: () => _fallbackLocale.value,
     set: val => {
+      _context.fallbackLocale = val
       _fallbackLocale.value = val
-      _context.fallbackLocale = _fallbackLocale.value
       updateFallbackLocale(_context, _locale.value, val)
     }
   })

--- a/packages/vue-i18n-core/test/composer.test.ts
+++ b/packages/vue-i18n-core/test/composer.test.ts
@@ -64,7 +64,16 @@ describe('locale', () => {
   test('reactivity', async () => {
     const fn = vi.fn()
 
-    const { locale } = createComposer({})
+    const { locale, t } = createComposer({
+      messages: {
+        en: {
+          test: 'en'
+        },
+        'en-US': {
+          test: 'en-US'
+        }
+      }
+    })
     watch(locale, fn)
     locale.value = 'en'
     await nextTick()
@@ -72,6 +81,18 @@ describe('locale', () => {
     expect(fn).toBeCalled()
     expect(fn.mock.calls[0][0]).toEqual('en')
     expect(fn.mock.calls[0][1]).toEqual('en-US')
+
+    let result = ''
+    locale.value = 'en'
+
+    watch(locale, () => (result = t('test')), {
+      immediate: true,
+      flush: 'sync'
+    })
+    expect(result).toEqual('en')
+    locale.value = 'en-US'
+    await nextTick()
+    expect(result).toEqual('en-US')
   })
 })
 


### PR DESCRIPTION
reproduction: https://codesandbox.io/p/devbox/vue-i18n-9-template-forked-ffq44z

This PR adjusts the order of operations in the locale setter to rectify the issue where, during locale updates, a synchronous watcher may trigger after modifying the _locale.value (as seen in [this file](https://github.com/intlify/vue-i18n/blob/897829bff49fe4694cc9fc0c571d2d42652e4b9f/packages/vue-i18n-core/src/composer.ts#L2113), but before updating the _context. This sequence led to errors because the translation mechanism relies exclusively on _context, not _locale.