### PR TITLE
fix: wrong $d type

### DIFF
--- a/packages/vue-i18n-core/test/composer.test-d.ts
+++ b/packages/vue-i18n-core/test/composer.test-d.ts
@@ -343,6 +343,13 @@ test('strict composer with direct options', () => {
     })
   ).toEqualTypeOf<Intl.DateTimeFormatPart[]>()
 
+  // ComposerDateTimeFormatting with ISO 8601 string
+  expectTypeOf(strictDirectComposer.d('2022-08-08T08:56:45.846Z')).toEqualTypeOf<string>()
+  expectTypeOf(strictDirectComposer.d('2022-08-08T08:56:45.846Z', 'short')).toEqualTypeOf<string>()
+  expectTypeOf(
+    strictDirectComposer.d('2022-08-08T08:56:45.846Z', { key: 'short', locale: 'zh' })
+  ).toEqualTypeOf<string>()
+
   // ComposerNumberFormatting
   expectTypeOf(strictDirectComposer.n(1)).toEqualTypeOf<string>()
   expectTypeOf(strictDirectComposer.n(1, 'currency', 'zh')).toEqualTypeOf<string>()

--- a/packages/vue-i18n/src/vue.d.ts
+++ b/packages/vue-i18n/src/vue.d.ts
@@ -600,7 +600,7 @@ declare module 'vue' {
      * @returns formatted value
      */
     $d<
-      Value extends number | Date = number,
+      Value extends number | Date | string = number,
       Key extends string = string,
       DefinedDateTimeFormat extends RemovedIndexResources<DefineDateTimeFormat> =
         RemovedIndexResources<DefineDateTimeFormat>,

--- a/packages/vue-i18n/src/vue.ts
+++ b/packages/vue-i18n/src/vue.ts
@@ -602,7 +602,7 @@ export interface ComponentCustomProperties {
    * @returns formatted value
    */
   $d<
-    Value extends number | Date = number,
+    Value extends number | Date | string = number,
     Key extends string = string,
     DefinedDateTimeFormat extends RemovedIndexResources<DefineDateTimeFormat> =
       RemovedIndexResources<DefineDateTimeFormat>,


### PR DESCRIPTION
resolve #1113

related #2098 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DateTime formatting function now accepts ISO 8601 string inputs (e.g., '2022-08-08T08:56:45.846Z') in addition to Date objects, providing greater flexibility when formatting dates from various data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->