### PR TITLE
fix: duplicate generated type config naming

### DIFF
--- a/packages/vue-i18n-core/src/types.ts
+++ b/packages/vue-i18n-core/src/types.ts
@@ -1,4 +1,4 @@
-import type { IsNever } from '@intlify/core-base'
+import type { GeneratedTypeConfig, IsNever } from '@intlify/core-base'
 import type { ExportedGlobalComposer } from './i18n'
 import type { VueI18n } from './legacy'
 
@@ -16,14 +16,14 @@ export type Disposer = () => void
  * ```ts
  * // generated-i18n-types.d.ts (`.d.ts` file at your app)
  *
- * declare module '@intlify/vue-i18n-core' {
+ * declare module '@intlify/core-base' {
  *   interface GeneratedTypeConfig {
  *     legacy: false
  *   }
  * }
  * ```
  */
-export interface GeneratedTypeConfig {}
+export { GeneratedTypeConfig }
 
 /**
  * Narrowed i18n instance type based on `GeneratedTypeConfig['legacy']`


### PR DESCRIPTION
I'm running into an issue while implementing https://github.com/nuxt-modules/i18n/pull/3341

In the build it looks like the `GeneratedTypeConfig` interface gets renamed to `GeneratedTypeConfig_2` and is no longer exported, which means we can't augment it.

This is what the type looks like in the build currently:
```ts
declare type GeneratedInstanceType = GeneratedTypeConfig_2 extends Record<'legacy', infer Legacy> ? Legacy : never;
export { GeneratedTypeConfig }
```