### PR TITLE
Fix declaration order in Number formatting with options ResourceKeys must be before OptionsType

### DIFF
--- a/packages/vue-i18n/src/vue.d.ts
+++ b/packages/vue-i18n/src/vue.d.ts
@@ -604,7 +604,6 @@ declare module 'vue' {
     $d<
       Value extends number | Date = number,
       Key extends string = string,
-      OptionsType = DateTimeOptions<Key | ResourceKeys>,
       DefinedDateTimeFormat extends
         RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedDateTimeFormat> extends false
@@ -612,7 +611,8 @@ declare module 'vue' {
             [K in keyof DefinedDateTimeFormat]: DefinedDateTimeFormat[K]
           }>
         : never,
-      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
+      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never,
+      OptionsType = DateTimeOptions<Key | ResourceKeys>
     >(
       value: Value,
       options: OptionsType,
@@ -670,7 +670,6 @@ declare module 'vue' {
      */
     $n<
       Key extends string = string,
-      OptionsType = NumberOptions<Key | ResourceKeys>,
       DefinedNumberFormat extends
         RemovedIndexResources<DefineDateTimeFormat> = RemovedIndexResources<DefineDateTimeFormat>,
       Keys = IsEmptyObject<DefinedNumberFormat> extends false
@@ -678,7 +677,8 @@ declare module 'vue' {
             [K in keyof DefinedNumberFormat]: DefinedNumberFormat[K]
           }>
         : never,
-      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
+      ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never,
+      OptionsType = NumberOptions<Key | ResourceKeys>
     >(
       value: number,
       options: OptionsType


### PR DESCRIPTION
Fix build error since 11.1.5 with vue-tsc : 

node_modules/vue-i18n/dist/vue-i18n.d.ts:3814:43 - error TS2744: Type parameter defaults can only reference previously declared type parameters.

3814       OptionsType = DateTimeOptions<Key | ResourceKeys>,
                                               ~~~~~~~~~~~~

node_modules/vue-i18n/dist/vue-i18n.d.ts:4022:41 - error TS2744: Type parameter defaults can only reference previously declared type parameters.

4022       OptionsType = NumberOptions<Key | ResourceKeys>,
                                             ~~~~~~~~~~~~



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved type parameter order for datetime and number formatting methods to enhance type safety and consistency. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->