### PR TITLE
fix: Resource Keys completion does not work with global messages and $t

### DIFF
--- a/packages/petite-vue-i18n/src/vue.d.ts
+++ b/packages/petite-vue-i18n/src/vue.d.ts
@@ -63,7 +63,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -73,7 +72,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number
+      key: ResourceKeys | (string & {}) | number
     ): string
     /**
      * Locale message translation
@@ -87,7 +86,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -97,7 +95,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       plural: number
     ): string
     /**
@@ -113,7 +111,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -123,7 +120,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       plural: number,
       options: TranslateOptions
     ): string
@@ -139,7 +136,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -149,7 +145,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       defaultMsg: string
     ): string
     /**
@@ -165,7 +161,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -175,7 +170,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       defaultMsg: string,
       options: TranslateOptions
     ): string
@@ -191,7 +186,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -201,7 +195,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       list: unknown[]
     ): string
     /**
@@ -217,7 +211,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -227,7 +220,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       list: unknown[],
       plural: number
     ): string
@@ -244,7 +237,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -254,7 +246,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       list: unknown[],
       defaultMsg: string
     ): string
@@ -271,7 +263,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -281,7 +272,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       list: unknown[],
       options: TranslateOptions
     ): string
@@ -297,7 +288,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -307,7 +297,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       named: NamedValue
     ): string
     /**
@@ -323,7 +313,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -333,7 +322,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       named: NamedValue,
       plural: number
     ): string
@@ -350,7 +339,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -360,7 +348,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       named: NamedValue,
       defaultMsg: string
     ): string
@@ -377,7 +365,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -387,7 +374,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       named: NamedValue,
       options: TranslateOptions
     ): string

--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -663,7 +663,7 @@ export interface ComposerTranslation<
    * @returns Translated message
    *
    */
-  <Key extends string>(key: Key | ResourceKeys | number): string
+  (key: ResourceKeys | (string & {}) | number): string
   /**
    * Locale message translation for plurals
    *
@@ -682,7 +682,7 @@ export interface ComposerTranslation<
    *
    * @returns Translated message
    */
-  <Key extends string>(key: Key | ResourceKeys | number, plural: number): string
+  (key: ResourceKeys | (string & {}) | number, plural: number): string
   /**
    * Locale message translation for plurals
    *
@@ -704,8 +704,8 @@ export interface ComposerTranslation<
    *
    * @returns Translated message
    */
-  <Key extends string>(
-    key: Key | ResourceKeys | number,
+  (
+    key: ResourceKeys | (string & {}) | number,
     plural: number,
     options: TranslateOptions<Locales>
   ): string
@@ -724,7 +724,7 @@ export interface ComposerTranslation<
    *
    * @returns Translated message
    */
-  <Key extends string>(key: Key | ResourceKeys | number, defaultMsg: string): string
+  (key: ResourceKeys | (string & {}) | number, defaultMsg: string): string
   /**
    * Locale message translation for missing default message
    *
@@ -743,8 +743,8 @@ export interface ComposerTranslation<
    *
    * @returns Translated message
    */
-  <Key extends string>(
-    key: Key | ResourceKeys | number,
+  (
+    key: ResourceKeys | (string & {}) | number,
     defaultMsg: string,
     options: TranslateOptions<Locales>
   ): string
@@ -766,7 +766,7 @@ export interface ComposerTranslation<
    *
    * @returns Translated message
    */
-  <Key extends string>(key: Key | ResourceKeys | number, list: unknown[]): string
+  (key: ResourceKeys | (string & {}) | number, list: unknown[]): string
   /**
    * Locale message translation for list interpolations and plurals
    *
@@ -785,7 +785,7 @@ export interface ComposerTranslation<
    *
    * @returns Translated message
    */
-  <Key extends string>(key: Key | ResourceKeys | number, list: unknown[], plural: number): string
+  (key: ResourceKeys | (string & {}) | number, list: unknown[], plural: number): string
   /**
    * Locale message translation for list interpolations and missing default message
    *
@@ -803,11 +803,7 @@ export interface ComposerTranslation<
    *
    * @returns Translated message
    */
-  <Key extends string>(
-    key: Key | ResourceKeys | number,
-    list: unknown[],
-    defaultMsg: string
-  ): string
+  (key: ResourceKeys | (string & {}) | number, list: unknown[], defaultMsg: string): string
   /**
    * Locale message translation for list interpolations
    *
@@ -829,8 +825,8 @@ export interface ComposerTranslation<
    *
    * @returns Translated message
    */
-  <Key extends string>(
-    key: Key | ResourceKeys | number,
+  (
+    key: ResourceKeys | (string & {}) | number,
     list: unknown[],
     options: TranslateOptions<Locales>
   ): string
@@ -852,7 +848,7 @@ export interface ComposerTranslation<
    *
    * @returns Translated message
    */
-  <Key extends string>(key: Key | ResourceKeys | number, named: NamedValue): string
+  (key: ResourceKeys | (string & {}) | number, named: NamedValue): string
   /**
    * Locale message translation for named interpolations and plurals
    *
@@ -871,7 +867,7 @@ export interface ComposerTranslation<
    *
    * @returns Translated message
    */
-  <Key extends string>(key: Key | ResourceKeys | number, named: NamedValue, plural: number): string
+  (key: ResourceKeys | (string & {}) | number, named: NamedValue, plural: number): string
   /**
    * Locale message translation for named interpolations and plurals
    *
@@ -889,11 +885,7 @@ export interface ComposerTranslation<
    *
    * @returns Translated message
    */
-  <Key extends string>(
-    key: Key | ResourceKeys | number,
-    named: NamedValue,
-    defaultMsg: string
-  ): string
+  (key: ResourceKeys | (string & {}) | number, named: NamedValue, defaultMsg: string): string
   /**
    * Locale message translation for named interpolations
    *
@@ -915,8 +907,8 @@ export interface ComposerTranslation<
    *
    * @returns Translated message
    */
-  <Key extends string>(
-    key: Key | ResourceKeys | number,
+  (
+    key: ResourceKeys | (string & {}) | number,
     named: NamedValue,
     options: TranslateOptions<Locales>
   ): string

--- a/packages/vue-i18n-core/test/i18n.test.ts
+++ b/packages/vue-i18n-core/test/i18n.test.ts
@@ -21,7 +21,7 @@ import {
   registerMessageResolver,
   resolveValue
 } from '@intlify/core-base'
-import { defineComponent, defineCustomElement, h, nextTick, ref } from 'vue'
+import { createApp, defineComponent, defineCustomElement, h, nextTick, ref } from 'vue'
 import { errorMessages, I18nErrorCodes } from '../src/errors'
 import { createI18n, useI18n } from '../src/i18n'
 import { getCurrentInstance } from '../src/utils'
@@ -558,6 +558,55 @@ describe('useI18n', () => {
       expect((composer as Composer).t('globalKey')).toEqual('from global')
     })
   })
+})
+
+test('reuse i18n instance after dispose', async () => {
+  const i18n = createI18n({
+    locale: 'en',
+    messages: {
+      en: { hello: 'Hello' },
+      de: { hello: 'Hallo' }
+    }
+  })
+
+  // First app: mount, verify, unmount (unmount triggers dispose via install wrapper)
+  const App1 = defineComponent({
+    setup() {
+      const { t } = useI18n()
+      return { t }
+    },
+    template: '<p>{{ t("hello") }}</p>'
+  })
+  const app1 = createApp(App1)
+  app1.use(i18n)
+  const el1 = document.createElement('div')
+  document.body.appendChild(el1)
+  app1.mount(el1)
+  expect(i18n.global.t('hello')).toEqual('Hello')
+  // unmount triggers dispose (globalScope.stop())
+  app1.unmount()
+  el1.remove()
+
+  // Second app: mount same i18n, should still work
+  const App2 = defineComponent({
+    setup() {
+      const { t } = useI18n()
+      return { t }
+    },
+    template: '<p>{{ t("hello") }}</p>'
+  })
+  const app2 = createApp(App2)
+  app2.use(i18n)
+  const el2 = document.createElement('div')
+  document.body.appendChild(el2)
+  app2.mount(el2)
+
+  expect(i18n.global.t('hello')).toEqual('Hello')
+  i18n.global.locale.value = 'de'
+  expect(i18n.global.t('hello')).toEqual('Hallo')
+
+  app2.unmount()
+  el2.remove()
 })
 
 test('slot reactivity', async () => {

--- a/packages/vue-i18n/src/vue.d.ts
+++ b/packages/vue-i18n/src/vue.d.ts
@@ -75,7 +75,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -85,7 +84,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number
+      key: ResourceKeys | (string & {}) | number
     ): string
     /**
      * Locale message translation
@@ -99,7 +98,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -109,7 +107,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       plural: number
     ): string
     /**
@@ -125,7 +123,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -135,7 +132,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       plural: number,
       options: TranslateOptions
     ): string
@@ -151,7 +148,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -161,7 +157,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       defaultMsg: string
     ): string
     /**
@@ -177,7 +173,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -187,7 +182,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       defaultMsg: string,
       options: TranslateOptions
     ): string
@@ -203,7 +198,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -213,7 +207,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       list: unknown[]
     ): string
     /**
@@ -229,7 +223,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -239,7 +232,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       list: unknown[],
       plural: number
     ): string
@@ -256,7 +249,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -266,7 +258,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       list: unknown[],
       defaultMsg: string
     ): string
@@ -283,7 +275,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -293,7 +284,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       list: unknown[],
       options: TranslateOptions
     ): string
@@ -309,7 +300,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -319,7 +309,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       named: NamedValue
     ): string
     /**
@@ -335,7 +325,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -345,7 +334,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       named: NamedValue,
       plural: number
     ): string
@@ -362,7 +351,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -372,7 +360,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       named: NamedValue,
       defaultMsg: string
     ): string
@@ -389,7 +377,6 @@ declare module 'vue' {
      * @returns translation message
      */
     $t<
-      Key extends string,
       DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
         RemovedIndexResources<DefineLocaleMessage>,
       Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -399,7 +386,7 @@ declare module 'vue' {
         : never,
       ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
     >(
-      key: Key | ResourceKeys | number,
+      key: ResourceKeys | (string & {}) | number,
       named: NamedValue,
       options: TranslateOptions
     ): string

--- a/packages/vue-i18n/src/vue.ts
+++ b/packages/vue-i18n/src/vue.ts
@@ -77,7 +77,6 @@ export interface ComponentCustomProperties {
    * @returns translation message
    */
   $t<
-    Key extends string,
     DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
       RemovedIndexResources<DefineLocaleMessage>,
     Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -87,7 +86,7 @@ export interface ComponentCustomProperties {
       : never,
     ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
   >(
-    key: Key | ResourceKeys | number
+    key: ResourceKeys | (string & {}) | number
   ): string
   /**
    * Locale message translation
@@ -101,7 +100,6 @@ export interface ComponentCustomProperties {
    * @returns translation message
    */
   $t<
-    Key extends string,
     DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
       RemovedIndexResources<DefineLocaleMessage>,
     Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -111,7 +109,7 @@ export interface ComponentCustomProperties {
       : never,
     ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
   >(
-    key: Key | ResourceKeys | number,
+    key: ResourceKeys | (string & {}) | number,
     plural: number
   ): string
   /**
@@ -127,7 +125,6 @@ export interface ComponentCustomProperties {
    * @returns translation message
    */
   $t<
-    Key extends string,
     DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
       RemovedIndexResources<DefineLocaleMessage>,
     Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -137,7 +134,7 @@ export interface ComponentCustomProperties {
       : never,
     ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
   >(
-    key: Key | ResourceKeys | number,
+    key: ResourceKeys | (string & {}) | number,
     plural: number,
     options: TranslateOptions
   ): string
@@ -153,7 +150,6 @@ export interface ComponentCustomProperties {
    * @returns translation message
    */
   $t<
-    Key extends string,
     DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
       RemovedIndexResources<DefineLocaleMessage>,
     Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -163,7 +159,7 @@ export interface ComponentCustomProperties {
       : never,
     ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
   >(
-    key: Key | ResourceKeys | number,
+    key: ResourceKeys | (string & {}) | number,
     defaultMsg: string
   ): string
   /**
@@ -179,7 +175,6 @@ export interface ComponentCustomProperties {
    * @returns translation message
    */
   $t<
-    Key extends string,
     DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
       RemovedIndexResources<DefineLocaleMessage>,
     Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -189,7 +184,7 @@ export interface ComponentCustomProperties {
       : never,
     ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
   >(
-    key: Key | ResourceKeys | number,
+    key: ResourceKeys | (string & {}) | number,
     defaultMsg: string,
     options: TranslateOptions
   ): string
@@ -205,7 +200,6 @@ export interface ComponentCustomProperties {
    * @returns translation message
    */
   $t<
-    Key extends string,
     DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
       RemovedIndexResources<DefineLocaleMessage>,
     Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -215,7 +209,7 @@ export interface ComponentCustomProperties {
       : never,
     ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
   >(
-    key: Key | ResourceKeys | number,
+    key: ResourceKeys | (string & {}) | number,
     list: unknown[]
   ): string
   /**
@@ -231,7 +225,6 @@ export interface ComponentCustomProperties {
    * @returns translation message
    */
   $t<
-    Key extends string,
     DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
       RemovedIndexResources<DefineLocaleMessage>,
     Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -241,7 +234,7 @@ export interface ComponentCustomProperties {
       : never,
     ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
   >(
-    key: Key | ResourceKeys | number,
+    key: ResourceKeys | (string & {}) | number,
     list: unknown[],
     plural: number
   ): string
@@ -258,7 +251,6 @@ export interface ComponentCustomProperties {
    * @returns translation message
    */
   $t<
-    Key extends string,
     DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
       RemovedIndexResources<DefineLocaleMessage>,
     Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -268,7 +260,7 @@ export interface ComponentCustomProperties {
       : never,
     ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
   >(
-    key: Key | ResourceKeys | number,
+    key: ResourceKeys | (string & {}) | number,
     list: unknown[],
     defaultMsg: string
   ): string
@@ -285,7 +277,6 @@ export interface ComponentCustomProperties {
    * @returns translation message
    */
   $t<
-    Key extends string,
     DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
       RemovedIndexResources<DefineLocaleMessage>,
     Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -295,7 +286,7 @@ export interface ComponentCustomProperties {
       : never,
     ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
   >(
-    key: Key | ResourceKeys | number,
+    key: ResourceKeys | (string & {}) | number,
     list: unknown[],
     options: TranslateOptions
   ): string
@@ -311,7 +302,6 @@ export interface ComponentCustomProperties {
    * @returns translation message
    */
   $t<
-    Key extends string,
     DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
       RemovedIndexResources<DefineLocaleMessage>,
     Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -321,7 +311,7 @@ export interface ComponentCustomProperties {
       : never,
     ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
   >(
-    key: Key | ResourceKeys | number,
+    key: ResourceKeys | (string & {}) | number,
     named: NamedValue
   ): string
   /**
@@ -337,7 +327,6 @@ export interface ComponentCustomProperties {
    * @returns translation message
    */
   $t<
-    Key extends string,
     DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
       RemovedIndexResources<DefineLocaleMessage>,
     Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -347,7 +336,7 @@ export interface ComponentCustomProperties {
       : never,
     ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
   >(
-    key: Key | ResourceKeys | number,
+    key: ResourceKeys | (string & {}) | number,
     named: NamedValue,
     plural: number
   ): string
@@ -364,7 +353,6 @@ export interface ComponentCustomProperties {
    * @returns translation message
    */
   $t<
-    Key extends string,
     DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
       RemovedIndexResources<DefineLocaleMessage>,
     Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -374,7 +362,7 @@ export interface ComponentCustomProperties {
       : never,
     ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
   >(
-    key: Key | ResourceKeys | number,
+    key: ResourceKeys | (string & {}) | number,
     named: NamedValue,
     defaultMsg: string
   ): string
@@ -391,7 +379,6 @@ export interface ComponentCustomProperties {
    * @returns translation message
    */
   $t<
-    Key extends string,
     DefinedLocaleMessage extends RemovedIndexResources<DefineLocaleMessage> =
       RemovedIndexResources<DefineLocaleMessage>,
     Keys = IsEmptyObject<DefinedLocaleMessage> extends false
@@ -401,7 +388,7 @@ export interface ComponentCustomProperties {
       : never,
     ResourceKeys extends Keys = IsNever<Keys> extends false ? Keys : never
   >(
-    key: Key | ResourceKeys | number,
+    key: ResourceKeys | (string & {}) | number,
     named: NamedValue,
     options: TranslateOptions
   ): string


### PR DESCRIPTION
resolve #1124 

related #2098 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined type definitions for translation methods to support broader string key acceptance across all API overloads.

* **Tests**
  * Added test coverage for reusing translation instances across multiple application lifecycle cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->