### PR TITLE
Part options support $n - v11

### DIFF
--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -1203,13 +1203,18 @@ export interface ComposerNumberFormatting<
    *
    * @returns Formatted value
    */
-  <Key extends string = string>(
+  <
+    Key extends string = string,
+    Return extends string | Intl.NumberFormatPart[] =
+      | string
+      | Intl.NumberFormatPart[]
+  >(
     value: number,
     keyOrOptions:
       | Key
       | ResourceKeys
       | NumberOptions<Key | ResourceKeys, Locales>
-  ): string | Intl.NumberFormatPart[]
+  ): Return
   /**
    * Number Formatting
    *
@@ -1224,14 +1229,19 @@ export interface ComposerNumberFormatting<
    *
    * @returns Formatted value
    */
-  <Key extends string = string>(
+  <
+    Key extends string = string,
+    Return extends string | Intl.NumberFormatPart[] =
+      | string
+      | Intl.NumberFormatPart[]
+  >(
     value: number,
     keyOrOptions:
       | Key
       | ResourceKeys
       | NumberOptions<Key | ResourceKeys, Locales>,
     locale: Locales
-  ): string | Intl.NumberFormatPart[]
+  ): Return
 }
 
 /**

--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -1209,7 +1209,7 @@ export interface ComposerNumberFormatting<
       | Key
       | ResourceKeys
       | NumberOptions<Key | ResourceKeys, Locales>
-  ): string
+  ): string | Intl.NumberFormatPart[]
   /**
    * Number Formatting
    *
@@ -1231,7 +1231,7 @@ export interface ComposerNumberFormatting<
       | ResourceKeys
       | NumberOptions<Key | ResourceKeys, Locales>,
     locale: Locales
-  ): string
+  ): string | Intl.NumberFormatPart[]
 }
 
 /**
@@ -2287,14 +2287,17 @@ export function createComposer(options: any = {}): any {
   }
 
   // n
-  function n(...args: unknown[]): string {
-    return wrapWithDeps<{}, string>(
-      context => Reflect.apply(number, null, [context, ...args]) as string,
+  function n(...args: unknown[]): string | Intl.NumberFormatPart[] {
+    return wrapWithDeps<{}, string | Intl.NumberFormatPart[]>(
+      context =>
+        Reflect.apply(number, null, [context, ...args]) as
+          | string
+          | Intl.NumberFormatPart[],
       () => parseNumberArgs(...args),
       'number format',
       root => Reflect.apply(root.n, root, [...args]),
       () => MISSING_RESOLVE_VALUE,
-      val => isString(val)
+      val => isString(val) || isArray(val)
     )
   }
 

--- a/packages/vue-i18n-core/test/composer.test-d.ts
+++ b/packages/vue-i18n-core/test/composer.test-d.ts
@@ -353,15 +353,15 @@ test('strict composer with direct options', () => {
     strictDirectComposer.d(new Date(), 'custom' as any)
   ).toEqualTypeOf<string>()
   expectTypeOf(strictDirectComposer.n(1)).toEqualTypeOf<string>()
-  expectTypeOf(
-    strictDirectComposer.n(1, 'currency', 'zh')
-  ).toEqualTypeOf<string>()
+  expectTypeOf(strictDirectComposer.n(1, 'currency', 'zh')).toEqualTypeOf<
+    string | Intl.NumberFormatPart[]
+  >()
   expectTypeOf(
     strictDirectComposer.n(1, { key: 'currency', locale: 'en' })
-  ).toEqualTypeOf<string>()
-  expectTypeOf(
-    strictDirectComposer.n(1, 'custom' as any)
-  ).toEqualTypeOf<string>()
+  ).toEqualTypeOf<string | Intl.NumberFormatPart[]>()
+  expectTypeOf(strictDirectComposer.n(1, 'custom' as any)).toEqualTypeOf<
+    string | Intl.NumberFormatPart[]
+  >()
 
   // const noOptionsComposer = createComposer({ missingWarn: true })
   const noOptionsComposer = createComposer({ locale: 'en' })

--- a/packages/vue-i18n-core/test/composer.test-d.ts
+++ b/packages/vue-i18n-core/test/composer.test-d.ts
@@ -357,8 +357,27 @@ test('strict composer with direct options', () => {
     string | Intl.NumberFormatPart[]
   >()
   expectTypeOf(
-    strictDirectComposer.n(1, { key: 'currency', locale: 'en' })
-  ).toEqualTypeOf<string | Intl.NumberFormatPart[]>()
+    strictDirectComposer.n<string, string>(1, 'currency', 'zh')
+  ).toEqualTypeOf<string>()
+  expectTypeOf(
+    strictDirectComposer.n<string, string>(1, { key: 'currency', locale: 'en' })
+  ).toEqualTypeOf<string>()
+  expectTypeOf(
+    strictDirectComposer.n<string, string>(1, { key: 'currency', locale: 'en' })
+  ).toEqualTypeOf<string>()
+  expectTypeOf(
+    strictDirectComposer.n<string, Intl.NumberFormatPart[]>(1, {
+      key: 'currency',
+      locale: 'en',
+      part: true
+    })
+  ).toEqualTypeOf<Intl.NumberFormatPart[]>()
+  expectTypeOf(strictDirectComposer.n(1, 'currency')).toEqualTypeOf<
+    string | Intl.NumberFormatPart[]
+  >()
+  expectTypeOf(
+    strictDirectComposer.n<string, string>(1, 'currency')
+  ).toEqualTypeOf<string>()
   expectTypeOf(strictDirectComposer.n(1, 'custom' as any)).toEqualTypeOf<
     string | Intl.NumberFormatPart[]
   >()

--- a/packages/vue-i18n/src/vue.d.ts
+++ b/packages/vue-i18n/src/vue.d.ts
@@ -865,7 +865,10 @@ declare module 'vue' {
      *
      * @returns formatted value
      */
-    $n(value: number, options: NumberOptions): string
+    $n<OptionsType extends NumberOptions>(
+      value: number,
+      options: OptionsType
+    ): OptionsType['type'] extends true ? Intl.NumberFormatPart[] : string
     /**
      * Locale messages getter
      *

--- a/packages/vue-i18n/src/vue.d.ts
+++ b/packages/vue-i18n/src/vue.d.ts
@@ -865,10 +865,23 @@ declare module 'vue' {
      *
      * @returns formatted value
      */
-    $n<OptionsType extends NumberOptions>(
+    $n<
+      Key extends string,
+      Return extends string | Intl.NumberFormatPart[] =
+        | string
+        | Intl.NumberFormatPart[],
+      DefinedNumberFormat extends
+        RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
+      Keys = IsEmptyObject<DefinedNumberFormat> extends false
+        ? PickupFormatPathKeys<{
+            [K in keyof DefinedNumberFormat]: DefinedNumberFormat[K]
+          }>
+        : never,
+      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
+    >(
       value: number,
-      options: OptionsType
-    ): OptionsType['type'] extends true ? Intl.NumberFormatPart[] : string
+      options: NumberOptions<Key, ResourceKeys>
+    ): Return
     /**
      * Locale messages getter
      *


### PR DESCRIPTION
Back ported part option functionality for $n().

Would close https://github.com/intlify/vue-i18n/issues/2172