### PR TITLE
fix(i18n-t): pass component children as slots

### DIFF
--- a/packages/vue-i18n-core/src/components/Translation.ts
+++ b/packages/vue-i18n-core/src/components/Translation.ts
@@ -73,7 +73,7 @@ export const TranslationImpl: ComponentOptions<TranslationProps> = /* #__PURE__*
           options.plural = isString(props.plural) ? +props.plural : props.plural
         }
         const arg = getInterpolateArg(context, keys)
-         
+
         return (i18n as any)[TranslateVNodeSymbol](props.keypath, arg, options)
       }
       const assignedAttrs = assign(create(), attrs)

--- a/packages/vue-i18n-core/src/components/Translation.ts
+++ b/packages/vue-i18n-core/src/components/Translation.ts
@@ -6,7 +6,13 @@ import { BaseFormatPropsValidators } from './base'
 import { getFragmentableTag, getInterpolateArg } from './utils'
 
 import type { TranslateOptions } from '@intlify/core-base'
-import type { ComponentOptions, SetupContext, VNodeChild, VNodeProps } from 'vue'
+import type {
+  ComponentOptions,
+  SetupContext,
+  VNodeArrayChildren,
+  VNodeChild,
+  VNodeProps
+} from 'vue'
 import type { Composer, ComposerInternal } from '../composer'
 import type { BaseFormatProps } from './base'
 
@@ -57,20 +63,24 @@ export const TranslationImpl: ComponentOptions<TranslationProps> = /* #__PURE__*
       }) as unknown as Composer & ComposerInternal)
 
     return (): VNodeChild => {
-      const keys = Object.keys(slots).filter(key => key[0] !== '_')
-      const options = create() as TranslateOptions
-      if (props.locale) {
-        options.locale = props.locale
+      const renderChildren = (): VNodeArrayChildren => {
+        const keys = Object.keys(slots).filter(key => key[0] !== '_')
+        const options = create() as TranslateOptions
+        if (props.locale) {
+          options.locale = props.locale
+        }
+        if (props.plural !== undefined) {
+          options.plural = isString(props.plural) ? +props.plural : props.plural
+        }
+        const arg = getInterpolateArg(context, keys)
+         
+        return (i18n as any)[TranslateVNodeSymbol](props.keypath, arg, options)
       }
-      if (props.plural !== undefined) {
-        options.plural = isString(props.plural) ? +props.plural : props.plural
-      }
-      const arg = getInterpolateArg(context, keys)
-
-      const children = (i18n as any)[TranslateVNodeSymbol](props.keypath, arg, options)
       const assignedAttrs = assign(create(), attrs)
       const tag = isString(props.tag) || isObject(props.tag) ? props.tag : getFragmentableTag()
-      return h(tag, assignedAttrs, children)
+      return isObject(tag)
+        ? h(tag, assignedAttrs, { default: renderChildren })
+        : h(tag, assignedAttrs, renderChildren())
     }
   }
 })

--- a/packages/vue-i18n-core/src/components/formatRenderer.ts
+++ b/packages/vue-i18n-core/src/components/formatRenderer.ts
@@ -52,44 +52,49 @@ export function renderFormatter<
   const { slots, attrs } = context
 
   return (): VNodeChild => {
-    const options = { part: true } as Arg
-    let overrides = create() as FormatOverrideOptions
+    const renderChildren = (): VNodeArrayChildren => {
+      const options = { part: true } as Arg
+      let overrides = create() as FormatOverrideOptions
 
-    if (props.locale) {
-      options.locale = props.locale
-    }
-
-    if (isString(props.format)) {
-      options.key = props.format
-    } else if (isObject(props.format)) {
-      if (isString((props.format as any).key)) {
-        options.key = (props.format as any).key
+      if (props.locale) {
+        options.locale = props.locale
       }
-      // Filter out number format options only
-      overrides = Object.keys(props.format).reduce((options, prop) => {
-        return slotKeys.includes(prop)
-          ? assign(create(), options, { [prop]: (props.format as any)[prop] })
-          : options
-      }, create())
-    }
 
-    const parts = partFormatter(props.value, options, overrides)
-    let children = [options.key] as VNodeArrayChildren
-    if (isArray(parts)) {
-      children = parts.map((part, index) => {
-        const slot = slots[part.type]
-        const node = slot ? slot({ [part.type]: part.value, index, parts }) : [part.value]
-        if (isVNode(node)) {
-          node[0].key = `${part.type}-${index}`
+      if (isString(props.format)) {
+        options.key = props.format
+      } else if (isObject(props.format)) {
+        if (isString((props.format as any).key)) {
+          options.key = (props.format as any).key
         }
-        return node
-      })
-    } else if (isString(parts)) {
-      children = [parts]
+        // Filter out number format options only
+        overrides = Object.keys(props.format).reduce((options, prop) => {
+          return slotKeys.includes(prop)
+            ? assign(create(), options, { [prop]: (props.format as any)[prop] })
+            : options
+        }, create())
+      }
+
+      const parts = partFormatter(props.value, options, overrides)
+      let children = [options.key] as VNodeArrayChildren
+      if (isArray(parts)) {
+        children = parts.map((part, index) => {
+          const slot = slots[part.type]
+          const node = slot ? slot({ [part.type]: part.value, index, parts }) : [part.value]
+          if (isVNode(node)) {
+            node[0].key = `${part.type}-${index}`
+          }
+          return node
+        })
+      } else if (isString(parts)) {
+        children = [parts]
+      }
+      return children
     }
 
     const assignedAttrs = assign(create(), attrs)
     const tag = isString(props.tag) || isObject(props.tag) ? props.tag : getFragmentableTag()
-    return h(tag, assignedAttrs, children)
+    return isObject(tag)
+      ? h(tag, assignedAttrs, { default: renderChildren })
+      : h(tag, assignedAttrs, renderChildren())
   }
 }

--- a/packages/vue-i18n-core/src/components/formatRenderer.ts
+++ b/packages/vue-i18n-core/src/components/formatRenderer.ts
@@ -80,7 +80,7 @@ export function renderFormatter<
         children = parts.map((part, index) => {
           const slot = slots[part.type]
           const node = slot ? slot({ [part.type]: part.value, index, parts }) : [part.value]
-          if (isVNode(node)) {
+          if (isVNode(node) && node.length > 0 && node[0]) {
             node[0].key = `${part.type}-${index}`
           }
           return node

--- a/packages/vue-i18n-core/test/components/DatetimeFormat.test.ts
+++ b/packages/vue-i18n-core/test/components/DatetimeFormat.test.ts
@@ -131,4 +131,7 @@ test('component', async () => {
   const wrapper = await mount(App, i18n)
 
   expect(wrapper.html().includes('span')).toBeTruthy()
+  expect(spy).not.toHaveBeenCalledWith(
+    expect.stringContaining('Non-function value encountered for default slot')
+  )
 })

--- a/packages/vue-i18n-core/test/components/NumberFormat.test.ts
+++ b/packages/vue-i18n-core/test/components/NumberFormat.test.ts
@@ -121,4 +121,7 @@ test('component', async () => {
   const wrapper = await mount(App, i18n)
 
   expect(wrapper.html()).toEqual(`<span>100</span><span>$100.00</span><span>￥100</span>`)
+  expect(spy).not.toHaveBeenCalledWith(
+    expect.stringContaining('Non-function value encountered for default slot')
+  )
 })

--- a/packages/vue-i18n-core/test/components/Translation.test.ts
+++ b/packages/vue-i18n-core/test/components/Translation.test.ts
@@ -211,6 +211,9 @@ test('component', async () => {
   const wrapper = await mount(App, i18n)
 
   expect(wrapper.html()).toEqual(`<p class="name">hello, <span>kazupon</span>!</p>`)
+  expect(spy).not.toHaveBeenCalledWith(
+    expect.stringContaining('Non-function value encountered for default slot')
+  )
 })
 
 test('message resolver', async () => {


### PR DESCRIPTION
port from #2474 #2473
related #2471 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal rendering to defer child generation for component tags and unify rendering paths for string/fragment tags.

* **Bug Fixes**
  * Eliminated spurious console warnings related to default slot rendering across tag types.

* **Tests**
  * Expanded tests to assert correct rendering and absence of the unnecessary default-slot warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->