### PR TITLE
fix: Set default value for __FEATURE_PROD_VUE_DEVTOOLS__ flag

### DIFF
--- a/packages/vue-i18n-core/src/misc.ts
+++ b/packages/vue-i18n-core/src/misc.ts
@@ -28,6 +28,10 @@ export function initFeatureFlags(): void {
   if (typeof __FEATURE_PROD_INTLIFY_DEVTOOLS__ !== 'boolean') {
     getGlobalThis().__INTLIFY_PROD_DEVTOOLS__ = false
   }
+
+  if (typeof __FEATURE_PROD_VUE_DEVTOOLS__ !== 'boolean') {
+    getGlobalThis().__VUE_PROD_DEVTOOLS__ = false
+  }
 }
 
 /**


### PR DESCRIPTION
fix https://github.com/intlify/vue-i18n/issues/2253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Production DevTools now default to disabled when the related feature flag is missing or misconfigured, preventing accidental exposure in production builds. Behavior is aligned with existing i18n DevTools handling. No API changes.
* **Chores**
  * Standardized feature-flag initialization for consistent behavior across environments, improving predictability and reducing configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->