### PR TITLE
fix: te function returns false although fallback exists

### DIFF
--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -2321,7 +2321,11 @@ export function createComposer(options: any = {}): any {
           return false
         }
         const targetLocale = isString(locale) ? locale : _locale.value
-        const locales = fallbackWithLocaleChain(_context, _fallbackLocale.value, targetLocale)
+        // When locale is explicitly specified, check only that locale (no fallback chain)
+        // When locale is not specified, check the fallback locale chain
+        const locales = isString(locale)
+          ? [targetLocale]
+          : fallbackWithLocaleChain(_context, _fallbackLocale.value, targetLocale)
         for (let i = 0; i < locales.length; i++) {
           const message = getLocaleMessage(locales[i])
           let resolved = _context.messageResolver(message, key)

--- a/packages/vue-i18n-core/test/composer.test.ts
+++ b/packages/vue-i18n-core/test/composer.test.ts
@@ -1562,12 +1562,17 @@ test('te with fallback locale chain', () => {
     }
   })
 
-  // exists in de-AT
+  // exists in de-AT (implicit locale)
   expect(te('hello')).toEqual(true)
-  // exists only in de (fallback)
+  // exists only in de (implicit fallback)
   expect(te('onlyDe')).toEqual(true)
   // does not exist in any locale
   expect(te('nonExistent')).toEqual(false)
+
+  // explicit locale checks
+  expect(te('hello', 'de-AT')).toEqual(true)
+  expect(te('onlyDe', 'de-AT')).toEqual(false)
+  expect(te('onlyDe', 'de')).toEqual(true)
 })
 
 describe('getLocaleMessage / setLocaleMessage / mergeLocaleMessage', () => {


### PR DESCRIPTION
resolve #1765

related #2098 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Translation key existence checking now properly searches across configured fallback locales, matching actual translation resolution and avoiding false negatives.

* **Tests**
  * Updated tests to validate fallback-aware existence checks and reflect the new lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->