### PR TITLE
fix: typo

### DIFF
--- a/examples/storybook/index.html
+++ b/examples/storybook/index.html
@@ -1,9 +1,9 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="">
   <head>
-    <meta charset="UTF-8">
-    <link rel="icon" href="/favicon.ico">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite App</title>
   </head>
   <body>

--- a/packages/core-base/package.json
+++ b/packages/core-base/package.json
@@ -26,7 +26,6 @@
   "files": [
     "dist"
   ],
-  "type": "module",
   "module": "dist/core-base.js",
   "unpkg": "dist/core-base.global.js",
   "jsdelivr": "dist/core-base.global.js",
@@ -69,5 +68,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "type": "module"
 }

--- a/packages/core-base/src/context.ts
+++ b/packages/core-base/src/context.ts
@@ -336,7 +336,7 @@ export interface CoreInternalContext {
  */
 export const VERSION: string = __VERSION__
 
-export const NOT_REOSLVED = -1
+export const NOT_RESOLVED = -1
 
 export const DEFAULT_LOCALE = 'en-US'
 

--- a/packages/core-base/src/datetime.ts
+++ b/packages/core-base/src/datetime.ts
@@ -12,7 +12,7 @@ import {
   handleMissing,
   isTranslateFallbackWarn,
   MISSING_RESOLVE_VALUE,
-  NOT_REOSLVED
+  NOT_RESOLVED
 } from './context'
 import { CoreErrorCodes, createCoreError } from './errors'
 import { getLocale } from './fallbacker'
@@ -275,7 +275,7 @@ export function datetime<
 
   // checking format and target locale
   if (!isPlainObject(format) || !isString(targetLocale)) {
-    return unresolving ? NOT_REOSLVED : key
+    return unresolving ? NOT_RESOLVED : key
   }
 
   let id = `${targetLocale}__${key}`

--- a/packages/core-base/src/number.ts
+++ b/packages/core-base/src/number.ts
@@ -11,7 +11,7 @@ import {
   handleMissing,
   isTranslateFallbackWarn,
   MISSING_RESOLVE_VALUE,
-  NOT_REOSLVED
+  NOT_RESOLVED
 } from './context'
 import { CoreErrorCodes, createCoreError } from './errors'
 import { getLocale } from './fallbacker'
@@ -270,7 +270,7 @@ export function number<
 
   // checking format and target locale
   if (!isPlainObject(format) || !isString(targetLocale)) {
-    return unresolving ? NOT_REOSLVED : key
+    return unresolving ? NOT_RESOLVED : key
   }
 
   let id = `${targetLocale}__${key}`

--- a/packages/core-base/src/translate.ts
+++ b/packages/core-base/src/translate.ts
@@ -24,7 +24,7 @@ import {
   isAlmostSameLocale,
   isImplicitFallback,
   isTranslateFallbackWarn,
-  NOT_REOSLVED
+  NOT_RESOLVED
 } from './context'
 import { translateDevTools } from './devtools'
 import { CoreErrorCodes, createCoreError } from './errors'
@@ -713,7 +713,7 @@ export function translate<
     ) ||
       !isString(targetLocale))
   ) {
-    return unresolving ? NOT_REOSLVED : (key as MessageFunctionReturn<Message>)
+    return unresolving ? NOT_RESOLVED : (key as MessageFunctionReturn<Message>)
   }
 
   // TODO: refactor

--- a/packages/core-base/test/datetime.test.ts
+++ b/packages/core-base/test/datetime.test.ts
@@ -20,14 +20,15 @@ vi.mock('../src/intl', async () => {
   }
 })
 
-import { createCoreContext as context, NOT_REOSLVED } from '../src/context'
+import { compile } from '../src/compilation'
+import {
+  createCoreContext as context,
+  NOT_RESOLVED,
+  registerLocaleFallbacker,
+  registerMessageCompiler
+} from '../src/context'
 import { datetime } from '../src/datetime'
 import { CoreErrorCodes, errorMessages } from '../src/errors'
-import {
-  registerMessageCompiler,
-  registerLocaleFallbacker
-} from '../src/context'
-import { compile } from '../src/compilation'
 import { fallbackWithLocaleChain } from '../src/fallbacker'
 
 import type { DateTimeFormats } from '../src/types'
@@ -265,7 +266,7 @@ describe('context unresolving option', () => {
       datetimeFormats
     })
 
-    expect(datetime(ctx, dt, 'long')).toEqual(NOT_REOSLVED)
+    expect(datetime(ctx, dt, 'long')).toEqual(NOT_RESOLVED)
     expect(mockWarn).not.toHaveBeenCalled()
   })
 
@@ -284,7 +285,7 @@ describe('context unresolving option', () => {
       datetimeFormats
     })
 
-    expect(datetime(ctx, dt, 'custom')).toEqual(NOT_REOSLVED)
+    expect(datetime(ctx, dt, 'custom')).toEqual(NOT_RESOLVED)
     expect(mockWarn).not.toHaveBeenCalled()
   })
 })

--- a/packages/core-base/test/number.test.ts
+++ b/packages/core-base/test/number.test.ts
@@ -23,7 +23,7 @@ vi.mock('../src/intl', async () => {
 import { compile } from '../src/compilation'
 import {
   createCoreContext as context,
-  NOT_REOSLVED,
+  NOT_RESOLVED,
   registerLocaleFallbacker,
   registerMessageCompiler
 } from '../src/context'
@@ -240,7 +240,7 @@ describe('context unresolving option', () => {
       numberFormats
     })
 
-    expect(number(ctx, 0.99, 'percent')).toEqual(NOT_REOSLVED)
+    expect(number(ctx, 0.99, 'percent')).toEqual(NOT_RESOLVED)
     expect(mockWarn).not.toHaveBeenCalled()
   })
 
@@ -259,7 +259,7 @@ describe('context unresolving option', () => {
       numberFormats
     })
 
-    expect(number(ctx, 123456789, 'custom')).toEqual(NOT_REOSLVED)
+    expect(number(ctx, 123456789, 'custom')).toEqual(NOT_RESOLVED)
     expect(mockWarn).not.toHaveBeenCalled()
   })
 })

--- a/packages/core-base/test/translate.test.ts
+++ b/packages/core-base/test/translate.test.ts
@@ -16,7 +16,7 @@ vi.mock('@intlify/shared', async () => {
 import { compile } from '../src/compilation'
 import {
   createCoreContext as context,
-  NOT_REOSLVED,
+  NOT_RESOLVED,
   registerLocaleFallbacker,
   registerMessageCompiler,
   registerMessageResolver
@@ -553,7 +553,7 @@ describe('context unresolving option', () => {
         ja: {}
       }
     })
-    expect(translate(ctx, 'hello.world')).toEqual(NOT_REOSLVED)
+    expect(translate(ctx, 'hello.world')).toEqual(NOT_RESOLVED)
   })
 
   test('fallbackWarn is false', () => {
@@ -568,7 +568,7 @@ describe('context unresolving option', () => {
         ja: {}
       }
     })
-    expect(translate(ctx, 'hello.world')).toEqual(NOT_REOSLVED)
+    expect(translate(ctx, 'hello.world')).toEqual(NOT_RESOLVED)
   })
 
   test('fallbackFormat is true', () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,6 @@
   "files": [
     "dist"
   ],
-  "type": "module",
   "module": "dist/core.js",
   "unpkg": "dist/core.global.js",
   "jsdelivr": "dist/core.global.js",
@@ -71,5 +70,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "type": "module"
 }

--- a/packages/devtools-types/package.json
+++ b/packages/devtools-types/package.json
@@ -25,7 +25,6 @@
   "files": [
     "dist"
   ],
-  "type": "module",
   "module": "dist/devtools-types.js",
   "types": "dist/devtools-types.d.ts",
   "dependencies": {
@@ -60,5 +59,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "type": "module"
 }

--- a/packages/message-compiler/package.json
+++ b/packages/message-compiler/package.json
@@ -26,7 +26,6 @@
   "files": [
     "dist"
   ],
-  "type": "module",
   "module": "dist/message-compiler.js",
   "unpkg": "dist/message-compiler.global.js",
   "jsdelivr": "dist/message-compiler.global.js",
@@ -68,5 +67,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "type": "module"
 }

--- a/packages/petite-vue-i18n/package.json
+++ b/packages/petite-vue-i18n/package.json
@@ -28,7 +28,6 @@
   "files": [
     "dist"
   ],
-  "type": "module",
   "module": "dist/petite-vue-i18n.js",
   "unpkg": "dist/petite-vue-i18n.global.js",
   "jsdelivr": "dist/petite-vue-i18n.global.js",
@@ -78,5 +77,6 @@
     "./package.json": "./package.json"
   },
   "funding": "https://github.com/sponsors/kazupon",
-  "sideEffects": false
+  "sideEffects": false,
+  "type": "module"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -25,7 +25,6 @@
   "files": [
     "dist"
   ],
-  "type": "module",
   "module": "dist/shared.js",
   "types": "dist/shared.d.ts",
   "engines": {
@@ -57,5 +56,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "type": "module"
 }

--- a/packages/vue-i18n-core/package.json
+++ b/packages/vue-i18n-core/package.json
@@ -28,7 +28,6 @@
   "files": [
     "dist"
   ],
-  "type": "module",
   "module": "dist/vue-i18n-core.mjs",
   "unpkg": "dist/vue-i18n-core.global.js",
   "jsdelivr": "dist/vue-i18n-core.global.js",
@@ -84,5 +83,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "type": "module"
 }

--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -2,7 +2,7 @@
 import {
   DEFAULT_LOCALE,
   MISSING_RESOLVE_VALUE,
-  NOT_REOSLVED,
+  NOT_RESOLVED,
   clearDateTimeFormat,
   clearNumberFormat,
   createCoreContext,
@@ -2237,7 +2237,7 @@ export function createComposer(options: any = {}): any {
     if (
       (warnType !== 'translate exists' && // for not `te` (e.g `t`)
         isNumber(ret) &&
-        ret === NOT_REOSLVED) ||
+        ret === NOT_RESOLVED) ||
       (warnType === 'translate exists' && !ret) // for `te`
     ) {
       const [key, arg2] = argumentParser()

--- a/packages/vue-i18n/package.json
+++ b/packages/vue-i18n/package.json
@@ -28,7 +28,6 @@
     "dist",
     "vetur"
   ],
-  "type": "module",
   "module": "dist/vue-i18n.js",
   "unpkg": "dist/vue-i18n.global.js",
   "jsdelivr": "dist/vue-i18n.global.js",
@@ -79,6 +78,7 @@
   },
   "funding": "https://github.com/sponsors/kazupon",
   "sideEffects": false,
+  "type": "module",
   "vetur": {
     "tags": "vetur/tags.json",
     "attributes": "vetur/attributes.json"


### PR DESCRIPTION
back port from https://github.com/intlify/vue-i18n/pull/2221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typographical error in a constant name from `NOT_REOSLVED` to `NOT_RESOLVED`, ensuring consistent fallback behavior in translation, number, and datetime formatting features.
  * Updated related test cases to use the corrected constant name.

* **Chores**
  * Relocated the `"type": "module"` field to the end of multiple package configuration files for improved consistency.
  * Standardized HTML tag formatting in example documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->