### PR TITLE
docs: more details for `availableLocales`

### DIFF
--- a/docs/guide/advanced/lazy.md
+++ b/docs/guide/advanced/lazy.md
@@ -88,6 +88,10 @@ You can learn more about the import function in the [webpack documentation](http
 
 Using the `loadLocaleMessages` function is straightforward. A common use case is inside a vue-router beforeEach hook.
 
+:::tip NOTE
+`i18n.global.availableLocales` is a **read-only computed property** that returns the locales currently registered in `messages`. It is automatically updated when you add messages via `setLocaleMessage` or `loadLocaleMessages`. You cannot set it directly via `createI18n` options — use a separate constant like `SUPPORT_LOCALES` to define the full list of locales your application supports.
+:::
+
 Here the code for the vue-router beforeEach hook part of `router.js`:
 
 ```js

--- a/docs/jp/guide/advanced/lazy.md
+++ b/docs/jp/guide/advanced/lazy.md
@@ -88,6 +88,10 @@ export async function loadLocaleMessages(i18n, locale) {
 
 `loadLocaleMessages` 関数の使用は簡単です。一般的な使用例は、vue-router の beforeEach フック内です。
 
+:::tip NOTE
+`i18n.global.availableLocales` は `messages` に現在登録されているロケールを返す**読み取り専用の算出プロパティ**です。`setLocaleMessage` や `loadLocaleMessages` でメッセージを追加すると自動的に更新されます。`createI18n` のオプションで直接設定することはできません。アプリケーションがサポートするロケールの完全なリストを定義するには、`SUPPORT_LOCALES` のような別の定数を使用してください。
+:::
+
 `router.js` の vue-router beforeEach フック部分のコードは次のとおりです：
 
 ```js

--- a/docs/zh/guide/advanced/lazy.md
+++ b/docs/zh/guide/advanced/lazy.md
@@ -88,6 +88,10 @@ export async function loadLocaleMessages(i18n, locale) {
 
 使用 `loadLocaleMessages` 函数很简单。常见的用例是在 vue-router beforeEach 钩子中。
 
+:::tip NOTE
+`i18n.global.availableLocales` 是一个**只读计算属性**，返回当前在 `messages` 中注册的区域设置。当您通过 `setLocaleMessage` 或 `loadLocaleMessages` 添加消息时，它会自动更新。不能通过 `createI18n` 选项直接设置它。要定义应用程序支持的完整区域设置列表，请使用单独的常量，如 `SUPPORT_LOCALES`。
+:::
+
 这是 `router.js` 中 vue-router beforeEach 钩子部分的代码：
 
 ```js


### PR DESCRIPTION
resolve #1158

related #2098 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation with a tip explaining that `availableLocales` is a read-only property automatically reflecting registered locales, which updates when new locales are added via message loading.
  * Clarified best practices for defining supported locales using a separate constant.
  * Updated guides in English, Japanese, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->