### PR TITLE
feat(core-base): accessor for locale messages

### DIFF
--- a/packages/core-base/src/context.ts
+++ b/packages/core-base/src/context.ts
@@ -3,6 +3,7 @@
 import {
   assign,
   create,
+  deepCopy,
   isArray,
   isBoolean,
   isFunction,
@@ -431,6 +432,7 @@ export const getFallbackContext = (): CoreContext | null => _fallbackContext
 // ID for CoreContext
 let _cid = 0
 
+// TODO: API documentation, if `@intlify/core` will be documented as a separate package
 export function createCoreContext<
   Message = string,
   Options extends CoreOptions<Message> = CoreOptions<Message>,
@@ -630,6 +632,33 @@ export function createCoreContext<Message = string>(options: any = {}): any {
 }
 
 const createResources = (locale: Locale) => ({ [locale]: create() })
+
+// TODO: API documentation, if `@intlify/core` will be documented as a separate package
+export function getMessages<
+  Context extends CoreContext,
+  Locales = keyof Context['messages'],
+  Return = Context['messages'][keyof Context['messages']]
+>(ctx: Context, locale: Locales): Return | undefined {
+  const src = (ctx.messages as any)[locale]
+  if (src == null) {
+    return undefined
+  }
+  const dest = create()
+  deepCopy(src, dest)
+  return dest as Return
+}
+
+// TODO: API documentation, if `@intlify/core` will be documented as a separate package
+export function setMessages<
+  Context extends CoreContext,
+  Locales = keyof Context['messages']
+>(
+  ctx: Context,
+  locale: Locales,
+  messages: Context['messages'][keyof Context['messages']]
+): void {
+  ;(ctx.messages as any)[locale] = messages
+}
 
 /** @internal */
 export function isTranslateFallbackWarn(

--- a/packages/core-base/test/context.test-d.ts
+++ b/packages/core-base/test/context.test-d.ts
@@ -1,4 +1,4 @@
-import { createCoreContext } from '../src'
+import { createCoreContext, getMessages } from '../src'
 
 import type {
   DateTimeFormat,
@@ -129,6 +129,10 @@ test('strict context', () => {
     en: NumberFormat
     ja: NumberFormat
   }>()
+
+  expectTypeOf(getMessages(strictCtx, 'en')).toEqualTypeOf<
+    ResourceSchema | undefined
+  >()
 })
 
 test('strict context with direct options', () => {
@@ -197,6 +201,10 @@ test('strict context with direct options', () => {
       }
     }
   }>()
+
+  expectTypeOf(getMessages(strictDirectCtx, 'en')).toEqualTypeOf<
+    ResourceSchema | undefined
+  >()
 
   const nullCtx1 = createCoreContext({})
   expectTypeOf(nullCtx1.locale).toEqualTypeOf<Locale | LocaleDetector>()

--- a/packages/core-base/test/context.test.ts
+++ b/packages/core-base/test/context.test.ts
@@ -1,4 +1,8 @@
-import { createCoreContext as context } from '../src/context'
+import {
+  createCoreContext as context,
+  getMessages,
+  setMessages
+} from '../src/context'
 
 describe('locale', () => {
   test('default', () => {
@@ -169,4 +173,40 @@ describe('escapeParameter', () => {
     const ctx = context({ escapeParameter: true })
     expect(ctx.escapeParameter).toEqual(true)
   })
+})
+
+describe('getMessages', () => {
+  test('exist locale', () => {
+    const ctx = context({
+      messages: {
+        en: { hello: 'hello' },
+        ja: { hello: 'こんにちは！' }
+      }
+    })
+    const messages = getMessages(ctx, 'en')
+    expect(messages).toEqual({ hello: 'hello' })
+  })
+
+  test('not exist locale', () => {
+    const ctx = context({
+      locale: 'en',
+      messages: {
+        en: { hello: 'hello' }
+      }
+    })
+    const messages = getMessages(ctx, 'ja')
+    expect(messages).toBeUndefined()
+  })
+})
+
+test('setMessages', () => {
+  const ctx = context({
+    locale: 'en',
+    messages: {
+      en: { hello: 'hello' }
+    }
+  })
+
+  setMessages(ctx, 'ja', { hello: 'こんにちは！' })
+  expect(getMessages(ctx, 'ja')).toMatchObject({ hello: 'こんにちは！' })
 })


### PR DESCRIPTION
`@intlify/core` API is not currently documented, but `@intlify/core` does not have an accessor for locale messages like the getLocaleMessages / setLocaleMessages of vue-i18n.
As shown in the reference, if you want to use `@intlify/core`, it would be useful to have such an API.

(The API documentation for `@intlify/core` will be published in the future)

## usecases
https://github.com/kazupon/gunshi/pull/29