### PR TITLE
perf: gate performance.mark/measure behind app.config.performance

### DIFF
--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -8,24 +8,26 @@ export const inBrowser: boolean = typeof window !== 'undefined'
 export let mark: (tag: string) => void | undefined
 export let measure: (name: string, startTag: string, endTag: string) => void | undefined
 
-if (__DEV__) {
-  const perf = inBrowser && window.performance
+export function initPerformanceMeasurement(): void {
+  if (__DEV__) {
+    const perf = inBrowser && window.performance
 
-  if (
-    perf &&
-    perf.mark &&
-    perf.measure &&
-    perf.clearMarks &&
-    // @ts-ignore browser compat
-    perf.clearMeasures
-  ) {
-    mark = (tag: string): void => {
-      perf.mark(tag)
-    }
-    measure = (name: string, startTag: string, endTag: string): void => {
-      perf.measure(name, startTag, endTag)
-      perf.clearMarks(startTag)
-      perf.clearMarks(endTag)
+    if (
+      perf &&
+      perf.mark &&
+      perf.measure &&
+      perf.clearMarks &&
+      // @ts-ignore browser compat
+      perf.clearMeasures
+    ) {
+      mark = (tag: string): void => {
+        perf.mark(tag)
+      }
+      measure = (name: string, startTag: string, endTag: string): void => {
+        perf.measure(name, startTag, endTag)
+        perf.clearMarks(startTag)
+        perf.clearMarks(endTag)
+      }
     }
   }
 }

--- a/packages/vue-i18n-core/src/i18n.ts
+++ b/packages/vue-i18n-core/src/i18n.ts
@@ -1,6 +1,7 @@
 import {
   assign,
   createEmitter,
+  initPerformanceMeasurement,
   isBoolean,
   isKeylessObject,
   isNumber,
@@ -377,6 +378,10 @@ export function createI18n(options: any = {}): any {
   const i18n = {
     // install plugin
     async install(app: App, ...options: unknown[]): Promise<void> {
+      if (__DEV__ && app.config.performance) {
+        initPerformanceMeasurement()
+      }
+
       if ((__DEV__ || __FEATURE_PROD_VUE_DEVTOOLS__) && !__NODE_JS__) {
         app.__VUE_I18N__ = i18n as unknown as _I18n
       }


### PR DESCRIPTION
## Summary

Dev mode calls `performance.mark()` and `performance.measure()` on every `t()` invocation unconditionally. This adds ~240ms overhead in apps with many components. This PR gates those calls behind `app.config.performance`, matching Vue core's opt-in behavior.

## Why this matters

Profiling a workflow editor with ~160 components showed 98ms in `mark` + 142ms in `measure` per workflow switch. That's 20% of the total frame time, all from instrumentation nobody asked for. Wrapping the initialization in `initPerformanceMeasurement()` and calling it only when `app.config.performance` is true eliminates this cost for the common case.

## Changes

- `packages/shared/src/utils.ts`: Moved `mark`/`measure` initialization into a new `initPerformanceMeasurement()` function. The functions stay `undefined` until explicitly enabled, so existing `if (mark && measure)` guards in `translate.ts` skip them by default.
- `packages/vue-i18n-core/src/i18n.ts`: Import and call `initPerformanceMeasurement()` in the plugin `install()` hook when `__DEV__ && app.config.performance` is true.

## Testing

- Without `app.config.performance = true`: `mark` and `measure` remain undefined, zero overhead from Performance API calls in dev mode.
- With `app.config.performance = true`: behavior is identical to the current dev mode (all three measurement phases fire).

Fixes #2462

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Performance measurement initialization now occurs on-demand during plugin setup instead of at module load time, improving initialization efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->