### PR TITLE
perf: use `shallowRef` server-side for datetimeFormats

### DIFF
--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -2008,7 +2008,7 @@ export function createComposer(options: any = {}): any {
         ? options.datetimeFormats
         : { [_locale.value]: {} }
     )
-    : /* #__PURE__*/ ref<DateTimeFormatsType>({})
+    : /* #__PURE__*/ _ref<DateTimeFormatsType>({})
 
   // prettier-ignore
   const _numberFormats = !__LITE__


### PR DESCRIPTION
just back-ported from #2333