### PR TITLE
perf: use `shallowRef` server-side for `datetimeFormats`

### DIFF
--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -1972,7 +1972,7 @@ export function createComposer(options: any = {}): any {
         ? options.datetimeFormats
         : { [_locale.value]: {} }
     )
-    : /* #__PURE__*/ ref<DateTimeFormatsType>({})
+    : /* #__PURE__*/ _ref<DateTimeFormatsType>({})
 
   // prettier-ignore
   const _numberFormats = !__LITE__


### PR DESCRIPTION
Looks like I forgot this line in #1677

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to the datetime formats initialization in the lite build path to maintain consistency with other build variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->