### PR TITLE
Fix nested key linked message

### DIFF
--- a/e2e/formatting/linked.spec.ts
+++ b/e2e/formatting/linked.spec.ts
@@ -15,6 +15,7 @@ import { getText, url } from '../helper'
       expect(await getText(page, '#app p.modifier')).toMatch(
         'custom modifiers example: snake-case'
       )
+      expect(await getText(page, '#app p.linked-nested')).toMatch('Nested key')
     })
 
     test('change locale', async () => {
@@ -27,6 +28,9 @@ import { getText, url } from '../helper'
       )
       expect(await getText(page, '#app p.modifier')).toMatch(
         'カスタム修飾子の例: スネーク-ケース'
+      )
+      expect(await getText(page, '#app p.linked-nested')).toMatch(
+        'ネストされたキー'
       )
     })
   })

--- a/examples/composition/formatting/linked.html
+++ b/examples/composition/formatting/linked.html
@@ -1,88 +1,85 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Linked message example</title>
+    <script src="../../../node_modules/vue/dist/vue.global.js"></script>
+    <script src="../../../packages/vue-i18n/dist/vue-i18n.global.js"></script>
+  </head>
+  <body>
+    <div id="app">
+      <form>
+        <label for="locale-select">{{ t('message.language') }}</label>
+        <select id="locale-select" v-model="locale">
+          <option value="en">en</option>
+          <option value="ja">ja</option>
+        </select>
+      </form>
+      <p class="linked">{{ t('message.linked') }}</p>
+      <label>{{ t('message.homeAddress') }}</label>
+      <p class="error">{{ t('message.missingHomeAddress') }}</p>
+      <p class="modifier">
+        {{ t('message.custom_modifier', { snake: 'message.snake' }) }}
+      </p>
+      <p class="linked-nested">{{ t('message.linkedWithNested') }}</p>
+    </div>
+    <script>
+      const { createApp } = Vue
+      const { createI18n, useI18n } = VueI18n
 
-<head>
-  <meta charset="utf-8" />
-  <title>Linked message example</title>
-  <script src="../../../node_modules/vue/dist/vue.global.js"></script>
-  <script src="../../../packages/vue-i18n/dist/vue-i18n.global.js"></script>
-</head>
-
-<body>
-  <div id="app">
-    <form>
-      <label for="locale-select">{{ t('message.language') }}</label>
-      <select id="locale-select" v-model="locale">
-        <option value="en">en</option>
-        <option value="ja">ja</option>
-      </select>
-    </form>
-    <p class="linked">{{ t('message.linked') }}</p>
-    <label>{{ t('message.homeAddress') }}</label>
-    <p class="error">{{ t('message.missingHomeAddress') }}</p>
-    <p class="modifier">
-      {{ t('message.custom_modifier', { snake: 'message.snake' }) }}
-    </p>
-    <p class="linked-nested">{{ t('message.linkedWithNested') }}</p>
-  </div>
-  <script>
-    const { createApp } = Vue
-    const { createI18n, useI18n } = VueI18n
-
-    const i18n = createI18n({
-      locale: 'en',
-      messages: {
-        en: {
-          'nested.key': 'Nested key',
-          message: {
-            language: 'Language',
-            the_world: 'the world',
-            dio: 'DIO:',
-            linked: '@:message.dio @:message.the_world !!!!',
-            homeAddress: 'Home address',
-            missingHomeAddress: 'Please provide @.lower:message.homeAddress',
-            snake: 'snake case',
-            custom_modifier:
-              "custom modifiers example: @.snakeCase:{'message.snake'}",
-            linkedWithNested: '@:nested.key'
+      const i18n = createI18n({
+        locale: 'en',
+        messages: {
+          en: {
+            'nested.key': 'Nested key',
+            message: {
+              language: 'Language',
+              the_world: 'the world',
+              dio: 'DIO:',
+              linked: '@:message.dio @:message.the_world !!!!',
+              homeAddress: 'Home address',
+              missingHomeAddress: 'Please provide @.lower:message.homeAddress',
+              snake: 'snake case',
+              custom_modifier:
+                "custom modifiers example: @.snakeCase:{'message.snake'}",
+              linkedWithNested: '@:nested.key'
+            }
+          },
+          ja: {
+            'nested.key': 'ネストされたキー',
+            message: {
+              language: '言語',
+              the_world: 'ザ・ワールド',
+              dio: 'ディオ:',
+              linked: '@:message.dio @:message.the_world ！！！！',
+              homeAddress: 'ホームアドレス',
+              missingHomeAddress:
+                'どうか、@.lower:message.homeAddress を提供してください。',
+              snake: 'スネーク ケース',
+              foo: 'message.snake',
+              custom_modifier:
+                "カスタム修飾子の例: @.snakeCase:{'message.snake'}",
+              linkedWithNested: '@:nested.key'
+            }
           }
         },
-        ja: {
-          'nested.key': 'ネストされたキー',
-          message: {
-            language: '言語',
-            the_world: 'ザ・ワールド',
-            dio: 'ディオ:',
-            linked: '@:message.dio @:message.the_world ！！！！',
-            homeAddress: 'ホームアドレス',
-            missingHomeAddress:
-              'どうか、@.lower:message.homeAddress を提供してください。',
-            snake: 'スネーク ケース',
-            foo: 'message.snake',
-            custom_modifier:
-              "カスタム修飾子の例: @.snakeCase:{'message.snake'}",
-            linkedWithNested: '@:nested.key'
-          }
+        modifiers: {
+          snakeCase: str => str.split(' ').join('-')
         }
-      },
-      modifiers: {
-        snakeCase: str => str.split(' ').join('-')
-      }
-    })
+      })
 
-    const app = createApp({
-      setup() {
-        const { t, locale } = useI18n()
+      const app = createApp({
+        setup() {
+          const { t, locale } = useI18n()
 
-        // Something to do ...
-        //
+          // Something to do ...
+          //
 
-        return { t, locale }
-      }
-    })
-    app.use(i18n)
-    app.mount('#app')
-  </script>
-</body>
-
+          return { t, locale }
+        }
+      })
+      app.use(i18n)
+      app.mount('#app')
+    </script>
+  </body>
 </html>

--- a/examples/composition/formatting/linked.html
+++ b/examples/composition/formatting/linked.html
@@ -1,80 +1,88 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <title>Linked message example</title>
-    <script src="../../../node_modules/vue/dist/vue.global.js"></script>
-    <script src="../../../packages/vue-i18n/dist/vue-i18n.global.js"></script>
-  </head>
-  <body>
-    <div id="app">
-      <form>
-        <label for="locale-select">{{ t('message.language') }}</label>
-        <select id="locale-select" v-model="locale">
-          <option value="en">en</option>
-          <option value="ja">ja</option>
-        </select>
-      </form>
-      <p class="linked">{{ t('message.linked') }}</p>
-      <label>{{ t('message.homeAddress') }}</label>
-      <p class="error">{{ t('message.missingHomeAddress') }}</p>
-      <p class="modifier">
-        {{ t('message.custom_modifier', { snake: 'message.snake' }) }}
-      </p>
-    </div>
-    <script>
-      const { createApp } = Vue
-      const { createI18n, useI18n } = VueI18n
 
-      const i18n = createI18n({
-        locale: 'en',
-        messages: {
-          en: {
-            message: {
-              language: 'Language',
-              the_world: 'the world',
-              dio: 'DIO:',
-              linked: '@:message.dio @:message.the_world !!!!',
-              homeAddress: 'Home address',
-              missingHomeAddress: 'Please provide @.lower:message.homeAddress',
-              snake: 'snake case',
-              custom_modifier:
-                "custom modifiers example: @.snakeCase:{'message.snake'}"
-            }
-          },
-          ja: {
-            message: {
-              language: '言語',
-              the_world: 'ザ・ワールド',
-              dio: 'ディオ:',
-              linked: '@:message.dio @:message.the_world ！！！！',
-              homeAddress: 'ホームアドレス',
-              missingHomeAddress:
-                'どうか、@.lower:message.homeAddress を提供してください。',
-              snake: 'スネーク ケース',
-              foo: 'message.snake',
-              custom_modifier:
-                "カスタム修飾子の例: @.snakeCase:{'message.snake'}"
-            }
+<head>
+  <meta charset="utf-8" />
+  <title>Linked message example</title>
+  <script src="../../../node_modules/vue/dist/vue.global.js"></script>
+  <script src="../../../packages/vue-i18n/dist/vue-i18n.global.js"></script>
+</head>
+
+<body>
+  <div id="app">
+    <form>
+      <label for="locale-select">{{ t('message.language') }}</label>
+      <select id="locale-select" v-model="locale">
+        <option value="en">en</option>
+        <option value="ja">ja</option>
+      </select>
+    </form>
+    <p class="linked">{{ t('message.linked') }}</p>
+    <label>{{ t('message.homeAddress') }}</label>
+    <p class="error">{{ t('message.missingHomeAddress') }}</p>
+    <p class="modifier">
+      {{ t('message.custom_modifier', { snake: 'message.snake' }) }}
+    </p>
+    <p class="linked-nested">{{ t('message.linkedWithNested') }}</p>
+  </div>
+  <script>
+    const { createApp } = Vue
+    const { createI18n, useI18n } = VueI18n
+
+    const i18n = createI18n({
+      locale: 'en',
+      messages: {
+        en: {
+          'nested.key': 'Nested key',
+          message: {
+            language: 'Language',
+            the_world: 'the world',
+            dio: 'DIO:',
+            linked: '@:message.dio @:message.the_world !!!!',
+            homeAddress: 'Home address',
+            missingHomeAddress: 'Please provide @.lower:message.homeAddress',
+            snake: 'snake case',
+            custom_modifier:
+              "custom modifiers example: @.snakeCase:{'message.snake'}",
+            linkedWithNested: '@:nested.key'
           }
         },
-        modifiers: {
-          snakeCase: str => str.split(' ').join('-')
+        ja: {
+          'nested.key': 'ネストされたキー',
+          message: {
+            language: '言語',
+            the_world: 'ザ・ワールド',
+            dio: 'ディオ:',
+            linked: '@:message.dio @:message.the_world ！！！！',
+            homeAddress: 'ホームアドレス',
+            missingHomeAddress:
+              'どうか、@.lower:message.homeAddress を提供してください。',
+            snake: 'スネーク ケース',
+            foo: 'message.snake',
+            custom_modifier:
+              "カスタム修飾子の例: @.snakeCase:{'message.snake'}",
+            linkedWithNested: '@:nested.key'
+          }
         }
-      })
+      },
+      modifiers: {
+        snakeCase: str => str.split(' ').join('-')
+      }
+    })
 
-      const app = createApp({
-        setup() {
-          const { t, locale } = useI18n()
+    const app = createApp({
+      setup() {
+        const { t, locale } = useI18n()
 
-          // Something to do ...
-          //
+        // Something to do ...
+        //
 
-          return { t, locale }
-        }
-      })
-      app.use(i18n)
-      app.mount('#app')
-    </script>
-  </body>
+        return { t, locale }
+      }
+    })
+    app.use(i18n)
+    app.mount('#app')
+  </script>
+</body>
+
 </html>

--- a/examples/petite/formatting/linked.html
+++ b/examples/petite/formatting/linked.html
@@ -1,77 +1,85 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <title>Linked message example</title>
-    <script src="../../../node_modules/vue/dist/vue.global.js"></script>
-    <script src="../../../packages/petite-vue-i18n/dist/petite-vue-i18n.global.js"></script>
-  </head>
-  <body>
-    <div id="app">
-      <form>
-        <label for="locale-select">{{ t('message.language') }}</label>
-        <select id="locale-select" v-model="locale">
-          <option value="en">en</option>
-          <option value="ja">ja</option>
-        </select>
-      </form>
-      <p class="linked">{{ t('message.linked') }}</p>
-      <label>{{ t('message.homeAddress') }}</label>
-      <p class="error">{{ t('message.missingHomeAddress') }}</p>
-      <p class="modifier">
-        {{ t('message.custom_modifier', { snake: 'message.snake' }) }}
-      </p>
-    </div>
-    <script>
-      const { createApp } = Vue
-      const { createI18n, useI18n } = PetiteVueI18n
 
-      const i18n = createI18n({
-        locale: 'en',
-        messages: {
-          en: {
-            'message.language': 'Language',
-            'message.the_world': 'the world',
-            'message.dio': 'DIO:',
-            'message.linked': '@:message.dio @:message.the_world !!!!',
-            'message.homeAddress': 'Home address',
-            'message.missingHomeAddress':
-              'Please provide @.lower:message.homeAddress',
-            'message.snake': 'snake case',
-            'message.custom_modifier':
-              "custom modifiers example: @.snakeCase:{'message.snake'}"
-          },
-          ja: {
-            'message.language': '言語',
-            'message.the_world': 'ザ・ワールド',
-            'message.dio': 'ディオ:',
-            'message.linked': '@:message.dio @:message.the_world ！！！！',
-            'message.homeAddress': 'ホームアドレス',
-            'message.missingHomeAddress':
-              'どうか、@.lower:message.homeAddress を提供してください。',
-            'message.snake': 'スネーク ケース',
-            'message.foo': 'message.snake',
-            'message.custom_modifier':
-              "カスタム修飾子の例: @.snakeCase:{'message.snake'}"
-          }
+<head>
+  <meta charset="utf-8" />
+  <title>Linked message example</title>
+  <script src="../../../node_modules/vue/dist/vue.global.js"></script>
+  <script src="../../../packages/petite-vue-i18n/dist/petite-vue-i18n.global.js"></script>
+</head>
+
+<body>
+  <div id="app">
+    <form>
+      <label for="locale-select">{{ t('message.language') }}</label>
+      <select id="locale-select" v-model="locale">
+        <option value="en">en</option>
+        <option value="ja">ja</option>
+      </select>
+    </form>
+    <p class="linked">{{ t('message.linked') }}</p>
+    <label>{{ t('message.homeAddress') }}</label>
+    <p class="error">{{ t('message.missingHomeAddress') }}</p>
+    <p class="modifier">
+      {{ t('message.custom_modifier', { snake: 'message.snake' }) }}
+    </p>
+    <p class="linked-nested">{{ t('message.linkedWithNested') }}</p>
+  </div>
+  <script>
+    const { createApp } = Vue
+    const { createI18n, useI18n } = PetiteVueI18n
+
+    const i18n = createI18n({
+      locale: 'en',
+      messages: {
+        en: {
+          'nested.key': 'Nested key',
+          'message.language': 'Language',
+          'message.the_world': 'the world',
+          'message.dio': 'DIO:',
+          'message.linked': '@:message.dio @:message.the_world !!!!',
+          'message.homeAddress': 'Home address',
+          'message.missingHomeAddress':
+            'Please provide @.lower:message.homeAddress',
+          'message.snake': 'snake case',
+          'message.custom_modifier':
+            "custom modifiers example: @.snakeCase:{'message.snake'}",
+          'message.linkedWithNested': '@:nested.key'
         },
-        modifiers: {
-          snakeCase: str => str.split(' ').join('-')
+        ja: {
+          'nested.key': 'ネストされたキー',
+          'message.language': '言語',
+          'message.the_world': 'ザ・ワールド',
+          'message.dio': 'ディオ:',
+          'message.linked': '@:message.dio @:message.the_world ！！！！',
+          'message.homeAddress': 'ホームアドレス',
+          'message.missingHomeAddress':
+            'どうか、@.lower:message.homeAddress を提供してください。',
+          'message.snake': 'スネーク ケース',
+          'message.foo': 'message.snake',
+          'message.custom_modifier':
+            "カスタム修飾子の例: @.snakeCase:{'message.snake'}",
+          'message.linkedWithNested': '@:nested.key'
         }
-      })
+      },
+      modifiers: {
+        snakeCase: str => str.split(' ').join('-')
+      }
+    })
 
-      const app = createApp({
-        setup() {
-          const { t, locale } = useI18n()
+    const app = createApp({
+      setup() {
+        const { t, locale } = useI18n()
 
-          // Something to do ...
-          //
+        // Something to do ...
+        //
 
-          return { t, locale }
-        }
-      })
-      app.use(i18n)
-      app.mount('#app')
-    </script>
-  </body>
+        return { t, locale }
+      }
+    })
+    app.use(i18n)
+    app.mount('#app')
+  </script>
+</body>
+
 </html>

--- a/examples/petite/formatting/linked.html
+++ b/examples/petite/formatting/linked.html
@@ -1,85 +1,82 @@
 <!doctype html>
 <html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Linked message example</title>
+    <script src="../../../node_modules/vue/dist/vue.global.js"></script>
+    <script src="../../../packages/petite-vue-i18n/dist/petite-vue-i18n.global.js"></script>
+  </head>
+  <body>
+    <div id="app">
+      <form>
+        <label for="locale-select">{{ t('message.language') }}</label>
+        <select id="locale-select" v-model="locale">
+          <option value="en">en</option>
+          <option value="ja">ja</option>
+        </select>
+      </form>
+      <p class="linked">{{ t('message.linked') }}</p>
+      <label>{{ t('message.homeAddress') }}</label>
+      <p class="error">{{ t('message.missingHomeAddress') }}</p>
+      <p class="modifier">
+        {{ t('message.custom_modifier', { snake: 'message.snake' }) }}
+      </p>
+      <p class="linked-nested">{{ t('message.linkedWithNested') }}</p>
+    </div>
+    <script>
+      const { createApp } = Vue
+      const { createI18n, useI18n } = PetiteVueI18n
 
-<head>
-  <meta charset="utf-8" />
-  <title>Linked message example</title>
-  <script src="../../../node_modules/vue/dist/vue.global.js"></script>
-  <script src="../../../packages/petite-vue-i18n/dist/petite-vue-i18n.global.js"></script>
-</head>
-
-<body>
-  <div id="app">
-    <form>
-      <label for="locale-select">{{ t('message.language') }}</label>
-      <select id="locale-select" v-model="locale">
-        <option value="en">en</option>
-        <option value="ja">ja</option>
-      </select>
-    </form>
-    <p class="linked">{{ t('message.linked') }}</p>
-    <label>{{ t('message.homeAddress') }}</label>
-    <p class="error">{{ t('message.missingHomeAddress') }}</p>
-    <p class="modifier">
-      {{ t('message.custom_modifier', { snake: 'message.snake' }) }}
-    </p>
-    <p class="linked-nested">{{ t('message.linkedWithNested') }}</p>
-  </div>
-  <script>
-    const { createApp } = Vue
-    const { createI18n, useI18n } = PetiteVueI18n
-
-    const i18n = createI18n({
-      locale: 'en',
-      messages: {
-        en: {
-          'nested.key': 'Nested key',
-          'message.language': 'Language',
-          'message.the_world': 'the world',
-          'message.dio': 'DIO:',
-          'message.linked': '@:message.dio @:message.the_world !!!!',
-          'message.homeAddress': 'Home address',
-          'message.missingHomeAddress':
-            'Please provide @.lower:message.homeAddress',
-          'message.snake': 'snake case',
-          'message.custom_modifier':
-            "custom modifiers example: @.snakeCase:{'message.snake'}",
-          'message.linkedWithNested': '@:nested.key'
+      const i18n = createI18n({
+        locale: 'en',
+        messages: {
+          en: {
+            'nested.key': 'Nested key',
+            'message.language': 'Language',
+            'message.the_world': 'the world',
+            'message.dio': 'DIO:',
+            'message.linked': '@:message.dio @:message.the_world !!!!',
+            'message.homeAddress': 'Home address',
+            'message.missingHomeAddress':
+              'Please provide @.lower:message.homeAddress',
+            'message.snake': 'snake case',
+            'message.custom_modifier':
+              "custom modifiers example: @.snakeCase:{'message.snake'}",
+            'message.linkedWithNested': '@:nested.key'
+          },
+          ja: {
+            'nested.key': 'ネストされたキー',
+            'message.language': '言語',
+            'message.the_world': 'ザ・ワールド',
+            'message.dio': 'ディオ:',
+            'message.linked': '@:message.dio @:message.the_world ！！！！',
+            'message.homeAddress': 'ホームアドレス',
+            'message.missingHomeAddress':
+              'どうか、@.lower:message.homeAddress を提供してください。',
+            'message.snake': 'スネーク ケース',
+            'message.foo': 'message.snake',
+            'message.custom_modifier':
+              "カスタム修飾子の例: @.snakeCase:{'message.snake'}",
+            'message.linkedWithNested': '@:nested.key'
+          }
         },
-        ja: {
-          'nested.key': 'ネストされたキー',
-          'message.language': '言語',
-          'message.the_world': 'ザ・ワールド',
-          'message.dio': 'ディオ:',
-          'message.linked': '@:message.dio @:message.the_world ！！！！',
-          'message.homeAddress': 'ホームアドレス',
-          'message.missingHomeAddress':
-            'どうか、@.lower:message.homeAddress を提供してください。',
-          'message.snake': 'スネーク ケース',
-          'message.foo': 'message.snake',
-          'message.custom_modifier':
-            "カスタム修飾子の例: @.snakeCase:{'message.snake'}",
-          'message.linkedWithNested': '@:nested.key'
+        modifiers: {
+          snakeCase: str => str.split(' ').join('-')
         }
-      },
-      modifiers: {
-        snakeCase: str => str.split(' ').join('-')
-      }
-    })
+      })
 
-    const app = createApp({
-      setup() {
-        const { t, locale } = useI18n()
+      const app = createApp({
+        setup() {
+          const { t, locale } = useI18n()
 
-        // Something to do ...
-        //
+          // Something to do ...
+          //
 
-        return { t, locale }
-      }
-    })
-    app.use(i18n)
-    app.mount('#app')
-  </script>
-</body>
-
+          return { t, locale }
+        }
+      })
+      app.use(i18n)
+      app.mount('#app')
+    </script>
+  </body>
 </html>

--- a/packages/core-base/src/translate.ts
+++ b/packages/core-base/src/translate.ts
@@ -1165,7 +1165,7 @@ function getMessageContextOptions<Messages, Message = string>(
 
     // fallback
     if (val == null && (fallbackContext || useLinked)) {
-      const [, , message] = resolveMessageFormat(
+      const [format] = resolveMessageFormat(
         fallbackContext || context, // NOTE: if has fallbackContext, fallback to root, else if use linked, fallback to local context
         key,
         locale,
@@ -1173,7 +1173,7 @@ function getMessageContextOptions<Messages, Message = string>(
         fallbackWarn,
         missingWarn
       )
-      val = resolveValue(message, key)
+      val = format
     }
 
     if (isString(val) || isMessageAST(val)) {

--- a/packages/core-base/test/translate.test.ts
+++ b/packages/core-base/test/translate.test.ts
@@ -1053,3 +1053,16 @@ test('locale detector', () => {
   expect(translate(ctx, 'hi')).toEqual('hi kazupon !')
   expect(locale).toHaveBeenCalledTimes(2)
 })
+
+test('linked nested key', () => {
+  const ctx = context({
+    locale: 'en',
+    messages: {
+      en: {
+        'nested.key': 'Nested key',
+        'message.linkedWithNested': '@:nested.key'
+      }
+    }
+  })
+  expect(translate(ctx, 'message.linkedWithNested')).toEqual('Nested key')
+})


### PR DESCRIPTION
# Problem description
When using a flat JSON for translation messages, linked messages are not resolved. 

For example:

```
messages: {
      en: {
        'nested.key': 'Nested key',
        'message.linkedWithNested': '@:nested.key'
      }
    }
```
The following does not return anything: `t('message.linkedWithNested')`
 