### PR TITLE
fix: mark several packages as having side effects

### DIFF
--- a/packages/core-base/package.json
+++ b/packages/core-base/package.json
@@ -31,7 +31,7 @@
     "node": ">= 16"
   },
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": true,
   "files": [
     "dist"
   ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
     "node": ">= 16"
   },
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": true,
   "files": [
     "dist"
   ],

--- a/packages/vue-i18n-core/package.json
+++ b/packages/vue-i18n-core/package.json
@@ -32,7 +32,7 @@
     "node": ">= 16"
   },
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": true,
   "files": [
     "dist"
   ],

--- a/packages/vue-i18n/package.json
+++ b/packages/vue-i18n/package.json
@@ -29,7 +29,7 @@
     "node": ">= 16"
   },
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": true,
   "files": [
     "dist",
     "vetur"


### PR DESCRIPTION
This pull request sets `sideEffects` to `true` for the following packages:

- @intlify/core-base
- @intlify/core
- @intlify/vue-i18n-core
- @intlify/vue-i18n

… because they have side effect calls: `registerMessageCompiler`, `registerMessageResolver`, `registerLocaleFallbacker`, and `initFeatureFlags` module scope. With `sideEffects: false`, bundlers may tree-shake these entry points away when only specific exports are imported. This may silently break the library at runtime.

I'm unsure if this was intended. Please feel free to leave comments for discussion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration across core packages to optimize module bundling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->