### PR TITLE
docs: add possible errors for number/datetime formatter APIs

### DIFF
--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -1073,6 +1073,8 @@ export interface ComposerDateTimeFormatting<
    * See about:
    * - [Datetime formatting](../../../guide/essentials/datetime)
    *
+   * @throws Error if `value` is not a valid date value.
+   *
    * @param value - A value, timestamp number or `Date` instance or ISO 8601 string
    *
    * @returns Formatted value
@@ -1169,6 +1171,8 @@ export interface ComposerNumberFormatting<
    *
    * See about:
    * - [Number formatting](../../../guide/essentials/number)
+   *
+   * @throws Error if `value` is not a number.
    *
    * @param value - A number value
    *


### PR DESCRIPTION
## Summary
- documents possible runtime errors for `ComposerNumberFormatting.n()`
- documents possible runtime errors for `ComposerDateTimeFormatting.d()`
- adds `@throws` notes in source TSDoc so generated API docs include this behavior

## Related issue
resolves #1749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved error documentation for date-time and number formatting functions, now clearly indicating when exceptions are thrown for invalid date values or non-numeric inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->