### PR TITLE
fix: include `vitest/node` types to fix Vitest 4 type errors

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,7 +48,7 @@
     },                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    "types": ["vitest/globals"],              /* Type declaration files to be included in compilation. */
+    "types": ["vitest/globals", "vitest/node"],              /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */


### PR DESCRIPTION
In https://github.com/vitest-dev/vitest/pull/8200, Vitest removed the Node types from its main entry. This broke the build pipeline in this project, and CI started to fail: https://github.com/intlify/vue-i18n/actions/runs/18880065087/job/53880358103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript configuration to include additional type declarations for development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->