### PR TITLE
Update StackBlitz link in getting started guide

### DIFF
--- a/docs/guide/essentials/started.md
+++ b/docs/guide/essentials/started.md
@@ -10,7 +10,7 @@ This guide will assume that you are already familiar with Vue itself. You don't 
 
 we're going to consider this example:
 
-- [StackBlitz example](https://stackblitz.com/edit/vue-i18n-get-started?file=main.js)
+- [StackBlitz example](https://stackblitz.com/edit/vue-i18n-get-started-jtknregd?file=main.js)
 
 Let's start by looking at the root component, `App.vue`.
 


### PR DESCRIPTION
https://github.com/intlify/vue-i18n/issues/2201

https://github.com/intlify/vue-i18n/pull/2209#issuecomment-3000559363

I replaced the stackblitz link with a typo-fixed link.