### PR TITLE
feat!: Support automatic pluralization with `Intl.PluralRules`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ docs/jp/api/vue
 docs/jp/api/index.md
 !docs/api/typedoc-sidebar.json
 .notes
+.data
+.playwright-cli
+.report
+.claude
 
 *.log
 *.swp

--- a/docs/guide/advanced/component.md
+++ b/docs/guide/advanced/component.md
@@ -51,8 +51,15 @@ const url = ref('/term')
 <template>
   <div id="app">
     <!-- ... -->
-    <i18n-t keypath="term" tag="label" for="tos">
-      <a :href="url" target="_blank">{{ t('tos') }}</a>
+    <i18n-t
+      keypath="term"
+      tag="label"
+      for="tos"
+    >
+      <a
+        :href="url"
+        target="_blank"
+      >{{ t('tos') }}</a>
     </i18n-t>
     <!-- ... -->
   </div>
@@ -128,11 +135,14 @@ const refundLimit = ref(30)
 <template>
   <div id="app">
     <!-- ... -->
-    <i18n-t keypath="info" tag="p">
-      <template v-slot:limit>
+    <i18n-t
+      keypath="info"
+      tag="p"
+    >
+      <template #limit>
         <span>{{ changeLimit }}</span>
       </template>
-      <template v-slot:action>
+      <template #action>
         <a :href="changeUrl">{{ t('change') }}</a>
       </template>
     </i18n-t>

--- a/docs/guide/essentials/local.md
+++ b/docs/guide/essentials/local.md
@@ -157,7 +157,9 @@ const { t } = useI18n({
       <p>This is good service</p>
     </div>
     <div class="footer">
-      <button type="button">{{ t('buttons.save') }}</button>
+      <button type="button">
+        {{ t('buttons.save') }}
+      </button>
     </div>
   </div>
 </template>

--- a/docs/guide/essentials/pluralization.md
+++ b/docs/guide/essentials/pluralization.md
@@ -114,11 +114,44 @@ As result the below:
 <p>too many bananas</p>
 ```
 
+## Automatic Pluralization with `Intl.PluralRules`
+
+Vue I18n automatically uses [`Intl.PluralRules`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules) to select the correct plural form based on the current locale. This means that for most languages, you don't need to write custom pluralization rules — just provide the correct number of message cases in CLDR plural category order: `zero | one | two | few | many | other`.
+
+For example, Russian has 4 plural categories (`one`, `few`, `many`, `other`):
+
+```js
+const i18n = createI18n({
+  locale: 'ru',
+  messages: {
+    ru: {
+      car: '{n} машина | {n} машины | {n} машин | {n} машин',
+      //    one          few          many         other
+    }
+  }
+})
+```
+
+Vue I18n will automatically select the correct form:
+
+| Value | `Intl.PluralRules` category | Selected case |
+|---|---|---|
+| 1 | `one` | `{n} машина` |
+| 2 | `few` | `{n} машины` |
+| 5 | `many` | `{n} машин` |
+| 21 | `one` | `{n} машина` |
+
+:::tip NOTE
+When the number of message cases exceeds the number of plural categories for the locale, Vue I18n falls back to the default rule (suitable for English).
+:::
+
+:::tip NOTE
+If `Intl.PluralRules` is not available in the runtime environment, Vue I18n falls back to the default English-based rule.
+:::
+
 ## Custom Pluralization
 
-Such pluralization, however, does not apply to all languages (Slavic languages, for example, have different pluralization rules).
-
-To implement these rules you can pass an optional `pluralRules` object into `createI18n` options.
+While automatic pluralization via `Intl.PluralRules` works for most languages, you may need custom logic for special cases. You can pass an optional `pluralRules` object into `createI18n` options to override the automatic behavior for specific locales.
 
 Very simplified example using rules for Slavic languages (Russian, Ukrainian, etc.):
 

--- a/docs/jp/guide/advanced/component.md
+++ b/docs/jp/guide/advanced/component.md
@@ -51,8 +51,15 @@ const url = ref('/term')
 <template>
   <div id="app">
     <!-- ... -->
-    <i18n-t keypath="term" tag="label" for="tos">
-      <a :href="url" target="_blank">{{ t('tos') }}</a>
+    <i18n-t
+      keypath="term"
+      tag="label"
+      for="tos"
+    >
+      <a
+        :href="url"
+        target="_blank"
+      >{{ t('tos') }}</a>
     </i18n-t>
     <!-- ... -->
   </div>
@@ -128,11 +135,14 @@ const refundLimit = ref(30)
 <template>
   <div id="app">
     <!-- ... -->
-    <i18n-t keypath="info" tag="p">
-      <template v-slot:limit>
+    <i18n-t
+      keypath="info"
+      tag="p"
+    >
+      <template #limit>
         <span>{{ changeLimit }}</span>
       </template>
-      <template v-slot:action>
+      <template #action>
         <a :href="changeUrl">{{ t('change') }}</a>
       </template>
     </i18n-t>

--- a/docs/jp/guide/essentials/local.md
+++ b/docs/jp/guide/essentials/local.md
@@ -157,7 +157,9 @@ const { t } = useI18n({
       <p>This is good service</p>
     </div>
     <div class="footer">
-      <button type="button">{{ t('buttons.save') }}</button>
+      <button type="button">
+        {{ t('buttons.save') }}
+      </button>
     </div>
   </div>
 </template>

--- a/docs/jp/guide/essentials/pluralization.md
+++ b/docs/jp/guide/essentials/pluralization.md
@@ -114,11 +114,44 @@ const messages = {
 <p>too many bananas</p>
 ```
 
+## `Intl.PluralRules` による自動複数化
+
+Vue I18n は現在のロケールに基づいて正しい複数形を自動的に選択するために [`Intl.PluralRules`](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules) を使用します。これにより、ほとんどの言語ではカスタムの複数化ルールを書く必要がありません。CLDR 複数形カテゴリの順序でメッセージのケースを正しい数だけ提供するだけです: `zero | one | two | few | many | other`。
+
+例えば、ロシア語には4つの複数形カテゴリがあります（`one`, `few`, `many`, `other`）:
+
+```js
+const i18n = createI18n({
+  locale: 'ru',
+  messages: {
+    ru: {
+      car: '{n} машина | {n} машины | {n} машин | {n} машин',
+      //    one          few          many         other
+    }
+  }
+})
+```
+
+Vue I18n は自動的に正しい形式を選択します:
+
+| 値 | `Intl.PluralRules` カテゴリ | 選択されるケース |
+|---|---|---|
+| 1 | `one` | `{n} машина` |
+| 2 | `few` | `{n} машины` |
+| 5 | `many` | `{n} машин` |
+| 21 | `one` | `{n} машина` |
+
+:::tip NOTE
+メッセージのケース数がロケールの複数形カテゴリ数を超える場合、Vue I18n はデフォルトルール（英語に適したもの）にフォールバックします。
+:::
+
+:::tip NOTE
+ランタイム環境で `Intl.PluralRules` が利用できない場合、Vue I18n はデフォルトの英語ベースルールにフォールバックします。
+:::
+
 ## カスタム複数化
 
-ただし、このような複数化はすべての言語に適用されるわけではありません（たとえば、スラブ語派の言語には異なる複数化ルールがあります）。
-
-これらのルールを実装するには、オプションの `pluralRules` オブジェクトを `createI18n` オプションに渡すことができます。
+`Intl.PluralRules` による自動複数化はほとんどの言語で機能しますが、特殊なケースにはカスタムロジックが必要な場合があります。特定のロケールの自動動作をオーバーライドするために、`createI18n` オプションにオプションの `pluralRules` オブジェクトを渡すことができます。
 
 スラブ語派の言語（ロシア語、ウクライナ語など）のルールを使用した非常に単純化された例：
 

--- a/docs/jp/guide/migration/breaking12.md
+++ b/docs/jp/guide/migration/breaking12.md
@@ -507,6 +507,40 @@ v11 Legacy API では、`i18n.global` は `VueI18n` インスタンスを返し�
 
 `@intlify/vue-i18n/no-deprecated-v-t` ルールを使用して、コードベース内のすべての `v-t` の使用箇所を検出できます。
 
+## デフォルトの複数形が `Intl.PluralRules` を使用するようになりました
+
+**理由**: 以前のデフォルト複数形ルールは英語専用の単純な実装で、複雑な複数形カテゴリを持つ言語（ロシア語、アラビア語、ポーランド語など）を正しく処理できませんでした。Vue I18n v12 では、現在のロケールに基づいて正しい複数形を自動的に選択するために `Intl.PluralRules` を使用します。
+
+### 変更点
+
+- ロケールにカスタム `pluralRules` が設定されていない場合、Vue I18n は自動的に `Intl.PluralRules` を使用して正しい複数形カテゴリ（zero, one, two, few, many, other）を決定します
+- メッセージのケースは CLDR 複数形カテゴリの順序に従って並べる必要があります: `zero | one | two | few | many | other`（ロケールに存在するカテゴリのみ含む）
+- メッセージのケース数がロケールの複数形カテゴリ数を超える場合、Vue I18n は以前のデフォルトルールにフォールバックします
+- ランタイム環境で `Intl.PluralRules` が利用できない場合、Vue I18n は以前のデフォルトルールにフォールバックします
+
+### 移行
+
+カスタム `pluralRules` **なし**で英語以外のロケールの以前のデフォルトルールに依存していた場合、メッセージのケースをロケールの CLDR 複数形カテゴリの順序に合わせて並べ替える必要があります。
+
+**以前 (v11) — カスタム `pluralRules` 付きのロシア語:**
+
+変更不要。カスタム `pluralRules` が優先され、以前と同様に動作します。
+
+**以後 (v12) — ロシア語（自動、カスタム `pluralRules` 不要）:**
+
+```js
+const i18n = createI18n({
+  locale: 'ru',
+  // pluralRules 不要 — Intl.PluralRules が自動的に処理します
+  messages: {
+    ru: {
+      // 順序: one | few | many | other（ロシア語の CLDR 順序）
+      car: '{n} машина | {n} машины | {n} машин | {n} машин'
+    }
+  }
+})
+```
+
 ## `MissingHandler` シグネチャの変更
 
 **理由**: Vue 3.6+ では `getCurrentInstance()` API が非推奨になります。`MissingHandler` 型は以前、3 番目のパラメータとして `ComponentInternalInstance` を受け取っていましたが、これは使用できなくなりました。

--- a/docs/zh/guide/advanced/component.md
+++ b/docs/zh/guide/advanced/component.md
@@ -51,8 +51,15 @@ const url = ref('/term')
 <template>
   <div id="app">
     <!-- ... -->
-    <i18n-t keypath="term" tag="label" for="tos">
-      <a :href="url" target="_blank">{{ t('tos') }}</a>
+    <i18n-t
+      keypath="term"
+      tag="label"
+      for="tos"
+    >
+      <a
+        :href="url"
+        target="_blank"
+      >{{ t('tos') }}</a>
     </i18n-t>
     <!-- ... -->
   </div>
@@ -128,11 +135,14 @@ const refundLimit = ref(30)
 <template>
   <div id="app">
     <!-- ... -->
-    <i18n-t keypath="info" tag="p">
-      <template v-slot:limit>
+    <i18n-t
+      keypath="info"
+      tag="p"
+    >
+      <template #limit>
         <span>{{ changeLimit }}</span>
       </template>
-      <template v-slot:action>
+      <template #action>
         <a :href="changeUrl">{{ t('change') }}</a>
       </template>
     </i18n-t>

--- a/docs/zh/guide/essentials/local.md
+++ b/docs/zh/guide/essentials/local.md
@@ -157,7 +157,9 @@ const { t } = useI18n({
       <p>This is good service</p>
     </div>
     <div class="footer">
-      <button type="button">{{ t('buttons.save') }}</button>
+      <button type="button">
+        {{ t('buttons.save') }}
+      </button>
     </div>
   </div>
 </template>

--- a/docs/zh/guide/essentials/pluralization.md
+++ b/docs/zh/guide/essentials/pluralization.md
@@ -114,11 +114,44 @@ const messages = {
 <p>too many bananas</p>
 ```
 
-## 自定义复数形式
+## 使用 `Intl.PluralRules` 自动复数化
 
-然而，这种复数形式并不适用于所有语言（例如，斯拉夫语言有不同的复数规则）。
+Vue I18n 根据当前语言环境自动使用 [`Intl.PluralRules`](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules) 来选择正确的复数形式。这意味着对于大多数语言，您不需要编写自定义复数化规则——只需按照 CLDR 复数类别顺序提供正确数量的消息形式：`zero | one | two | few | many | other`。
 
-要实现这些规则，你可以将可选的 `pluralRules` 对象传递给 `createI18n` 选项。
+例如，俄语有4个复数类别（`one`、`few`、`many`、`other`）：
+
+```js
+const i18n = createI18n({
+  locale: 'ru',
+  messages: {
+    ru: {
+      car: '{n} машина | {n} машины | {n} машин | {n} машин',
+      //    one          few          many         other
+    }
+  }
+})
+```
+
+Vue I18n 将自动选择正确的形式：
+
+| 值 | `Intl.PluralRules` 类别 | 选择的形式 |
+|---|---|---|
+| 1 | `one` | `{n} машина` |
+| 2 | `few` | `{n} машины` |
+| 5 | `many` | `{n} машин` |
+| 21 | `one` | `{n} машина` |
+
+:::tip NOTE
+当消息的形式数量超过语言环境的复数类别数量时，Vue I18n 将回退到默认规则（适用于英语）。
+:::
+
+:::tip NOTE
+如果运行时环境中没有 `Intl.PluralRules`，Vue I18n 将回退到默认的基于英语的规则。
+:::
+
+## 自定义复数化
+
+虽然通过 `Intl.PluralRules` 进行的自动复数化适用于大多数语言，但对于特殊情况，您可能需要自定义逻辑。您可以将可选的 `pluralRules` 对象传递给 `createI18n` 选项，以覆盖特定语言环境的自动行为。
 
 使用斯拉夫语言（俄语、乌克兰语等）规则的非常简化的示例：
 

--- a/docs/zh/guide/migration/breaking12.md
+++ b/docs/zh/guide/migration/breaking12.md
@@ -507,6 +507,40 @@ i18n.global.setMissingHandler((locale, key) => { /* ... */ })
 
 您可以使用 `@intlify/vue-i18n/no-deprecated-v-t` 规则来检测代码库中所有的 `v-t` 用法。
 
+## 默认复数形式现在使用 `Intl.PluralRules`
+
+**原因**: 以前的默认复数形式规则是一个简单的仅适用于英语的实现，无法正确处理具有复杂复数类别的语言（例如俄语、阿拉伯语、波兰语）。Vue I18n v12 现在使用 `Intl.PluralRules` 根据当前语言环境自动选择正确的复数形式。
+
+### 变更内容
+
+- 当语言环境没有设置自定义 `pluralRules` 时，Vue I18n 自动使用 `Intl.PluralRules` 来确定正确的复数类别（zero、one、two、few、many、other）
+- 消息的各种形式必须按照 CLDR 复数类别顺序排列：`zero | one | two | few | many | other`（仅包含该语言环境中存在的类别）
+- 如果消息的形式数量超过语言环境的复数类别数量，Vue I18n 将回退到之前的默认规则
+- 如果运行时环境中没有 `Intl.PluralRules`，Vue I18n 将回退到之前的默认规则
+
+### 迁移
+
+如果您在**没有**自定义 `pluralRules` 的情况下依赖非英语语言环境的之前默认规则，您需要重新排列消息的形式以匹配该语言环境的 CLDR 复数类别顺序。
+
+**之前 (v11) — 带自定义 `pluralRules` 的俄语：**
+
+无需更改。自定义 `pluralRules` 优先，并继续像以前一样工作。
+
+**之后 (v12) — 俄语（自动，无需自定义 `pluralRules`）：**
+
+```js
+const i18n = createI18n({
+  locale: 'ru',
+  // 不需要 pluralRules — Intl.PluralRules 自动处理
+  messages: {
+    ru: {
+      // 顺序：one | few | many | other（俄语的 CLDR 顺序）
+      car: '{n} машина | {n} машины | {n} машин | {n} машин'
+    }
+  }
+})
+```
+
 ## 更改 `MissingHandler` 签名
 
 **原因**: Vue 3.6+ 弃用了 `getCurrentInstance()` API。`MissingHandler` 类型以前接收 `ComponentInternalInstance` 作为第三个参数，但这不再可用。


### PR DESCRIPTION
resolve #2020 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic pluralization using Intl.PluralRules for multi-language support with CLDR-compliant plural categories.

* **Documentation**
  * Updated guides with Vue 3 syntax improvements and clearer examples.
  * Added comprehensive migration guidance for pluralization behavior in v12.
  * Translated documentation updates across English, Japanese, and Chinese.

* **Tests**
  * Added test coverage for new Intl.PluralRules-based pluralization behavior.

* **Chores**
  * Updated ignore patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->