### PR TITLE
fix: te returns false if the key contains a do

### DIFF
--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -2423,7 +2423,11 @@ export function createComposer(options: any = {}): any {
         }
         const targetLocale = isString(locale) ? locale : _locale.value
         const message = getLocaleMessage(targetLocale)
-        const resolved = _context.messageResolver(message, key)
+        let resolved = _context.messageResolver(message, key)
+        // if null, resolve with object key path (for flat keys containing dots)
+        if (resolved === null) {
+          resolved = (message as any)[key]
+        }
         return (
           isMessageAST(resolved) ||
           isMessageFunction(resolved) ||


### PR DESCRIPTION
back-ported from #2409