### PR TITLE
docs: correct default value of warnHtmlMessage

### DIFF
--- a/docs/api/composition.md
+++ b/docs/api/composition.md
@@ -1468,7 +1468,7 @@ See the warnHtmlMessage property.
 
 **Default Value**
 
-`'off'`
+`true`
 
 **See Also**
 - [HTML Message](../guide/essentials/syntax#html-message)

--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -470,7 +470,7 @@ export interface ComposerOptions<
    * @VueI18nSee [HTML Message](../../guide/essentials/syntax#html-message)
    * @VueI18nSee [Change `warnHtmlInMessage` option default value](../../guide/migration/breaking#change-warnhtmlinmessage-option-default-value)
    *
-   * @defaultValue `'off'`
+   * @defaultValue `true`
    */
   warnHtmlMessage?: boolean
   /**


### PR DESCRIPTION
This PR makes a small update to the API docs to match the actual behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the documented default value for the `warnHtmlMessage` option from 'off' to true to accurately reflect its current behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->