### PR TITLE
fix: avoid bundler warning for `getCurrentInstance` compatibility

### DIFF
--- a/packages/vue-i18n-core/src/utils.ts
+++ b/packages/vue-i18n-core/src/utils.ts
@@ -223,6 +223,7 @@ export function getCurrentInstance():
   | GenericComponentInstance
   | ComponentInternalInstance
   | null {
+  // NOTE(kazupon): avoid bundler warning
   const key = 'currentInstance'
   if (key in Vue) {
     return (Vue as any)[key] as GenericComponentInstance | null


### PR DESCRIPTION
fix #2322 #2334