### PR TITLE
fix: Usage of `n()` and `$n()` with `undefined` should not throw errors

### DIFF
--- a/packages/core-base/src/datetime.ts
+++ b/packages/core-base/src/datetime.ts
@@ -208,6 +208,17 @@ export function datetime<
     return MISSING_RESOLVE_VALUE
   }
 
+  if (!isString(args[0]) && !isDate(args[0]) && !isNumber(args[0])) {
+    if (__DEV__) {
+      onWarn(
+        getWarnMessage(CoreWarnCodes.INVALID_DATE_ARGUMENT, {
+          value: String(args[0])
+        })
+      )
+    }
+    return MISSING_RESOLVE_VALUE
+  }
+
   const [key, value, options, overrides] = parseDateTimeArgs(...args)
   const missingWarn = isBoolean(options.missingWarn)
     ? options.missingWarn

--- a/packages/core-base/src/number.ts
+++ b/packages/core-base/src/number.ts
@@ -203,6 +203,17 @@ export function number<
     return MISSING_RESOLVE_VALUE
   }
 
+  if (!isNumber(args[0])) {
+    if (__DEV__) {
+      onWarn(
+        getWarnMessage(CoreWarnCodes.INVALID_NUMBER_ARGUMENT, {
+          value: String(args[0])
+        })
+      )
+    }
+    return MISSING_RESOLVE_VALUE
+  }
+
   const [key, value, options, overrides] = parseNumberArgs(...args)
   const missingWarn = isBoolean(options.missingWarn)
     ? options.missingWarn

--- a/packages/core-base/src/warnings.ts
+++ b/packages/core-base/src/warnings.ts
@@ -7,10 +7,12 @@ export const CoreWarnCodes = {
   FALLBACK_TO_NUMBER_FORMAT: 4,
   CANNOT_FORMAT_DATE: 5,
   FALLBACK_TO_DATE_FORMAT: 6,
-  EXPERIMENTAL_CUSTOM_MESSAGE_COMPILER: 7
+  EXPERIMENTAL_CUSTOM_MESSAGE_COMPILER: 7,
+  INVALID_NUMBER_ARGUMENT: 8,
+  INVALID_DATE_ARGUMENT: 9
 } as const
 
-export const CORE_WARN_CODES_EXTEND_POINT = 8
+export const CORE_WARN_CODES_EXTEND_POINT = 10
 
 export type CoreWarnCodes = (typeof CoreWarnCodes)[keyof typeof CoreWarnCodes]
 
@@ -22,7 +24,9 @@ export const warnMessages: { [code: number]: string } = {
   [CoreWarnCodes.FALLBACK_TO_NUMBER_FORMAT]: `Fall back to number format '{key}' key with '{target}' locale.`,
   [CoreWarnCodes.CANNOT_FORMAT_DATE]: `Cannot format a date value due to not supported Intl.DateTimeFormat.`,
   [CoreWarnCodes.FALLBACK_TO_DATE_FORMAT]: `Fall back to datetime format '{key}' key with '{target}' locale.`,
-  [CoreWarnCodes.EXPERIMENTAL_CUSTOM_MESSAGE_COMPILER]: `This project is using Custom Message Compiler, which is an experimental feature. It may receive breaking changes or be removed in the future.`
+  [CoreWarnCodes.EXPERIMENTAL_CUSTOM_MESSAGE_COMPILER]: `This project is using Custom Message Compiler, which is an experimental feature. It may receive breaking changes or be removed in the future.`,
+  [CoreWarnCodes.INVALID_NUMBER_ARGUMENT]: `Invalid argument for number formatting: expected a number but received '{value}'.`,
+  [CoreWarnCodes.INVALID_DATE_ARGUMENT]: `Invalid argument for datetime formatting: expected a Date, number, or ISO string but received '{value}'.`
 }
 
 export function getWarnMessage(

--- a/packages/core-base/test/datetime.test.ts
+++ b/packages/core-base/test/datetime.test.ts
@@ -349,9 +349,8 @@ describe('error', () => {
       datetime(ctx, '2020-01-01TSomeDefinitelyInvalidString')
     }).toThrowError(errorMessages[CoreErrorCodes.INVALID_ISO_DATE_ARGUMENT])
 
-    expect(() => {
-      datetime(ctx, { someObject: true } as any)
-    }).toThrowError(errorMessages[CoreErrorCodes.INVALID_ARGUMENT])
+    expect(datetime(ctx, { someObject: true } as any)).toEqual('')
+    expect(datetime(ctx, undefined as any)).toEqual('')
 
     expect(() => {
       datetime(ctx, new Date('invalid'))

--- a/packages/core-base/test/number.test.ts
+++ b/packages/core-base/test/number.test.ts
@@ -300,7 +300,7 @@ test('not available Intl API', () => {
 })
 
 describe('error', () => {
-  test(errorMessages[CoreErrorCodes.INVALID_ARGUMENT], () => {
+  test('invalid argument should warn and return empty string', () => {
     const mockWarn = vi.spyOn(shared, 'warn')
     mockWarn.mockImplementation(() => {})
     const mockAvailabilities = Availabilities
@@ -309,9 +309,8 @@ describe('error', () => {
       locale: 'en-US',
       numberFormats
     })
-    expect(() => {
-      number(ctx, '111' as any)
-    }).toThrowError(errorMessages[CoreErrorCodes.INVALID_ARGUMENT])
+    expect(number(ctx, '111' as any)).toEqual('')
+    expect(number(ctx, undefined as any)).toEqual('')
   })
 })
 

--- a/packages/core-base/test/warnings.test.ts
+++ b/packages/core-base/test/warnings.test.ts
@@ -1,5 +1,5 @@
 import { CORE_WARN_CODES_EXTEND_POINT } from '../src/warnings'
 
 test('CoreWarnCodes', () => {
-  expect(CORE_WARN_CODES_EXTEND_POINT).toBe(8)
+  expect(CORE_WARN_CODES_EXTEND_POINT).toBe(10)
 })

--- a/packages/vue-i18n-core/src/warnings.ts
+++ b/packages/vue-i18n-core/src/warnings.ts
@@ -2,19 +2,20 @@ import { CORE_WARN_CODES_EXTEND_POINT } from '@intlify/core-base'
 import { format } from '@intlify/shared'
 
 export const I18nWarnCodes = {
-  FALLBACK_TO_ROOT: CORE_WARN_CODES_EXTEND_POINT, // 8
-  NOT_FOUND_PARENT_SCOPE: 9,
-  IGNORE_OBJ_FLATTEN: 10,
+  FALLBACK_TO_ROOT: CORE_WARN_CODES_EXTEND_POINT, // 10
+  NOT_FOUND_PARENT_SCOPE: (CORE_WARN_CODES_EXTEND_POINT + 1) as number,
+  IGNORE_OBJ_FLATTEN: (CORE_WARN_CODES_EXTEND_POINT + 2) as number,
   /**
    * @deprecated will be removed at vue-i18n v12
    */
-  DEPRECATE_LEGACY_MODE: 11,
+  DEPRECATE_LEGACY_MODE: (CORE_WARN_CODES_EXTEND_POINT + 3) as number,
   /**
    * @deprecated will be removed at vue-i18n v12
    */
-  DEPRECATE_TRANSLATE_CUSTOME_DIRECTIVE: 12,
+  DEPRECATE_TRANSLATE_CUSTOME_DIRECTIVE: (CORE_WARN_CODES_EXTEND_POINT +
+    4) as number,
   // duplicate `useI18n` calling
-  DUPLICATE_USE_I18N_CALLING: 13
+  DUPLICATE_USE_I18N_CALLING: (CORE_WARN_CODES_EXTEND_POINT + 5) as number
 } as const
 
 type I18nWarnCodes = (typeof I18nWarnCodes)[keyof typeof I18nWarnCodes]


### PR DESCRIPTION
back-ported from #2417 