### PR TITLE
fix: Suppressing automatic locale fallback with `!` breaks `n`/`$n` and `d`/`$d` formatting

### DIFF
--- a/packages/core-base/src/datetime.ts
+++ b/packages/core-base/src/datetime.ts
@@ -235,7 +235,9 @@ export function datetime<
   )
 
   if (!isString(key) || key === '') {
-    return new Intl.DateTimeFormat(locale, overrides).format(value)
+    return new Intl.DateTimeFormat(locale.replace(/!/g, ''), overrides).format(
+      value
+    )
   }
 
   // resolve format

--- a/packages/core-base/src/number.ts
+++ b/packages/core-base/src/number.ts
@@ -230,7 +230,9 @@ export function number<
   )
 
   if (!isString(key) || key === '') {
-    return new Intl.NumberFormat(locale, overrides).format(value)
+    return new Intl.NumberFormat(locale.replace(/!/g, ''), overrides).format(
+      value
+    )
   }
 
   // resolve format


### PR DESCRIPTION
back-ported from #2418 