### PR TITLE
fix: modifiers skip missing translation keys

### DIFF
--- a/packages/core-base/src/runtime.ts
+++ b/packages/core-base/src/runtime.ts
@@ -432,9 +432,11 @@ export function createMessageContext<T = string, N = {}>(
       }
     }
     const ret = message(key, true)(ctx)
+    // If the linked message is not resolved (empty string), fall back to the key itself
+    const resolved = ret === '' || ret === undefined ? (key as unknown as MessageType<T>) : ret
     const msg =
       // The message in vnode resolved with linked are returned as an array by processor.nomalize
-      type === 'vnode' && isArray(ret) && modifier ? ret[0] : (ret as MessageType<T>)
+      type === 'vnode' && isArray(resolved) && modifier ? resolved[0] : (resolved as MessageType<T>)
     return modifier ? _modifier(modifier)(msg as T, type) : msg
   }
 

--- a/packages/core-base/test/translate.test.ts
+++ b/packages/core-base/test/translate.test.ts
@@ -88,6 +88,18 @@ describe('features', () => {
     expect(translate(ctx, 'hi')).toEqual('hi KAZUPON !')
   })
 
+  test('linked with modifier and missing key', () => {
+    const ctx = context({
+      locale: 'en',
+      messages: {
+        en: {
+          greeting: 'hello @.upper:nonExistent !'
+        }
+      }
+    })
+    expect(translate(ctx, 'greeting')).toEqual('hello NONEXISTENT !')
+  })
+
   test('plural', () => {
     const ctx = context({
       locale: 'en',


### PR DESCRIPTION
resolve #2121 

related #2098

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved fallback behavior for linked messages with missing keys—modifiers are now correctly applied to the fallback key, ensuring proper message resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->