### PR TITLE
docs: fix typos in docs

### DIFF
--- a/docs/api/composition.md
+++ b/docs/api/composition.md
@@ -1246,7 +1246,7 @@ function messageCompiler(message, { locale, key, onError }) {
     return ctx => formatter.format(ctx.values)
   } else {
     // If you would like to support it for AST,
-    // You need to transform locale mesages such as `json`, `yaml`, etc. with the bundle plugin.
+    // You need to transform locale messages such as `json`, `yaml`, etc. with the bundle plugin.
     onError && onError(new Error('not support for AST'))
     return () => key // return default with `key`
   }
@@ -1512,7 +1512,7 @@ The use-case for `rt` is for programmatic locale messages translation with using
 :::
 
 :::warning
-`rt` differs from `t` in that it processes the locale message directly, not the key of the locale message. There is no internal fallback with `rt`. You need to understand and use the structure of the locale messge returned by `tm`.
+`rt` differs from `t` in that it processes the locale message directly, not the key of the locale message. There is no internal fallback with `rt`. You need to understand and use the structure of the locale message returned by `tm`.
 :::
 
 #### Parameters
@@ -1548,7 +1548,7 @@ The use-case for `rt` is for programmatic locale messages translation with using
 :::
 
 :::warning
-`rt` differs from `t` in that it processes the locale message directly, not the key of the locale message. There is no internal fallback with `rt`. You need to understand and use the structure of the locale messge returned by `tm`.
+`rt` differs from `t` in that it processes the locale message directly, not the key of the locale message. There is no internal fallback with `rt`. You need to understand and use the structure of the locale message returned by `tm`.
 :::
 
 #### Parameters
@@ -1586,7 +1586,7 @@ The use-case for `rt` is for programmatic locale messages translation with using
 :::
 
 :::warning
-`rt` differs from `t` in that it processes the locale message directly, not the key of the locale message. There is no internal fallback with `rt`. You need to understand and use the structure of the locale messge returned by `tm`.
+`rt` differs from `t` in that it processes the locale message directly, not the key of the locale message. There is no internal fallback with `rt`. You need to understand and use the structure of the locale message returned by `tm`.
 :::
 
 #### Parameters
@@ -1624,7 +1624,7 @@ The use-case for `rt` is for programmatic locale messages translation with using
 :::
 
 :::warning
-`rt` differs from `t` in that it processes the locale message directly, not the key of the locale message. There is no internal fallback with `rt`. You need to understand and use the structure of the locale messge returned by `tm`.
+`rt` differs from `t` in that it processes the locale message directly, not the key of the locale message. There is no internal fallback with `rt`. You need to understand and use the structure of the locale message returned by `tm`.
 :::
 
 #### Parameters

--- a/docs/api/general.md
+++ b/docs/api/general.md
@@ -639,7 +639,7 @@ A fallback locale function implemented with a fallback chain algorithm. It's use
 
 ## fallbackWithSimple
 
-Fallback with simple implemenation
+Fallback with simple implementation
 
 **Signature:**
 ```typescript
@@ -870,13 +870,13 @@ linked(key: Path, modifier?: string, type?: string): MessageType<T>;
 
  A resolve message.
 
-### linked(key, optoins)
+### linked(key, options)
 
 Overloaded `linked`
 
 **Signature:**
 ```typescript
-linked(key: Path, optoins?: LinkedOptions): MessageType<T>;
+linked(key: Path, options?: LinkedOptions): MessageType<T>;
 ```
 
 #### Parameters
@@ -884,7 +884,7 @@ linked(key: Path, optoins?: LinkedOptions): MessageType<T>;
 | Parameter | Type | Description |
 | --- | --- | --- |
 | key | Path | A message key |
-| optoins | LinkedOptions | An [linked options](#linkedoptions) |
+| options | LinkedOptions | An [linked options](#linkedoptions) |
 
 #### Returns
 


### PR DESCRIPTION
Found via `codespell docs/ -L te,manger,custome`