### PR TITLE
fix: linked messages fail to resolve keys containing dots

### DIFF
--- a/packages/core-base/src/translate.ts
+++ b/packages/core-base/src/translate.ts
@@ -1027,7 +1027,7 @@ function getMessageContextOptions<Messages, Message = string>(
 
     // fallback
     if (val == null && (fallbackContext || useLinked)) {
-      const [, , message] = resolveMessageFormat(
+      const [format, , message] = resolveMessageFormat(
         fallbackContext || context, // NOTE: if has fallbackContext, fallback to root, else if use linked, fallback to local context
         key,
         locale,
@@ -1035,7 +1035,7 @@ function getMessageContextOptions<Messages, Message = string>(
         fallbackWarn,
         missingWarn
       )
-      val = resolveValue(message, key)
+      val = format ?? resolveValue(message, key)
     }
 
     if (isString(val) || isMessageAST(val)) {

--- a/packages/vue-i18n-core/test/issues.test.ts
+++ b/packages/vue-i18n-core/test/issues.test.ts
@@ -1187,3 +1187,60 @@ describe('#2156', () => {
     expect(i18n.global.t('product.test.type')).toEqual('Product test type')
   })
 })
+
+describe('issue #2455', () => {
+  test('without flatJson', async () => {
+    const i18n = createI18n({
+      locale: 'en',
+      messages: {
+        en: {
+          linkedBase: 'Base',
+          'linkedBase.deep': 'Deep',
+          'linkedBase.deep.deeper': 'Deeper',
+          testBase: 'Test: @:linkedBase',
+          testDeep: 'Test: @:linkedBase.deep',
+          testDeeper: 'Test: @:linkedBase.deep.deeper'
+        }
+      }
+    })
+
+    const App = defineComponent({
+      setup() {
+        const { t } = useI18n()
+        return { t }
+      },
+      template: `<div>{{ t('testBase') }} | {{ t('testDeep') }} | {{ t('testDeeper') }}</div>`
+    })
+    const wrapper = await mount(App, i18n)
+
+    expect(wrapper.html()).toEqual('<div>Test: Base | Test: Deep | Test: Deeper</div>')
+  })
+
+  test('with flatJson', async () => {
+    const i18n = createI18n({
+      locale: 'en',
+      flatJson: true,
+      messages: {
+        en: {
+          linkedBase: 'Base',
+          'linkedBase.deep': 'Deep',
+          'linkedBase.deep.deeper': 'Deeper',
+          testBase: 'Test: @:linkedBase',
+          testDeep: 'Test: @:linkedBase.deep',
+          testDeeper: 'Test: @:linkedBase.deep.deeper'
+        }
+      }
+    })
+
+    const App = defineComponent({
+      setup() {
+        const { t } = useI18n()
+        return { t }
+      },
+      template: `<div>{{ t('testBase') }} | {{ t('testDeep') }} | {{ t('testDeeper') }}</div>`
+    })
+    const wrapper = await mount(App, i18n)
+
+    expect(wrapper.html()).toEqual('<div>Test: Base | Test: Deep | Test: Deeper</div>')
+  })
+})


### PR DESCRIPTION
fixes https://github.com/intlify/vue-i18n/issues/2455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed message resolution with fallback/linking when using nested message key references.

## Tests
* Added test coverage for issue #2455, verifying nested and linked message key references resolve correctly with and without `flatJson` option enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->