### PR TITLE
fix: `useI18n` implementation with provide-inject fully

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
   "pnpm": {
     "overrides": {
       "vite": "^7.3.0",
-      "vue": "3.6.0-beta.1"
+      "vue": "3.6.0-beta.2"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/packages/vue-i18n-core/src/vue.d.ts
+++ b/packages/vue-i18n-core/src/vue.d.ts
@@ -36,4 +36,19 @@ declare module 'vue' {
      */
     __VUE_I18N__?: Composer
   }
+
+  /**
+   * `useInstanceOption` API does not still public API,
+   * so we will define it as declaration module at vue-i18n
+   */
+
+  var internalOptions = ['ce', 'type', 'uid'] as const
+
+  export declare function useInstanceOption<K extends (typeof internalOptions)[number]>(
+    key: K,
+    silent = false
+  ): {
+    hasInstance: boolean
+    value: GenericComponentInstance[K] | undefined
+  }
 }

--- a/packages/vue-i18n-core/test/ssr.test.ts
+++ b/packages/vue-i18n-core/test/ssr.test.ts
@@ -63,8 +63,8 @@ test('component: i18n-t', async () => {
         locale: 'ja',
         inheritLocale: false,
         messages: {
-          ja: { hello: 'こんにちは！' },
-          en: { hello: 'hello!' }
+          ja: { hello: 'やあ！' },
+          en: { hello: 'hi!' }
         }
       })
       return () => h(resolveComponent('i18n-t'), { tag: 'p', keypath: 'hello' })
@@ -74,5 +74,5 @@ test('component: i18n-t', async () => {
   const app = createSSRApp(App)
   app.use(i18n)
 
-  expect(await renderToString(app)).toMatch(`<p>こんにちは！</p>`)
+  expect(await renderToString(app)).toMatch(`<p>やあ！</p>`)
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   vite: ^7.3.0
-  vue: 3.6.0-beta.1
+  vue: 3.6.0-beta.2
 
 importers:
 
@@ -208,8 +208,8 @@ importers:
         specifier: ^4.0.16
         version: 4.0.16(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.9.3)
+        specifier: 3.6.0-beta.2
+        version: 3.6.0-beta.2(typescript@5.9.3)
       vue-i18n:
         specifier: workspace:*
         version: link:packages/vue-i18n
@@ -217,18 +217,18 @@ importers:
   examples/backend:
     dependencies:
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.8.3)
+        specifier: 3.6.0-beta.2
+        version: 3.6.0-beta.2(typescript@5.8.3)
       vue-i18n:
         specifier: 11.1.12
-        version: 11.1.12(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 11.1.12(vue@3.6.0-beta.2(typescript@5.8.3))
     devDependencies:
       '@intlify/bundle-utils':
         specifier: ^11.0.1
-        version: 11.0.1(vue-i18n@11.1.12(vue@3.6.0-beta.1(typescript@5.8.3)))
+        version: 11.0.1(vue-i18n@11.1.12(vue@3.6.0-beta.2(typescript@5.8.3)))
       '@intlify/unplugin-vue-i18n':
         specifier: ^11.0.1
-        version: 11.0.1(@vue/compiler-dom@3.5.22)(eslint@9.39.2(jiti@2.6.1))(rollup@4.54.0)(typescript@5.8.3)(vue-i18n@11.1.12(vue@3.6.0-beta.1(typescript@5.8.3)))(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 11.0.1(@vue/compiler-dom@3.5.22)(eslint@9.39.2(jiti@2.6.1))(rollup@4.54.0)(typescript@5.8.3)(vue-i18n@11.1.12(vue@3.6.0-beta.2(typescript@5.8.3)))(vue@3.6.0-beta.2(typescript@5.8.3))
       '@types/body-parser':
         specifier: ^1.19.2
         version: 1.19.6
@@ -237,7 +237,7 @@ importers:
         version: 4.17.23
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))
       body-parser:
         specifier: ^1.20.3
         version: 1.20.3
@@ -263,21 +263,21 @@ importers:
   examples/lazy-loading/vite:
     dependencies:
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.8.3)
+        specifier: 3.6.0-beta.2
+        version: 3.6.0-beta.2(typescript@5.8.3)
       vue-i18n:
         specifier: 11.1.12
-        version: 11.1.12(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 11.1.12(vue@3.6.0-beta.2(typescript@5.8.3))
       vue-router:
         specifier: '4'
-        version: 4.6.3(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 4.6.3(vue@3.6.0-beta.2(typescript@5.8.3))
     devDependencies:
       '@intlify/unplugin-vue-i18n':
         specifier: ^11.0.1
-        version: 11.0.1(@vue/compiler-dom@3.5.22)(eslint@9.39.2(jiti@2.6.1))(rollup@4.54.0)(typescript@5.8.3)(vue-i18n@11.1.12(vue@3.6.0-beta.1(typescript@5.8.3)))(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 11.0.1(@vue/compiler-dom@3.5.22)(eslint@9.39.2(jiti@2.6.1))(rollup@4.54.0)(typescript@5.8.3)(vue-i18n@11.1.12(vue@3.6.0-beta.2(typescript@5.8.3)))(vue@3.6.0-beta.2(typescript@5.8.3))
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))
       typescript:
         specifier: ^5.0.2
         version: 5.8.3
@@ -291,18 +291,18 @@ importers:
   examples/lazy-loading/webpack:
     dependencies:
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.9.3)
+        specifier: 3.6.0-beta.2
+        version: 3.6.0-beta.2(typescript@5.9.3)
       vue-i18n:
         specifier: workspace:*
         version: link:../../../packages/vue-i18n
       vue-router:
         specifier: ^4.0.5
-        version: 4.6.3(vue@3.6.0-beta.1(typescript@5.9.3))
+        version: 4.6.3(vue@3.6.0-beta.2(typescript@5.9.3))
     devDependencies:
       '@intlify/vue-i18n-loader':
         specifier: ^3.2.0
-        version: 3.3.0(vue@3.6.0-beta.1(typescript@5.9.3))
+        version: 3.3.0(vue@3.6.0-beta.2(typescript@5.9.3))
       '@vue/compiler-sfc':
         specifier: ^3.2.0
         version: 3.5.22
@@ -320,7 +320,7 @@ importers:
         version: 4.1.1(file-loader@6.2.0(webpack@4.47.0))(webpack@4.47.0)
       vue-loader:
         specifier: ^16.8.0
-        version: 16.8.3(@vue/compiler-sfc@3.5.22)(vue@3.6.0-beta.1(typescript@5.9.3))(webpack@4.47.0)
+        version: 16.8.3(@vue/compiler-sfc@3.5.22)(vue@3.6.0-beta.2(typescript@5.9.3))(webpack@4.47.0)
       webpack:
         specifier: ^4.44.0
         version: 4.47.0(webpack-cli@3.3.12)
@@ -337,18 +337,18 @@ importers:
         specifier: ^10.5.0
         version: 10.7.18
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.8.3)
+        specifier: 3.6.0-beta.2
+        version: 3.6.0-beta.2(typescript@5.8.3)
       vue-i18n:
         specifier: workspace:*
         version: link:../../packages/vue-i18n
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))
       '@vue/tsconfig':
         specifier: ^0.8.1
-        version: 0.8.1(typescript@5.8.3)(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 0.8.1(typescript@5.8.3)(vue@3.6.0-beta.2(typescript@5.8.3))
       typescript:
         specifier: ^5.0.2
         version: 5.8.3
@@ -365,24 +365,24 @@ importers:
         specifier: file:example-external-component
         version: link:example-external-component
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.9.3)
+        specifier: 3.6.0-beta.2
+        version: 3.6.0-beta.2(typescript@5.9.3)
       vue-i18n:
         specifier: workspace:*
         version: link:../../../packages/vue-i18n
       vue-router:
         specifier: ^4.1.2
-        version: 4.6.3(vue@3.6.0-beta.1(typescript@5.9.3))
+        version: 4.6.3(vue@3.6.0-beta.2(typescript@5.9.3))
     devDependencies:
       '@intlify/unplugin-vue-i18n':
         specifier: ^11.0.1
-        version: 11.0.1(@vue/compiler-dom@3.5.22)(eslint@9.39.2(jiti@2.6.1))(rollup@4.54.0)(typescript@5.9.3)(vue-i18n@packages+vue-i18n)(vue@3.6.0-beta.1(typescript@5.9.3))
+        version: 11.0.1(@vue/compiler-dom@3.5.22)(eslint@9.39.2(jiti@2.6.1))(rollup@4.54.0)(typescript@5.9.3)(vue-i18n@packages+vue-i18n)(vue@3.6.0-beta.2(typescript@5.9.3))
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.9.3))
+        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx':
         specifier: ^5.1.1
-        version: 5.1.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.9.3))
+        version: 5.1.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.9.3))
       compression:
         specifier: ^1.7.4
         version: 1.8.1
@@ -420,7 +420,7 @@ importers:
     devDependencies:
       '@intlify/unplugin-vue-i18n':
         specifier: ^11.0.1
-        version: 11.0.1(@vue/compiler-dom@3.5.22)(eslint@9.39.2(jiti@2.6.1))(rollup@4.54.0)(typescript@5.8.3)(vue-i18n@packages+vue-i18n)(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 11.0.1(@vue/compiler-dom@3.5.22)(eslint@9.39.2(jiti@2.6.1))(rollup@4.54.0)(typescript@5.8.3)(vue-i18n@packages+vue-i18n)(vue@3.6.0-beta.2(typescript@5.8.3))
       typescript:
         specifier: ^5.0.0
         version: 5.8.3
@@ -428,8 +428,8 @@ importers:
   examples/storybook:
     dependencies:
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.8.3)
+        specifier: 3.6.0-beta.2
+        version: 3.6.0-beta.2(typescript@5.8.3)
       vue-i18n:
         specifier: workspace:*
         version: link:../../packages/vue-i18n
@@ -451,10 +451,10 @@ importers:
         version: 8.6.14(storybook@8.6.14(prettier@3.5.3))
       '@storybook/vue3':
         specifier: ^8.6.12
-        version: 8.6.14(storybook@8.6.14(prettier@3.5.3))(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 8.6.14(storybook@8.6.14(prettier@3.5.3))(vue@3.6.0-beta.2(typescript@5.8.3))
       '@storybook/vue3-vite':
         specifier: ^8.6.12
-        version: 8.6.14(storybook@8.6.14(prettier@3.5.3))(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 8.6.14(storybook@8.6.14(prettier@3.5.3))(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))
       '@tsconfig/node22':
         specifier: ^22.0.1
         version: 22.0.2
@@ -463,7 +463,7 @@ importers:
         version: 22.18.12
       '@vitejs/plugin-vue':
         specifier: ^5.2.3
-        version: 5.2.4(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 5.2.4(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))
       '@vue/eslint-config-prettier':
         specifier: ^10.2.0
         version: 10.2.0(@types/eslint@9.6.1)(eslint@9.38.0(jiti@2.6.1))(prettier@3.5.3)
@@ -472,7 +472,7 @@ importers:
         version: 14.6.0(eslint-plugin-vue@10.0.1(eslint@9.38.0(jiti@2.6.1))(vue-eslint-parser@10.2.0(eslint@9.38.0(jiti@2.6.1))))(eslint@9.38.0(jiti@2.6.1))(typescript@5.8.3)
       '@vue/tsconfig':
         specifier: ^0.7.0
-        version: 0.7.0(typescript@5.8.3)(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 0.7.0(typescript@5.8.3)(vue@3.6.0-beta.2(typescript@5.8.3))
       eslint:
         specifier: ^9.22.0
         version: 9.38.0(jiti@2.6.1)
@@ -502,7 +502,7 @@ importers:
         version: 7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
       vite-plugin-vue-devtools:
         specifier: ^7.7.2
-        version: 7.7.7(rollup@4.54.0)(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 7.7.7(rollup@4.54.0)(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))
       vue-tsc:
         specifier: ^2.2.8
         version: 2.2.12(typescript@5.8.3)
@@ -510,24 +510,24 @@ importers:
   examples/tsx:
     dependencies:
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.8.3)
+        specifier: 3.6.0-beta.2
+        version: 3.6.0-beta.2(typescript@5.8.3)
       vue-i18n:
         specifier: workspace:*
         version: link:../../packages/vue-i18n
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))
       '@vitejs/plugin-vue-jsx':
         specifier: ^5.1.1
-        version: 5.1.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 5.1.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.5.22
       '@vue/tsconfig':
         specifier: ^0.8.1
-        version: 0.8.1(typescript@5.8.3)(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 0.8.1(typescript@5.8.3)(vue@3.6.0-beta.2(typescript@5.8.3))
       typescript:
         specifier: ^5.0.2
         version: 5.8.3
@@ -541,21 +541,21 @@ importers:
   examples/type-safe/global-type-definition:
     dependencies:
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.8.3)
+        specifier: 3.6.0-beta.2
+        version: 3.6.0-beta.2(typescript@5.8.3)
       vue-i18n:
         specifier: workspace:*
         version: link:../../../packages/vue-i18n
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.5.22
       '@vue/tsconfig':
         specifier: ^0.8.1
-        version: 0.8.1(typescript@5.8.3)(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 0.8.1(typescript@5.8.3)(vue@3.6.0-beta.2(typescript@5.8.3))
       typescript:
         specifier: ^5.0.2
         version: 5.8.3
@@ -569,21 +569,21 @@ importers:
   examples/type-safe/type-annotation:
     dependencies:
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.8.3)
+        specifier: 3.6.0-beta.2
+        version: 3.6.0-beta.2(typescript@5.8.3)
       vue-i18n:
         specifier: workspace:*
         version: link:../../../packages/vue-i18n
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.5.22
       '@vue/tsconfig':
         specifier: ^0.8.1
-        version: 0.8.1(typescript@5.8.3)(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 0.8.1(typescript@5.8.3)(vue@3.6.0-beta.2(typescript@5.8.3))
       typescript:
         specifier: ^5.0.2
         version: 5.8.3
@@ -597,21 +597,21 @@ importers:
   examples/web-components:
     dependencies:
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.8.3)
+        specifier: 3.6.0-beta.2
+        version: 3.6.0-beta.2(typescript@5.8.3)
       vue-i18n:
         specifier: 11.1.12
-        version: 11.1.12(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 11.1.12(vue@3.6.0-beta.2(typescript@5.8.3))
     devDependencies:
       '@intlify/unplugin-vue-i18n':
         specifier: ^11.0.1
-        version: 11.0.1(@vue/compiler-dom@3.5.22)(eslint@9.39.2(jiti@2.6.1))(rollup@4.54.0)(typescript@5.8.3)(vue-i18n@11.1.12(vue@3.6.0-beta.1(typescript@5.8.3)))(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 11.0.1(@vue/compiler-dom@3.5.22)(eslint@9.39.2(jiti@2.6.1))(rollup@4.54.0)(typescript@5.8.3)(vue-i18n@11.1.12(vue@3.6.0-beta.2(typescript@5.8.3)))(vue@3.6.0-beta.2(typescript@5.8.3))
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))
       '@vue/tsconfig':
         specifier: ^0.8.1
-        version: 0.8.1(typescript@5.8.3)(vue@3.6.0-beta.1(typescript@5.8.3))
+        version: 0.8.1(typescript@5.8.3)(vue@3.6.0-beta.2(typescript@5.8.3))
       typescript:
         specifier: ^5.0.2
         version: 5.8.3
@@ -662,12 +662,12 @@ importers:
         specifier: ^1.0.2
         version: 1.2.1
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.9.3)
+        specifier: 3.6.0-beta.2
+        version: 3.6.0-beta.2(typescript@5.9.3)
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.0
-        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.9.3))
+        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.9.3))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.5.22
@@ -702,8 +702,8 @@ importers:
         specifier: ^6.5.0
         version: 6.6.4
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.9.3)
+        specifier: 3.6.0-beta.2
+        version: 3.6.0-beta.2(typescript@5.9.3)
     devDependencies:
       '@intlify/devtools-types':
         specifier: workspace:*
@@ -727,12 +727,12 @@ importers:
         specifier: workspace:*
         version: link:../petite-vue-i18n
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.9.3)
+        specifier: 3.6.0-beta.2
+        version: 3.6.0-beta.2(typescript@5.9.3)
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.0
-        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.9.3))
+        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.9.3))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.5.22
@@ -746,15 +746,15 @@ importers:
   packages/size-check-vue-i18n:
     dependencies:
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.9.3)
+        specifier: 3.6.0-beta.2
+        version: 3.6.0-beta.2(typescript@5.9.3)
       vue-i18n:
         specifier: workspace:*
         version: link:../vue-i18n
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.0
-        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.9.3))
+        version: 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.9.3))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.5.22
@@ -780,8 +780,8 @@ importers:
         specifier: ^6.5.0
         version: 6.6.4
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.9.3)
+        specifier: 3.6.0-beta.2
+        version: 3.6.0-beta.2(typescript@5.9.3)
     devDependencies:
       '@intlify/devtools-types':
         specifier: workspace:*
@@ -799,8 +799,8 @@ importers:
         specifier: ^6.5.0
         version: 6.6.4
       vue:
-        specifier: 3.6.0-beta.1
-        version: 3.6.0-beta.1(typescript@5.9.3)
+        specifier: 3.6.0-beta.2
+        version: 3.6.0-beta.2(typescript@5.9.3)
     devDependencies:
       '@intlify/devtools-types':
         specifier: workspace:*
@@ -1643,7 +1643,7 @@ packages:
     engines: {node: '>= 20'}
     peerDependencies:
       petite-vue-i18n: '*'
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
       vue-i18n: '*'
     peerDependenciesMeta:
       petite-vue-i18n:
@@ -1657,7 +1657,7 @@ packages:
     peerDependencies:
       '@intlify/shared': ^9.0.0 || ^10.0.0 || ^11.0.0
       '@vue/compiler-dom': ^3.0.0
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
       vue-i18n: ^9.0.0 || ^10.0.0 || ^11.0.0
     peerDependenciesMeta:
       '@intlify/shared':
@@ -1674,7 +1674,7 @@ packages:
     engines: {node: '>= 12'}
     deprecated: This package no longer supported. About maintenance status, see https://github.com/intlify/bundle-tools?tab=readme-ov-file#-packages
     peerDependencies:
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
 
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
@@ -3140,7 +3140,7 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       storybook: ^8.6.14
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
 
   '@stylistic/eslint-plugin@4.4.1':
     resolution: {integrity: sha512-CEigAk7eOLyHvdgmpZsKFwtiqS2wFwI1fn4j09IU9GmD4euFM4jEBAViWeCqaNLlbX2k2+A/Fq9cje4HQBXuJQ==}
@@ -3577,21 +3577,21 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^7.3.0
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
 
   '@vitejs/plugin-vue@5.2.4':
     resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       vite: ^7.3.0
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
 
   '@vitejs/plugin-vue@6.0.1':
     resolution: {integrity: sha512-+MaE752hU0wfPFJEUAIxqw18+20euHHdxVtMvbFcOEpjEyfqXH/5DCoTHiVJ0J29EhTJdoTkjEv5YBKU9dnoTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^7.3.0
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
 
   '@vitest/coverage-v8@4.0.16':
     resolution: {integrity: sha512-2rNdjEIsPRzsdu6/9Eq0AYAzYdpP6Bx9cje9tL3FE5XzXRQF1fNU9pe/1yE8fCrS0HD+fBtt6gLPh6LI57tX7A==}
@@ -3686,29 +3686,29 @@ packages:
   '@vue/compiler-core@3.5.22':
     resolution: {integrity: sha512-jQ0pFPmZwTEiRNSb+i9Ow/I/cHv2tXYqsnHKKyCQ08irI2kdF5qmYedmF8si8mA7zepUFmJ2hqzS8CQmNOWOkQ==}
 
-  '@vue/compiler-core@3.6.0-beta.1':
-    resolution: {integrity: sha512-Oiki36gKyoxc0pPnazo83coH6I4KTenCbhcMjALVo+vhz3cPVylo5Y5PyzX/u45IiMHc/25t492VB6CrFYKEgQ==}
+  '@vue/compiler-core@3.6.0-beta.2':
+    resolution: {integrity: sha512-sZzUfoqA3T99OCKxF+Ju/ttjZQEuwEseqQjfX4Qpf9bStBVrtxUtO4EUhs0lEvUHpq2YOK5VTzmwsG6+IwhCqg==}
 
   '@vue/compiler-dom@3.5.22':
     resolution: {integrity: sha512-W8RknzUM1BLkypvdz10OVsGxnMAuSIZs9Wdx1vzA3mL5fNMN15rhrSCLiTm6blWeACwUwizzPVqGJgOGBEN/hA==}
 
-  '@vue/compiler-dom@3.6.0-beta.1':
-    resolution: {integrity: sha512-6fbQSyjk6tdJO6UOvOtVl1BHw3CuzKSeNRU84LXvlyqm4K1LWJwKaceu5RZyi8+cFusuxtArpH6dwx9cPbejAg==}
+  '@vue/compiler-dom@3.6.0-beta.2':
+    resolution: {integrity: sha512-jqtqh+Xpgd3vd15Nr4tvrfoAvurT7Oju2ohg4H6sAbXbrXqsSTzfwZxvf4AE2+61w5EjK9xcb6VHB1EQfyQVew==}
 
   '@vue/compiler-sfc@3.5.22':
     resolution: {integrity: sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ==}
 
-  '@vue/compiler-sfc@3.6.0-beta.1':
-    resolution: {integrity: sha512-ntC1t5lbbbA5122ONOVQiQVXgDwJQ/xkB/KGUpP7e59An9m/I2CONRtAEB9wB6QQmMMP4ThoOuRH9+t2o6dqjQ==}
+  '@vue/compiler-sfc@3.6.0-beta.2':
+    resolution: {integrity: sha512-fFuDsqD4p7RSFV+0hnYTetyEcWUpR9Eza5wr4M/JABL7mE0JMot5UL2KcMYEvr2Y6SVe3P0RCbJiSJbgu+8Opw==}
 
   '@vue/compiler-ssr@3.5.22':
     resolution: {integrity: sha512-GdgyLvg4R+7T8Nk2Mlighx7XGxq/fJf9jaVofc3IL0EPesTE86cP/8DD1lT3h1JeZr2ySBvyqKQJgbS54IX1Ww==}
 
-  '@vue/compiler-ssr@3.6.0-beta.1':
-    resolution: {integrity: sha512-8hvHjcNPcKYto87/vRCxFFCp6FEg9HAA/oQHQ6DZQe70xnJguCPvYhh+e59HuywN4E68RBOIPC9IYTXenTaIWA==}
+  '@vue/compiler-ssr@3.6.0-beta.2':
+    resolution: {integrity: sha512-sQECEzTD7EmqlmhJ+VEuMFAZh87a6nX8O33LQYKoTCjTz6+Jh2rV3BTQVYqLauwefOhBpFwO5lpTNMTHoppMqw==}
 
-  '@vue/compiler-vapor@3.6.0-beta.1':
-    resolution: {integrity: sha512-NW1FMqjag5fPVf8uK199gw5qFzPBNc4OghchSffS7D2UOs5QMzIpC4XevGA5DeGEuxhpuG9ckisGN2r9BsnTzQ==}
+  '@vue/compiler-vapor@3.6.0-beta.2':
+    resolution: {integrity: sha512-6hVPlf2iXpBnjxeEUxeBytHqBu/CeUQWcI66Zne0xj1Z+Uo7BJ1dQT8EhvhMkxTUIF6FqVzBGvAfdYY/e3B+GA==}
 
   '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
@@ -3725,7 +3725,7 @@ packages:
   '@vue/devtools-core@7.7.7':
     resolution: {integrity: sha512-9z9TLbfC+AjAi1PQyWX+OErjIaJmdFlbDHcD+cAMYKY6Bh5VlsAtCeGyRMrXwIlMEQPukvnWt3gZBLwTAIMKzQ==}
     peerDependencies:
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
 
   '@vue/devtools-kit@7.7.7':
     resolution: {integrity: sha512-wgoZtxcTta65cnZ1Q6MbAfePVFxfM+gq0saaeytoph7nEa7yMXoi6sCPy4ufO111B9msnw0VOWjPEFCXuAKRHA==}
@@ -3775,24 +3775,24 @@ packages:
   '@vue/reactivity@3.5.22':
     resolution: {integrity: sha512-f2Wux4v/Z2pqc9+4SmgZC1p73Z53fyD90NFWXiX9AKVnVBEvLFOWCEgJD3GdGnlxPZt01PSlfmLqbLYzY/Fw4A==}
 
-  '@vue/reactivity@3.6.0-beta.1':
-    resolution: {integrity: sha512-IbmZR0/UVlfRgDE8oVERx8pmYpG0CtE8CWfkdrnjnQckuCoImXCn7W9HiShzmmDNus371hGw6cXCctjQL7hkZw==}
+  '@vue/reactivity@3.6.0-beta.2':
+    resolution: {integrity: sha512-enSThk8ppxiQYddWmzllHH7YTftdx2ac54y4ulhq6rnKhxkRb3jTfu/YTV5gujtZN7sRuKPV+HB27TPuouIVUQ==}
 
-  '@vue/runtime-core@3.6.0-beta.1':
-    resolution: {integrity: sha512-UtZCF+rPSPsKQUTOwB3EHd2y8mY9lD6nr78Gt/fqwnSdxaXY0ksbhc1Q9BjHZPaDMpn8NKzQKlMXf/h1w8VMkg==}
+  '@vue/runtime-core@3.6.0-beta.2':
+    resolution: {integrity: sha512-XO4XEje7mPjBQYdUbKM4xrytVn0YioA4BSZv8qXsW1roYAtDRSBOjhoBQoVlJVN3XOlWarNh0PSGLl7aaZQDiA==}
 
-  '@vue/runtime-dom@3.6.0-beta.1':
-    resolution: {integrity: sha512-+vv8WwxSFzXzjXWvZ92q1ec13fp+RBtAiOTu7M5dWRLqsDEHuVnuzmPB5O+gmiNU0YViLEXP5c/+gDCP3y5yUw==}
+  '@vue/runtime-dom@3.6.0-beta.2':
+    resolution: {integrity: sha512-l6bN4sE1YFQcwW/GLeYT1Td0QmkMF2fIc42eEncGTbbcQwtKkSZcaeYs4NjnbRQgcoOwZdG2KwLm5m045HAkGQ==}
 
-  '@vue/runtime-vapor@3.6.0-beta.1':
-    resolution: {integrity: sha512-XVethfYDcowADbaq1XVEq6BAqnpKgc/75WL5xjy2ChwEB9slMa7B2PBpGSGwvEKKsNyAapYQoa/af5fyogaSlw==}
+  '@vue/runtime-vapor@3.6.0-beta.2':
+    resolution: {integrity: sha512-518kMs9SbmG7q1W91PCDmJoh/StXk+8Jx9nRcaNDixXoAiNkOMmdXPfk09RG6OTRwgZNBpirZ+ZMwHVAQqIoRQ==}
     peerDependencies:
-      '@vue/runtime-dom': 3.6.0-beta.1
+      '@vue/runtime-dom': 3.6.0-beta.2
 
-  '@vue/server-renderer@3.6.0-beta.1':
-    resolution: {integrity: sha512-MpjAiqP/4JTDMswoDSWyS1PCDzR9+ud2aRAOhvtlpnsuNFLwYbf8tNOiPd3x3gty8ghWYMyKCP4isQHNcPRmLA==}
+  '@vue/server-renderer@3.6.0-beta.2':
+    resolution: {integrity: sha512-lmLqEHU6GJWmfqMxAOHkX8s6zkuZJfpnHuXG9Z5r4Gmhwxsv5sQNQs4DjbWB6cj9PXSoFAMQW+r27gqyMk5OIg==}
     peerDependencies:
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
 
   '@vue/shared@3.5.22':
     resolution: {integrity: sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==}
@@ -3800,14 +3800,14 @@ packages:
   '@vue/shared@3.5.24':
     resolution: {integrity: sha512-9cwHL2EsJBdi8NY22pngYYWzkTDhld6fAD6jlaeloNGciNSJL6bLpbxVgXl96X00Jtc6YWQv96YA/0sxex/k1A==}
 
-  '@vue/shared@3.6.0-beta.1':
-    resolution: {integrity: sha512-M+JCCPvuXgRGkgRYQ9LISH8eJXlQgz862OBtO2n7Ef2cyz+DgLQTGfZoNzf3WbVnNUP9/5x7/O0P1ED42IDCCw==}
+  '@vue/shared@3.6.0-beta.2':
+    resolution: {integrity: sha512-FR2lQAfTKwiVw4K/LuMFaiiFDi/RW5oQX2Y0lpYCdJQFjFMKVsbV+yA5VW8llNv9fOtNxeedO8RygihwE2aemw==}
 
   '@vue/tsconfig@0.7.0':
     resolution: {integrity: sha512-ku2uNz5MaZ9IerPPUyOHzyjhXoX2kVJaVf7hL315DC17vS6IiZRmmCPfggNbU16QTvM80+uYYy3eYJB59WCtvg==}
     peerDependencies:
       typescript: 5.x
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -3818,7 +3818,7 @@ packages:
     resolution: {integrity: sha512-aK7feIWPXFSUhsCP9PFqPyFOcz4ENkb8hZ2pneL6m2UjCkccvaOhC/5KCKluuBufvp2KzkbdA2W2pk20vLzu3g==}
     peerDependencies:
       typescript: 5.x
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -3831,7 +3831,7 @@ packages:
   '@vueuse/core@14.0.0':
     resolution: {integrity: sha512-d6tKRWkZE8IQElX2aHBxXOMD478fHIYV+Dzm2y9Ag122ICBpNKtGICiXKOhWU3L1kKdttDD9dCMS4bGP3jhCTQ==}
     peerDependencies:
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
 
   '@vueuse/integrations@12.8.2':
     resolution: {integrity: sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==}
@@ -3889,7 +3889,7 @@ packages:
       qrcode: ^1.5
       sortablejs: ^1
       universal-cookie: ^7 || ^8
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
     peerDependenciesMeta:
       async-validator:
         optional: true
@@ -3928,7 +3928,7 @@ packages:
   '@vueuse/shared@14.0.0':
     resolution: {integrity: sha512-mTCA0uczBgurRlwVaQHfG0Ja7UdGe4g9mwffiJmvLiTtp1G4AQyIjej6si/k8c8pUwTfVpNufck+23gXptPAkw==}
     peerDependencies:
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
 
   '@webassemblyjs/ast@1.9.0':
     resolution: {integrity: sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==}
@@ -9061,7 +9061,7 @@ packages:
   vue-docgen-api@4.79.2:
     resolution: {integrity: sha512-n9ENAcs+40awPZMsas7STqjkZiVlIjxIKgiJr5rSohDP0/JCrD9VtlzNojafsA1MChm/hz2h3PDtUedx3lbgfA==}
     peerDependencies:
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
 
   vue-eslint-parser@10.2.0:
     resolution: {integrity: sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==}
@@ -9080,18 +9080,18 @@ packages:
     engines: {node: '>= 16'}
     deprecated: This version is NOT deprecated. Previous deprecation was a mistake.
     peerDependencies:
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
 
   vue-inbrowser-compiler-independent-utils@4.71.1:
     resolution: {integrity: sha512-K3wt3iVmNGaFEOUR4JIThQRWfqokxLfnPslD41FDZB2ajXp789+wCqJyGYlIFsvEQ2P61PInw6/ph5iiqg51gg==}
     peerDependencies:
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
 
   vue-loader@16.8.3:
     resolution: {integrity: sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==}
     peerDependencies:
       '@vue/compiler-sfc': ^3.0.8
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
       webpack: ^4.1.0 || ^5.0.0-0
     peerDependenciesMeta:
       '@vue/compiler-sfc':
@@ -9102,7 +9102,7 @@ packages:
   vue-router@4.6.3:
     resolution: {integrity: sha512-ARBedLm9YlbvQomnmq91Os7ck6efydTSpRP3nuOKCvgJOHNrhRoJDSKtee8kcL1Vf7nz6U+PMBL+hTvR3bTVQg==}
     peerDependencies:
-      vue: 3.6.0-beta.1
+      vue: 3.6.0-beta.2
 
   vue-tsc@2.2.12:
     resolution: {integrity: sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==}
@@ -9116,8 +9116,8 @@ packages:
     peerDependencies:
       typescript: '>=5.0.0'
 
-  vue@3.6.0-beta.1:
-    resolution: {integrity: sha512-z2VKatkexJ9XZ/eYbUUQaitaYC1MpTtE+7zESy7bBvfcExlF5ubBmCB001I6GznEw4vRR1WMZbDqT482QJEJHw==}
+  vue@3.6.0-beta.2:
+    resolution: {integrity: sha512-jqx3kNNBZrvRnqhO0WEOSrPnwPXeANkbYQz82bF0IizBHFYaiCx3d6hpcn+oY5o7lMbTCKoP/Ww6eD+drwCAVA==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -10189,7 +10189,7 @@ snapshots:
       source-map: 0.6.1
       yaml-eslint-parser: 0.3.2
 
-  '@intlify/bundle-utils@11.0.1(vue-i18n@11.1.12(vue@3.6.0-beta.1(typescript@5.8.3)))':
+  '@intlify/bundle-utils@11.0.1(vue-i18n@11.1.12(vue@3.6.0-beta.2(typescript@5.8.3)))':
     dependencies:
       '@intlify/message-compiler': 11.1.12
       '@intlify/shared': 11.1.12
@@ -10201,7 +10201,7 @@ snapshots:
       source-map-js: 1.2.1
       yaml-eslint-parser: 1.3.0
     optionalDependencies:
-      vue-i18n: 11.1.12(vue@3.6.0-beta.1(typescript@5.8.3))
+      vue-i18n: 11.1.12(vue@3.6.0-beta.2(typescript@5.8.3))
 
   '@intlify/bundle-utils@11.0.1(vue-i18n@packages+vue-i18n)':
     dependencies:
@@ -10246,12 +10246,12 @@ snapshots:
 
   '@intlify/shared@9.14.5': {}
 
-  '@intlify/unplugin-vue-i18n@11.0.1(@vue/compiler-dom@3.5.22)(eslint@9.39.2(jiti@2.6.1))(rollup@4.54.0)(typescript@5.8.3)(vue-i18n@11.1.12(vue@3.6.0-beta.1(typescript@5.8.3)))(vue@3.6.0-beta.1(typescript@5.8.3))':
+  '@intlify/unplugin-vue-i18n@11.0.1(@vue/compiler-dom@3.5.22)(eslint@9.39.2(jiti@2.6.1))(rollup@4.54.0)(typescript@5.8.3)(vue-i18n@11.1.12(vue@3.6.0-beta.2(typescript@5.8.3)))(vue@3.6.0-beta.2(typescript@5.8.3))':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@2.6.1))
-      '@intlify/bundle-utils': 11.0.1(vue-i18n@11.1.12(vue@3.6.0-beta.1(typescript@5.8.3)))
+      '@intlify/bundle-utils': 11.0.1(vue-i18n@11.1.12(vue@3.6.0-beta.2(typescript@5.8.3)))
       '@intlify/shared': 11.1.12
-      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.1.12)(@vue/compiler-dom@3.5.22)(vue-i18n@11.1.12(vue@3.6.0-beta.1(typescript@5.8.3)))(vue@3.6.0-beta.1(typescript@5.8.3))
+      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.1.12)(@vue/compiler-dom@3.5.22)(vue-i18n@11.1.12(vue@3.6.0-beta.2(typescript@5.8.3)))(vue@3.6.0-beta.2(typescript@5.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.54.0)
       '@typescript-eslint/scope-manager': 8.46.2
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.8.3)
@@ -10260,9 +10260,9 @@ snapshots:
       pathe: 2.0.3
       picocolors: 1.1.1
       unplugin: 2.3.10
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
     optionalDependencies:
-      vue-i18n: 11.1.12(vue@3.6.0-beta.1(typescript@5.8.3))
+      vue-i18n: 11.1.12(vue@3.6.0-beta.2(typescript@5.8.3))
     transitivePeerDependencies:
       - '@vue/compiler-dom'
       - eslint
@@ -10270,12 +10270,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@intlify/unplugin-vue-i18n@11.0.1(@vue/compiler-dom@3.5.22)(eslint@9.39.2(jiti@2.6.1))(rollup@4.54.0)(typescript@5.8.3)(vue-i18n@packages+vue-i18n)(vue@3.6.0-beta.1(typescript@5.8.3))':
+  '@intlify/unplugin-vue-i18n@11.0.1(@vue/compiler-dom@3.5.22)(eslint@9.39.2(jiti@2.6.1))(rollup@4.54.0)(typescript@5.8.3)(vue-i18n@packages+vue-i18n)(vue@3.6.0-beta.2(typescript@5.8.3))':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@2.6.1))
       '@intlify/bundle-utils': 11.0.1(vue-i18n@packages+vue-i18n)
       '@intlify/shared': 11.1.12
-      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.1.12)(@vue/compiler-dom@3.5.22)(vue-i18n@packages+vue-i18n)(vue@3.6.0-beta.1(typescript@5.8.3))
+      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.1.12)(@vue/compiler-dom@3.5.22)(vue-i18n@packages+vue-i18n)(vue@3.6.0-beta.2(typescript@5.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.54.0)
       '@typescript-eslint/scope-manager': 8.46.2
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.8.3)
@@ -10284,7 +10284,7 @@ snapshots:
       pathe: 2.0.3
       picocolors: 1.1.1
       unplugin: 2.3.10
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
     optionalDependencies:
       vue-i18n: link:packages/vue-i18n
     transitivePeerDependencies:
@@ -10294,12 +10294,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@intlify/unplugin-vue-i18n@11.0.1(@vue/compiler-dom@3.5.22)(eslint@9.39.2(jiti@2.6.1))(rollup@4.54.0)(typescript@5.9.3)(vue-i18n@packages+vue-i18n)(vue@3.6.0-beta.1(typescript@5.9.3))':
+  '@intlify/unplugin-vue-i18n@11.0.1(@vue/compiler-dom@3.5.22)(eslint@9.39.2(jiti@2.6.1))(rollup@4.54.0)(typescript@5.9.3)(vue-i18n@packages+vue-i18n)(vue@3.6.0-beta.2(typescript@5.9.3))':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@2.6.1))
       '@intlify/bundle-utils': 11.0.1(vue-i18n@packages+vue-i18n)
       '@intlify/shared': 11.1.12
-      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.1.12)(@vue/compiler-dom@3.5.22)(vue-i18n@packages+vue-i18n)(vue@3.6.0-beta.1(typescript@5.9.3))
+      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.1.12)(@vue/compiler-dom@3.5.22)(vue-i18n@packages+vue-i18n)(vue@3.6.0-beta.2(typescript@5.9.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.54.0)
       '@typescript-eslint/scope-manager': 8.46.2
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.3)
@@ -10308,7 +10308,7 @@ snapshots:
       pathe: 2.0.3
       picocolors: 1.1.1
       unplugin: 2.3.10
-      vue: 3.6.0-beta.1(typescript@5.9.3)
+      vue: 3.6.0-beta.2(typescript@5.9.3)
     optionalDependencies:
       vue-i18n: link:packages/vue-i18n
     transitivePeerDependencies:
@@ -10318,41 +10318,41 @@ snapshots:
       - supports-color
       - typescript
 
-  '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.1.12)(@vue/compiler-dom@3.5.22)(vue-i18n@11.1.12(vue@3.6.0-beta.1(typescript@5.8.3)))(vue@3.6.0-beta.1(typescript@5.8.3))':
+  '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.1.12)(@vue/compiler-dom@3.5.22)(vue-i18n@11.1.12(vue@3.6.0-beta.2(typescript@5.8.3)))(vue@3.6.0-beta.2(typescript@5.8.3))':
     dependencies:
       '@babel/parser': 7.28.5
     optionalDependencies:
       '@intlify/shared': 11.1.12
       '@vue/compiler-dom': 3.5.22
-      vue: 3.6.0-beta.1(typescript@5.8.3)
-      vue-i18n: 11.1.12(vue@3.6.0-beta.1(typescript@5.8.3))
+      vue: 3.6.0-beta.2(typescript@5.8.3)
+      vue-i18n: 11.1.12(vue@3.6.0-beta.2(typescript@5.8.3))
 
-  '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.1.12)(@vue/compiler-dom@3.5.22)(vue-i18n@packages+vue-i18n)(vue@3.6.0-beta.1(typescript@5.8.3))':
+  '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.1.12)(@vue/compiler-dom@3.5.22)(vue-i18n@packages+vue-i18n)(vue@3.6.0-beta.2(typescript@5.8.3))':
     dependencies:
       '@babel/parser': 7.28.5
     optionalDependencies:
       '@intlify/shared': 11.1.12
       '@vue/compiler-dom': 3.5.22
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
       vue-i18n: link:packages/vue-i18n
 
-  '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.1.12)(@vue/compiler-dom@3.5.22)(vue-i18n@packages+vue-i18n)(vue@3.6.0-beta.1(typescript@5.9.3))':
+  '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.1.12)(@vue/compiler-dom@3.5.22)(vue-i18n@packages+vue-i18n)(vue@3.6.0-beta.2(typescript@5.9.3))':
     dependencies:
       '@babel/parser': 7.28.5
     optionalDependencies:
       '@intlify/shared': 11.1.12
       '@vue/compiler-dom': 3.5.22
-      vue: 3.6.0-beta.1(typescript@5.9.3)
+      vue: 3.6.0-beta.2(typescript@5.9.3)
       vue-i18n: link:packages/vue-i18n
 
-  '@intlify/vue-i18n-loader@3.3.0(vue@3.6.0-beta.1(typescript@5.9.3))':
+  '@intlify/vue-i18n-loader@3.3.0(vue@3.6.0-beta.2(typescript@5.9.3))':
     dependencies:
       '@intlify/bundle-utils': 1.0.0
       '@intlify/shared': 9.14.5
       js-yaml: 4.1.0
       json5: 2.2.3
       loader-utils: 2.0.4
-      vue: 3.6.0-beta.1(typescript@5.9.3)
+      vue: 3.6.0-beta.2(typescript@5.9.3)
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -11395,21 +11395,21 @@ snapshots:
     dependencies:
       storybook: 8.6.14(prettier@3.5.3)
 
-  '@storybook/vue3-vite@8.6.14(storybook@8.6.14(prettier@3.5.3))(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))':
+  '@storybook/vue3-vite@8.6.14(storybook@8.6.14(prettier@3.5.3))(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))':
     dependencies:
       '@storybook/builder-vite': 8.6.14(storybook@8.6.14(prettier@3.5.3))(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
-      '@storybook/vue3': 8.6.14(storybook@8.6.14(prettier@3.5.3))(vue@3.6.0-beta.1(typescript@5.8.3))
+      '@storybook/vue3': 8.6.14(storybook@8.6.14(prettier@3.5.3))(vue@3.6.0-beta.2(typescript@5.8.3))
       find-package-json: 1.2.0
       magic-string: 0.30.19
       storybook: 8.6.14(prettier@3.5.3)
       typescript: 5.8.3
       vite: 7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
       vue-component-meta: 2.2.12(typescript@5.8.3)
-      vue-docgen-api: 4.79.2(vue@3.6.0-beta.1(typescript@5.8.3))
+      vue-docgen-api: 4.79.2(vue@3.6.0-beta.2(typescript@5.8.3))
     transitivePeerDependencies:
       - vue
 
-  '@storybook/vue3@8.6.14(storybook@8.6.14(prettier@3.5.3))(vue@3.6.0-beta.1(typescript@5.8.3))':
+  '@storybook/vue3@8.6.14(storybook@8.6.14(prettier@3.5.3))(vue@3.6.0-beta.2(typescript@5.8.3))':
     dependencies:
       '@storybook/components': 8.6.14(storybook@8.6.14(prettier@3.5.3))
       '@storybook/global': 5.0.0
@@ -11420,7 +11420,7 @@ snapshots:
       storybook: 8.6.14(prettier@3.5.3)
       ts-dedent: 2.2.0
       type-fest: 2.19.0
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
       vue-component-type-helpers: 3.2.1
 
   '@stylistic/eslint-plugin@4.4.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
@@ -11936,7 +11936,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-vue-jsx@5.1.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))':
+  '@vitejs/plugin-vue-jsx@5.1.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.4)
@@ -11944,11 +11944,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.44
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.4)
       vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@5.1.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.9.3))':
+  '@vitejs/plugin-vue-jsx@5.1.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.4)
@@ -11956,31 +11956,31 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.44
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.4)
       vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
-      vue: 3.6.0-beta.1(typescript@5.9.3)
+      vue: 3.6.0-beta.2(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.2.4(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))':
     dependencies:
       vite: 7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
 
-  '@vitejs/plugin-vue@5.2.4(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))':
     dependencies:
       vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
 
-  '@vitejs/plugin-vue@6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.0-beta.29
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
-      vue: 3.6.0-beta.1(typescript@5.8.3)
-
-  '@vitejs/plugin-vue@6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
       vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
-      vue: 3.6.0-beta.1(typescript@5.9.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
+
+  '@vitejs/plugin-vue@6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.9.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-beta.29
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
+      vue: 3.6.0-beta.2(typescript@5.9.3)
 
   '@vitest/coverage-v8@4.0.16(vitest@4.0.16(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
@@ -12131,10 +12131,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-core@3.6.0-beta.1':
+  '@vue/compiler-core@3.6.0-beta.2':
     dependencies:
       '@babel/parser': 7.28.5
-      '@vue/shared': 3.6.0-beta.1
+      '@vue/shared': 3.6.0-beta.2
       entities: 7.0.0
       estree-walker: 2.0.2
       source-map-js: 1.2.1
@@ -12144,10 +12144,10 @@ snapshots:
       '@vue/compiler-core': 3.5.22
       '@vue/shared': 3.5.22
 
-  '@vue/compiler-dom@3.6.0-beta.1':
+  '@vue/compiler-dom@3.6.0-beta.2':
     dependencies:
-      '@vue/compiler-core': 3.6.0-beta.1
-      '@vue/shared': 3.6.0-beta.1
+      '@vue/compiler-core': 3.6.0-beta.2
+      '@vue/shared': 3.6.0-beta.2
 
   '@vue/compiler-sfc@3.5.22':
     dependencies:
@@ -12161,14 +12161,14 @@ snapshots:
       postcss: 8.5.6
       source-map-js: 1.2.1
 
-  '@vue/compiler-sfc@3.6.0-beta.1':
+  '@vue/compiler-sfc@3.6.0-beta.2':
     dependencies:
       '@babel/parser': 7.28.5
-      '@vue/compiler-core': 3.6.0-beta.1
-      '@vue/compiler-dom': 3.6.0-beta.1
-      '@vue/compiler-ssr': 3.6.0-beta.1
-      '@vue/compiler-vapor': 3.6.0-beta.1
-      '@vue/shared': 3.6.0-beta.1
+      '@vue/compiler-core': 3.6.0-beta.2
+      '@vue/compiler-dom': 3.6.0-beta.2
+      '@vue/compiler-ssr': 3.6.0-beta.2
+      '@vue/compiler-vapor': 3.6.0-beta.2
+      '@vue/shared': 3.6.0-beta.2
       estree-walker: 2.0.2
       magic-string: 0.30.21
       postcss: 8.5.6
@@ -12179,16 +12179,16 @@ snapshots:
       '@vue/compiler-dom': 3.5.22
       '@vue/shared': 3.5.22
 
-  '@vue/compiler-ssr@3.6.0-beta.1':
+  '@vue/compiler-ssr@3.6.0-beta.2':
     dependencies:
-      '@vue/compiler-dom': 3.6.0-beta.1
-      '@vue/shared': 3.6.0-beta.1
+      '@vue/compiler-dom': 3.6.0-beta.2
+      '@vue/shared': 3.6.0-beta.2
 
-  '@vue/compiler-vapor@3.6.0-beta.1':
+  '@vue/compiler-vapor@3.6.0-beta.2':
     dependencies:
       '@babel/parser': 7.28.5
-      '@vue/compiler-dom': 3.6.0-beta.1
-      '@vue/shared': 3.6.0-beta.1
+      '@vue/compiler-dom': 3.6.0-beta.2
+      '@vue/shared': 3.6.0-beta.2
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
@@ -12207,7 +12207,7 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 8.0.5
 
-  '@vue/devtools-core@7.7.7(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))':
+  '@vue/devtools-core@7.7.7(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))':
     dependencies:
       '@vue/devtools-kit': 7.7.7
       '@vue/devtools-shared': 7.7.7
@@ -12215,7 +12215,7 @@ snapshots:
       nanoid: 5.1.6
       pathe: 2.0.3
       vite-hot-client: 2.1.0(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
     transitivePeerDependencies:
       - vite
 
@@ -12311,88 +12311,88 @@ snapshots:
       '@vue/shared': 3.5.22
     optional: true
 
-  '@vue/reactivity@3.6.0-beta.1':
+  '@vue/reactivity@3.6.0-beta.2':
     dependencies:
-      '@vue/shared': 3.6.0-beta.1
+      '@vue/shared': 3.6.0-beta.2
 
-  '@vue/runtime-core@3.6.0-beta.1':
+  '@vue/runtime-core@3.6.0-beta.2':
     dependencies:
-      '@vue/reactivity': 3.6.0-beta.1
-      '@vue/shared': 3.6.0-beta.1
+      '@vue/reactivity': 3.6.0-beta.2
+      '@vue/shared': 3.6.0-beta.2
 
-  '@vue/runtime-dom@3.6.0-beta.1':
+  '@vue/runtime-dom@3.6.0-beta.2':
     dependencies:
-      '@vue/reactivity': 3.6.0-beta.1
-      '@vue/runtime-core': 3.6.0-beta.1
-      '@vue/shared': 3.6.0-beta.1
+      '@vue/reactivity': 3.6.0-beta.2
+      '@vue/runtime-core': 3.6.0-beta.2
+      '@vue/shared': 3.6.0-beta.2
       csstype: 3.2.3
 
-  '@vue/runtime-vapor@3.6.0-beta.1(@vue/runtime-dom@3.6.0-beta.1)':
+  '@vue/runtime-vapor@3.6.0-beta.2(@vue/runtime-dom@3.6.0-beta.2)':
     dependencies:
-      '@vue/reactivity': 3.6.0-beta.1
-      '@vue/runtime-dom': 3.6.0-beta.1
-      '@vue/shared': 3.6.0-beta.1
+      '@vue/reactivity': 3.6.0-beta.2
+      '@vue/runtime-dom': 3.6.0-beta.2
+      '@vue/shared': 3.6.0-beta.2
 
-  '@vue/server-renderer@3.6.0-beta.1(vue@3.6.0-beta.1(typescript@5.8.3))':
+  '@vue/server-renderer@3.6.0-beta.2(vue@3.6.0-beta.2(typescript@5.8.3))':
     dependencies:
-      '@vue/compiler-ssr': 3.6.0-beta.1
-      '@vue/shared': 3.6.0-beta.1
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      '@vue/compiler-ssr': 3.6.0-beta.2
+      '@vue/shared': 3.6.0-beta.2
+      vue: 3.6.0-beta.2(typescript@5.8.3)
 
-  '@vue/server-renderer@3.6.0-beta.1(vue@3.6.0-beta.1(typescript@5.9.3))':
+  '@vue/server-renderer@3.6.0-beta.2(vue@3.6.0-beta.2(typescript@5.9.3))':
     dependencies:
-      '@vue/compiler-ssr': 3.6.0-beta.1
-      '@vue/shared': 3.6.0-beta.1
-      vue: 3.6.0-beta.1(typescript@5.9.3)
+      '@vue/compiler-ssr': 3.6.0-beta.2
+      '@vue/shared': 3.6.0-beta.2
+      vue: 3.6.0-beta.2(typescript@5.9.3)
 
   '@vue/shared@3.5.22': {}
 
   '@vue/shared@3.5.24': {}
 
-  '@vue/shared@3.6.0-beta.1': {}
+  '@vue/shared@3.6.0-beta.2': {}
 
-  '@vue/tsconfig@0.7.0(typescript@5.8.3)(vue@3.6.0-beta.1(typescript@5.8.3))':
+  '@vue/tsconfig@0.7.0(typescript@5.8.3)(vue@3.6.0-beta.2(typescript@5.8.3))':
     optionalDependencies:
       typescript: 5.8.3
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
 
-  '@vue/tsconfig@0.8.1(typescript@5.8.3)(vue@3.6.0-beta.1(typescript@5.8.3))':
+  '@vue/tsconfig@0.8.1(typescript@5.8.3)(vue@3.6.0-beta.2(typescript@5.8.3))':
     optionalDependencies:
       typescript: 5.8.3
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
 
   '@vueuse/core@12.8.2(typescript@5.8.3)':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 12.8.2
       '@vueuse/shared': 12.8.2(typescript@5.8.3)
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/core@14.0.0(vue@3.6.0-beta.1(typescript@5.9.3))':
+  '@vueuse/core@14.0.0(vue@3.6.0-beta.2(typescript@5.9.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 14.0.0
-      '@vueuse/shared': 14.0.0(vue@3.6.0-beta.1(typescript@5.9.3))
-      vue: 3.6.0-beta.1(typescript@5.9.3)
+      '@vueuse/shared': 14.0.0(vue@3.6.0-beta.2(typescript@5.9.3))
+      vue: 3.6.0-beta.2(typescript@5.9.3)
 
   '@vueuse/integrations@12.8.2(change-case@5.4.4)(focus-trap@7.6.5)(typescript@5.8.3)':
     dependencies:
       '@vueuse/core': 12.8.2(typescript@5.8.3)
       '@vueuse/shared': 12.8.2(typescript@5.8.3)
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
     optionalDependencies:
       change-case: 5.4.4
       focus-trap: 7.6.5
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/integrations@14.0.0(change-case@5.4.4)(focus-trap@7.6.6)(vue@3.6.0-beta.1(typescript@5.9.3))':
+  '@vueuse/integrations@14.0.0(change-case@5.4.4)(focus-trap@7.6.6)(vue@3.6.0-beta.2(typescript@5.9.3))':
     dependencies:
-      '@vueuse/core': 14.0.0(vue@3.6.0-beta.1(typescript@5.9.3))
-      '@vueuse/shared': 14.0.0(vue@3.6.0-beta.1(typescript@5.9.3))
-      vue: 3.6.0-beta.1(typescript@5.9.3)
+      '@vueuse/core': 14.0.0(vue@3.6.0-beta.2(typescript@5.9.3))
+      '@vueuse/shared': 14.0.0(vue@3.6.0-beta.2(typescript@5.9.3))
+      vue: 3.6.0-beta.2(typescript@5.9.3)
     optionalDependencies:
       change-case: 5.4.4
       focus-trap: 7.6.6
@@ -12403,13 +12403,13 @@ snapshots:
 
   '@vueuse/shared@12.8.2(typescript@5.8.3)':
     dependencies:
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/shared@14.0.0(vue@3.6.0-beta.1(typescript@5.9.3))':
+  '@vueuse/shared@14.0.0(vue@3.6.0-beta.2(typescript@5.9.3))':
     dependencies:
-      vue: 3.6.0-beta.1(typescript@5.9.3)
+      vue: 3.6.0-beta.2(typescript@5.9.3)
 
   '@webassemblyjs/ast@1.9.0':
     dependencies:
@@ -18605,9 +18605,9 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-vue-devtools@7.7.7(rollup@4.54.0)(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3)):
+  vite-plugin-vue-devtools@7.7.7(rollup@4.54.0)(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3)):
     dependencies:
-      '@vue/devtools-core': 7.7.7(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))
+      '@vue/devtools-core': 7.7.7(vite@7.3.0(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))
       '@vue/devtools-kit': 7.7.7
       '@vue/devtools-shared': 7.7.7
       execa: 9.6.0
@@ -18698,7 +18698,7 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.8.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.8.3))
       '@vue/devtools-api': 7.7.7
       '@vue/shared': 3.5.22
       '@vueuse/core': 12.8.2(typescript@5.8.3)
@@ -18708,7 +18708,7 @@ snapshots:
       minisearch: 7.2.0
       shiki: 2.5.0
       vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
     optionalDependencies:
       postcss: 8.5.6
     transitivePeerDependencies:
@@ -18750,17 +18750,17 @@ snapshots:
       '@shikijs/transformers': 3.15.0
       '@shikijs/types': 3.15.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.1(typescript@5.9.3))
+      '@vitejs/plugin-vue': 6.0.1(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vue@3.6.0-beta.2(typescript@5.9.3))
       '@vue/devtools-api': 8.0.5
       '@vue/shared': 3.5.24
-      '@vueuse/core': 14.0.0(vue@3.6.0-beta.1(typescript@5.9.3))
-      '@vueuse/integrations': 14.0.0(change-case@5.4.4)(focus-trap@7.6.6)(vue@3.6.0-beta.1(typescript@5.9.3))
+      '@vueuse/core': 14.0.0(vue@3.6.0-beta.2(typescript@5.9.3))
+      '@vueuse/integrations': 14.0.0(change-case@5.4.4)(focus-trap@7.6.6)(vue@3.6.0-beta.2(typescript@5.9.3))
       focus-trap: 7.6.6
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 3.15.0
       vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
-      vue: 3.6.0-beta.1(typescript@5.9.3)
+      vue: 3.6.0-beta.2(typescript@5.9.3)
     optionalDependencies:
       oxc-minify: 0.106.0
       postcss: 8.5.6
@@ -18848,7 +18848,7 @@ snapshots:
 
   vue-component-type-helpers@3.2.1: {}
 
-  vue-docgen-api@4.79.2(vue@3.6.0-beta.1(typescript@5.8.3)):
+  vue-docgen-api@4.79.2(vue@3.6.0-beta.2(typescript@5.8.3)):
     dependencies:
       '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
@@ -18861,8 +18861,8 @@ snapshots:
       pug: 3.0.3
       recast: 0.23.11
       ts-map: 1.0.3
-      vue: 3.6.0-beta.1(typescript@5.8.3)
-      vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.6.0-beta.1(typescript@5.8.3))
+      vue: 3.6.0-beta.2(typescript@5.8.3)
+      vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.6.0-beta.2(typescript@5.8.3))
 
   vue-eslint-parser@10.2.0(eslint@9.38.0(jiti@2.6.1)):
     dependencies:
@@ -18901,18 +18901,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-i18n@11.1.12(vue@3.6.0-beta.1(typescript@5.8.3)):
+  vue-i18n@11.1.12(vue@3.6.0-beta.2(typescript@5.8.3)):
     dependencies:
       '@intlify/core-base': 11.1.12
       '@intlify/shared': 11.1.12
       '@vue/devtools-api': 6.6.4
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
 
-  vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.6.0-beta.1(typescript@5.8.3)):
+  vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.6.0-beta.2(typescript@5.8.3)):
     dependencies:
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
 
-  vue-loader@16.8.3(@vue/compiler-sfc@3.5.22)(vue@3.6.0-beta.1(typescript@5.9.3))(webpack@4.47.0):
+  vue-loader@16.8.3(@vue/compiler-sfc@3.5.22)(vue@3.6.0-beta.2(typescript@5.9.3))(webpack@4.47.0):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
@@ -18920,17 +18920,17 @@ snapshots:
       webpack: 4.47.0(webpack-cli@3.3.12)
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.22
-      vue: 3.6.0-beta.1(typescript@5.9.3)
+      vue: 3.6.0-beta.2(typescript@5.9.3)
 
-  vue-router@4.6.3(vue@3.6.0-beta.1(typescript@5.8.3)):
+  vue-router@4.6.3(vue@3.6.0-beta.2(typescript@5.8.3)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.6.0-beta.1(typescript@5.8.3)
+      vue: 3.6.0-beta.2(typescript@5.8.3)
 
-  vue-router@4.6.3(vue@3.6.0-beta.1(typescript@5.9.3)):
+  vue-router@4.6.3(vue@3.6.0-beta.2(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.6.0-beta.1(typescript@5.9.3)
+      vue: 3.6.0-beta.2(typescript@5.9.3)
 
   vue-tsc@2.2.12(typescript@5.8.3):
     dependencies:
@@ -18950,25 +18950,25 @@ snapshots:
       '@vue/language-core': 3.1.2(typescript@5.9.3)
       typescript: 5.9.3
 
-  vue@3.6.0-beta.1(typescript@5.8.3):
+  vue@3.6.0-beta.2(typescript@5.8.3):
     dependencies:
-      '@vue/compiler-dom': 3.6.0-beta.1
-      '@vue/compiler-sfc': 3.6.0-beta.1
-      '@vue/runtime-dom': 3.6.0-beta.1
-      '@vue/runtime-vapor': 3.6.0-beta.1(@vue/runtime-dom@3.6.0-beta.1)
-      '@vue/server-renderer': 3.6.0-beta.1(vue@3.6.0-beta.1(typescript@5.8.3))
-      '@vue/shared': 3.6.0-beta.1
+      '@vue/compiler-dom': 3.6.0-beta.2
+      '@vue/compiler-sfc': 3.6.0-beta.2
+      '@vue/runtime-dom': 3.6.0-beta.2
+      '@vue/runtime-vapor': 3.6.0-beta.2(@vue/runtime-dom@3.6.0-beta.2)
+      '@vue/server-renderer': 3.6.0-beta.2(vue@3.6.0-beta.2(typescript@5.8.3))
+      '@vue/shared': 3.6.0-beta.2
     optionalDependencies:
       typescript: 5.8.3
 
-  vue@3.6.0-beta.1(typescript@5.9.3):
+  vue@3.6.0-beta.2(typescript@5.9.3):
     dependencies:
-      '@vue/compiler-dom': 3.6.0-beta.1
-      '@vue/compiler-sfc': 3.6.0-beta.1
-      '@vue/runtime-dom': 3.6.0-beta.1
-      '@vue/runtime-vapor': 3.6.0-beta.1(@vue/runtime-dom@3.6.0-beta.1)
-      '@vue/server-renderer': 3.6.0-beta.1(vue@3.6.0-beta.1(typescript@5.9.3))
-      '@vue/shared': 3.6.0-beta.1
+      '@vue/compiler-dom': 3.6.0-beta.2
+      '@vue/compiler-sfc': 3.6.0-beta.2
+      '@vue/runtime-dom': 3.6.0-beta.2
+      '@vue/runtime-vapor': 3.6.0-beta.2(@vue/runtime-dom@3.6.0-beta.2)
+      '@vue/server-renderer': 3.6.0-beta.2(vue@3.6.0-beta.2(typescript@5.9.3))
+      '@vue/shared': 3.6.0-beta.2
     optionalDependencies:
       typescript: 5.9.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,18 @@ packages:
   - '!examples/frameworks/nuxt3'
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
+  - vue
+  - '@vue/compiler-dom'
+  - '@vue/shared'
+  - '@vue/runtime-vapor'
+  - '@vue/server-renderer'
+  - '@vue/compiler-sfc'
+  - '@vue/runtime-dom'
+  - '@vue/reactivity'
+  - '@vue/compiler-vapor'
+  - '@vue/compiler-ssr'
+  - '@vue/runtime-core'
+  - '@vue/compiler-core'
   - '@kazupon/eslint-config'
   - vitest
   - '@vitest/mocker'


### PR DESCRIPTION
## Background

The internal implementation of `useI18n` uses `getCurrentInstance`. While `getCurrentInstance` is provided in Vue 3.6, it is scheduled to become a deprecated API in Vue 4.0 and later.

We will change the implementation architecture of `useI18n` to a provide-inject based approach to provide the same functionality as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added useInstanceOption API for component option access.

* **Refactor**
  * Refactored internal instance tracking mechanism for improved maintainability.
  * Enhanced DevTools component inspection functionality.

* **Chores**
  * Updated Vue to 3.6.0-beta.2.
  * Extended workspace package exclusion configuration.

* **Tests**
  * Updated SSR test data and assertions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->