### PR TITLE
fix: te returns false if the key contains a do

### DIFF
--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -2322,7 +2322,11 @@ export function createComposer(options: any = {}): any {
         }
         const targetLocale = isString(locale) ? locale : _locale.value
         const message = getLocaleMessage(targetLocale)
-        const resolved = _context.messageResolver(message, key)
+        let resolved = _context.messageResolver(message, key)
+        // if null, resolve with object key path (for flat keys containing dots)
+        if (resolved === null) {
+          resolved = (message as any)[key]
+        }
         return isMessageAST(resolved) || isMessageFunction(resolved) || isString(resolved)
       },
       () => [key],

--- a/packages/vue-i18n-core/test/composer.test.ts
+++ b/packages/vue-i18n-core/test/composer.test.ts
@@ -1524,6 +1524,29 @@ test('te', async () => {
   expect(te('')).toEqual(false)
 })
 
+test('te with flat key containing dots', () => {
+  const { te, t } = createComposer({
+    locale: 'en',
+    messages: {
+      en: {
+        'key.exampleNestedKey': 'Translation',
+        'key2.exampleNestedKey.evenMoreNesting': 'Translation2'
+      }
+    }
+  })
+
+  // t() resolves flat keys correctly
+  expect(t('key.exampleNestedKey')).toEqual('Translation')
+  expect(t('key2.exampleNestedKey.evenMoreNesting')).toEqual('Translation2')
+
+  // te() should also return true for flat keys
+  expect(te('key.exampleNestedKey')).toEqual(true)
+  expect(te('key2.exampleNestedKey.evenMoreNesting')).toEqual(true)
+
+  // non-existent key should still return false
+  expect(te('key.nonExistent')).toEqual(false)
+})
+
 describe('getLocaleMessage / setLocaleMessage / mergeLocaleMessage', () => {
   test('basic', () => {
     const { getLocaleMessage, setLocaleMessage, mergeLocaleMessage } = createComposer({


### PR DESCRIPTION
resolve #2375 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved translation key resolution to properly handle flat keys containing dots.

* **Tests**
  * Added test coverage for flat keys containing dots in translation lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->