### PR TITLE
 Fix: Adjust stub file paths for accurate resolution during rolldown build

### DIFF
--- a/scripts/rolldown.ts
+++ b/scripts/rolldown.ts
@@ -323,16 +323,22 @@ export function createConfigsForPackage({
             if (rawFile == null) {
               return
             }
-            const stub = stubs[rawFile]
+            const filename = path.basename(rawFile)
+            const stub = stubs[`dist/${filename}`]
             if (!stub) {
               return
             }
 
-            const filename = path.basename(rawFile)
             const contents = `export * from './${filename}'`
 
-            await fs.writeFile(stub, contents)
-            // console.log(`created stub ${pc.bold(path.join('packages', target, 'dist', path.basename(stub)))}`)
+            const fullpath = path.join(
+              'packages',
+              target,
+              'dist',
+              path.basename(stub)
+            )
+            await fs.writeFile(fullpath, contents)
+            console.log(`created stub ${pc.bold(fullpath)}`)
           }
         }
       ],


### PR DESCRIPTION
Fixed a bug that caused stub generation to not work properly.

```sh
$ nr build:rolldown  
$ ls -1 packages/*/dist/*js > before_build
$ git checkout rolldown
$ nr build:rolldown  
$ ls -1 packages/*/dist/*js > after_build
$ diff before_build after_build
```

```diff
2a3
> packages/core-base/dist/core-base.esm-bundler.js
7a9
> packages/core/dist/core.esm-bundler.js
13a16
> packages/core/dist/core.runtime.esm-bundler.js
17a21
> packages/devtools-types/dist/devtools-types.esm-bundler.js
20a25
> packages/message-compiler/dist/message-compiler.esm-bundler.js
26a32
> packages/petite-vue-i18n/dist/petite-vue-i18n.esm-bundler.js
32a39
> packages/petite-vue-i18n/dist/petite-vue-i18n.runtime.esm-bundler.js
38a46
> packages/shared/dist/shared.esm-bundler.js
41a50
> packages/vue-i18n-core/dist/petite-vue-i18n-core.esm-bundler.js
46a56
> packages/vue-i18n-core/dist/vue-i18n-core.esm-bundler.js
51a62
> packages/vue-i18n/dist/vue-i18n.esm-bundler.js
57a69
> packages/vue-i18n/dist/vue-i18n.runtime.esm-bundler.js

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the handling and placement of generated stub files to ensure they are written to the correct location with consistent path resolution.
  - Added a console log to display the full path of each created stub file for better visibility during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->