### PR TITLE
fix: Numeric named parameter overwrites plural parameter in pluralization

### DIFF
--- a/packages/core-base/src/runtime.ts
+++ b/packages/core-base/src/runtime.ts
@@ -379,8 +379,8 @@ export function createMessageContext<T = string, N = {}>(
   const _named = options.named || (create() as any)
   // normalize named
   if (isNumber(options.pluralIndex)) {
-    _named.count ||= options.pluralIndex
-    _named.n ||= options.pluralIndex
+    _named.count ??= options.pluralIndex
+    _named.n ??= options.pluralIndex
   }
   const named = (key: string): unknown => _named[key]
 

--- a/packages/core-base/test/translate.test.ts
+++ b/packages/core-base/test/translate.test.ts
@@ -125,6 +125,22 @@ describe('features', () => {
     // plural=2 (second form), named.n=1 → should select "{n}" and display 1
     expect(translate(ctx, 'test', { n: 1 }, 2)).toEqual('1')
   })
+
+  test('plural with named n=0 should preserve zero value', () => {
+    const ctx = context({
+      locale: 'en',
+      messages: {
+        en: {
+          testN: 'none | {n} item | {n} items',
+          testCount: 'none | {count} item | {count} items'
+        }
+      }
+    })
+    // named.n=0 with plural=3 → should select third form and display n=0
+    expect(translate(ctx, 'testN', { n: 0 }, 3)).toEqual('0 items')
+    // named.count=0 with plural=3 → should select third form and display count=0
+    expect(translate(ctx, 'testCount', { count: 0 }, 3)).toEqual('0 items')
+  })
 })
 
 describe('locale option', () => {


### PR DESCRIPTION
resolve #2120 

related #2098 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plural selection now consistently respects an explicit plural index over named parameters, preventing incorrect form overrides and ensuring the intended plural form is shown.
  * Named parameter values of 0 are preserved and displayed correctly when selecting plural forms.

* **Tests**
  * Added tests validating plural selection priority and correct handling/display of n=0 in plural outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->