### PR TITLE
fix: `$n` overloads use `DefineNumberFormat` instead of `DefineDateTimeFormat`

### DIFF
--- a/packages/vue-i18n/src/vue.d.ts
+++ b/packages/vue-i18n/src/vue.d.ts
@@ -655,8 +655,8 @@ declare module 'vue' {
      */
     $n<
       Key extends string = string,
-      DefinedNumberFormat extends RemovedIndexResources<DefineDateTimeFormat> =
-        RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedNumberFormat extends RemovedIndexResources<DefineNumberFormat> =
+        RemovedIndexResources<DefineNumberFormat>,
       Keys = IsEmptyObject<DefinedNumberFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedNumberFormat]: DefinedNumberFormat[K]
@@ -682,8 +682,8 @@ declare module 'vue' {
      */
     $n<
       Key extends string = string,
-      DefinedNumberFormat extends RemovedIndexResources<DefineDateTimeFormat> =
-        RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedNumberFormat extends RemovedIndexResources<DefineNumberFormat> =
+        RemovedIndexResources<DefineNumberFormat>,
       Keys = IsEmptyObject<DefinedNumberFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedNumberFormat]: DefinedNumberFormat[K]
@@ -709,8 +709,8 @@ declare module 'vue' {
      */
     $n<
       Key extends string = string,
-      DefinedNumberFormat extends RemovedIndexResources<DefineDateTimeFormat> =
-        RemovedIndexResources<DefineDateTimeFormat>,
+      DefinedNumberFormat extends RemovedIndexResources<DefineNumberFormat> =
+        RemovedIndexResources<DefineNumberFormat>,
       Keys = IsEmptyObject<DefinedNumberFormat> extends false
         ? PickupFormatPathKeys<{
             [K in keyof DefinedNumberFormat]: DefinedNumberFormat[K]


### PR DESCRIPTION
fixes https://github.com/intlify/vue-i18n/issues/2452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect type definitions for the number formatting method, ensuring proper type hints and IDE autocomplete support for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->