### PR TITLE
fix: error on duplicate useI18n calling on local scope

### DIFF
--- a/packages/vue-i18n-core/src/errors.ts
+++ b/packages/vue-i18n-core/src/errors.ts
@@ -22,7 +22,9 @@ export const I18nErrorCodes = {
   CANNOT_SETUP_VUE_DEVTOOLS_PLUGIN: 30,
   NOT_INSTALLED_WITH_PROVIDE: 31,
   // unexpected error
-  UNEXPECTED_ERROR: 32
+  UNEXPECTED_ERROR: 32,
+  // duplicate `useI18n` calling
+  DUPLICATE_USE_I18N_CALLING: 33
 } as const
 
 type I18nErrorCodes = (typeof I18nErrorCodes)[keyof typeof I18nErrorCodes]
@@ -49,5 +51,7 @@ export const errorMessages: { [code: number]: string } = {
   [I18nErrorCodes.INVALID_VALUE]: `Invalid value`,
   [I18nErrorCodes.CANNOT_SETUP_VUE_DEVTOOLS_PLUGIN]: `Cannot setup vue-devtools plugin`,
   [I18nErrorCodes.NOT_INSTALLED_WITH_PROVIDE]:
-    'Need to install with `provide` function'
+    'Need to install with `provide` function',
+  [I18nErrorCodes.DUPLICATE_USE_I18N_CALLING]:
+    "Duplicate `useI18n` calling by local scope. Please don't call it on local scope"
 }

--- a/packages/vue-i18n-core/src/errors.ts
+++ b/packages/vue-i18n-core/src/errors.ts
@@ -53,5 +53,5 @@ export const errorMessages: { [code: number]: string } = {
   [I18nErrorCodes.NOT_INSTALLED_WITH_PROVIDE]:
     'Need to install with `provide` function',
   [I18nErrorCodes.DUPLICATE_USE_I18N_CALLING]:
-    "Duplicate `useI18n` calling by local scope. Please don't call it on local scope"
+    'Duplicate local-scope `useI18n` call detected. Call `useI18n` only once per component.'
 }

--- a/packages/vue-i18n-core/src/i18n.ts
+++ b/packages/vue-i18n-core/src/i18n.ts
@@ -610,6 +610,10 @@ export function useI18n<
     setupLifeCycle(i18nInternal, instance, composer)
 
     i18nInternal.__setInstance(instance, composer)
+  } else {
+    if (__DEV__ && scope === 'local') {
+      throw createI18nError(I18nErrorCodes.DUPLICATE_USE_I18N_CALLING)
+    }
   }
 
   return composer as unknown as Composer<


### PR DESCRIPTION
This PR is bringed up from #2203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to prevent duplicate calls to `useI18n` within the same component, displaying a clear error message if this occurs.

- **Tests**
  - Added a test case to ensure an error is thrown when `useI18n` is called multiple times in the same local scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->