### PR TITLE
fix: backport CVE-2025-53892

### DIFF
--- a/docs/guide/essentials/syntax.md
+++ b/docs/guide/essentials/syntax.md
@@ -492,7 +492,7 @@ t('message.welcome', { name: userInput })
 
 // With escape parameter (SAFE):
 t('message.welcome', { name: userInput }, { escapeParameter: true })
-// Result: Welcome <strong>&lt;img src=x &#111;nerror=alert(1)&gt;</strong>!
+// Result: Welcome <strong>&lt;img src&#x3D;x onerror&#x3D;alert(1)&gt;</strong>!
 ```
 
 :::warning IMPORTANT

--- a/docs/guide/essentials/syntax.md
+++ b/docs/guide/essentials/syntax.md
@@ -444,8 +444,9 @@ world</p>
 
 To help mitigate XSS risks when using HTML messages, Vue I18n provides the `escapeParameter` option. When enabled, this option escapes interpolation parameters and sanitizes the final translated HTML.
 
+Enable it globally via `createI18n`:
+
 ```js
-// enable `escapeParameter` globally
 const i18n = createI18n({
   locale: 'en',
   escapeParameter: true,
@@ -457,10 +458,18 @@ const i18n = createI18n({
     }
   }
 })
+```
 
-// or enable it per translation
+Or enable it per translation:
+
+```vue
+<script setup>
+import { useI18n } from 'vue-i18n'
+
 const { t } = useI18n()
-t('message.welcome', { name: userInput }, { escapeParameter: true })
+
+const greeting = t('message.welcome', { name: userInput }, { escapeParameter: true })
+</script>
 ```
 
 #### How it works

--- a/docs/guide/essentials/syntax.md
+++ b/docs/guide/essentials/syntax.md
@@ -439,3 +439,53 @@ As result, the below:
 <!--<br> exists but is rendered as html and not a string-->
 world</p>
 ```
+
+### Using the escapeParameter option
+
+To help mitigate XSS risks when using HTML messages, Vue I18n provides the `escapeParameter` option. When enabled, this option escapes interpolation parameters and sanitizes the final translated HTML.
+
+```js
+// enable `escapeParameter` globally
+const i18n = createI18n({
+  locale: 'en',
+  escapeParameter: true,
+  messages: {
+    en: {
+      message: {
+        welcome: 'Welcome <strong>{name}</strong>!'
+      }
+    }
+  }
+})
+
+// or enable it per translation
+const { t } = useI18n()
+t('message.welcome', { name: userInput }, { escapeParameter: true })
+```
+
+#### How it works
+
+When the `escapeParameter` option is enabled:
+- HTML special characters (`<`, `>`, `"`, `'`, `&`, `/`, `=`) in interpolation parameters are escaped
+- The final translated HTML is sanitized to prevent XSS attacks:
+  - Dangerous characters in HTML attribute values are escaped
+  - Event handler attributes (`onclick`, `onerror`, etc.) are neutralized
+  - JavaScript URLs in `href`, `src`, `action`, `formaction`, and `style` attributes are disabled
+
+#### Example
+
+```js
+const userInput = '<img src=x onerror=alert(1)>'
+
+// Without escape parameter (DANGEROUS):
+t('message.welcome', { name: userInput })
+// Result: Welcome <strong><img src=x onerror=alert(1)></strong>!
+
+// With escape parameter (SAFE):
+t('message.welcome', { name: userInput }, { escapeParameter: true })
+// Result: Welcome <strong>&lt;img src=x &#111;nerror=alert(1)&gt;</strong>!
+```
+
+:::warning IMPORTANT
+Even with the `escapeParameter` option enabled, you should still be cautious about using HTML in translations. Always validate and sanitize user input before using it in translations, and prefer [Component interpolation](../advanced/component) when possible.
+:::

--- a/packages/core-base/src/translate.ts
+++ b/packages/core-base/src/translate.ts
@@ -15,6 +15,7 @@ import {
   isString,
   mark,
   measure,
+  sanitizeTranslatedHtml,
   warn
 } from '@intlify/shared'
 import { isMessageAST } from './ast'
@@ -148,7 +149,16 @@ export interface TranslateOptions<Locales = Locale> extends LocaleOptions<Locale
   fallbackWarn?: boolean
   /**
    * @remarks
-   * Whether do escape parameter for list or named interpolation values
+   * Whether to escape parameters for list or named interpolation values.
+   * When enabled, this option:
+   * - Escapes HTML special characters (`<`, `>`, `"`, `'`, `&`, `/`, `=`) in interpolation parameters
+   * - Sanitizes the final translated HTML to prevent XSS attacks by:
+   *   - Escaping dangerous characters in HTML attribute values
+   *   - Neutralizing event handler attributes (onclick, onerror, etc.)
+   *   - Disabling javascript: URLs in href, src, action, formaction, and style attributes
+   *
+   * @defaultValue false
+   * @see [HTML Message - Using the escapeParameter option](https://vue-i18n.intlify.dev/guide/essentials/syntax.html#using-the-escapeparameter-option)
    */
   escapeParameter?: boolean
   /**
@@ -695,9 +705,14 @@ export function translate<Context extends CoreContext<Message, {}, {}, {}>, Mess
 
   // prettier-ignore
   // if use post translation option, proceed it with handler
-  const ret = context.postTranslation
+  let ret = context.postTranslation
     ? context.postTranslation(messaged, key as string)
     : messaged
+
+  // apply HTML sanitization for security
+  if (escapeParameter && isString(ret)) {
+    ret = sanitizeTranslatedHtml(ret) as MessageFunctionReturn<Message>
+  }
 
   return ret
 }

--- a/packages/core-base/test/translate.test.ts
+++ b/packages/core-base/test/translate.test.ts
@@ -782,7 +782,7 @@ describe('escapeParameter', () => {
     })
 
     expect(translate(ctx, 'hello', { name: '<b>kazupon</b>' })).toEqual(
-      'hello, &lt;b&gt;kazupon&lt;/b&gt;!'
+      'hello, &lt;b&gt;kazupon&lt;&#x2F;b&gt;!'
     )
   })
 
@@ -799,7 +799,7 @@ describe('escapeParameter', () => {
     })
 
     expect(translate(ctx, 'hello', ['<b>kazupon</b>'], { escapeParameter: true })).toEqual(
-      'hello, &lt;b&gt;kazupon&lt;/b&gt;!'
+      'hello, &lt;b&gt;kazupon&lt;&#x2F;b&gt;!'
     )
   })
 
@@ -816,6 +816,70 @@ describe('escapeParameter', () => {
     })
 
     expect(translate(ctx, 'hello', { name: '<b>kazupon</b>' })).toEqual('hello, <b>kazupon</b>!')
+  })
+
+  test('vulnerable case from GHSA report - img onerror attack', () => {
+    // Mock console.warn to suppress warnings for this test
+    const originalWarn = console.warn
+    console.warn = vi.fn()
+
+    const ctx = context({
+      locale: 'en',
+      warnHtmlMessage: false,
+      escapeParameter: true,
+      messages: {
+        en: {
+          vulnerable: 'Caution: <img src=x onerror="{payload}">'
+        }
+      }
+    })
+
+    const result = translate(ctx, 'vulnerable', {
+      payload: '<script>alert("xss")</script>'
+    })
+
+    // with the fix, the payload should be escaped, preventing the attack
+    // The onerror attribute is neutralized by converting 'o' to &#111;
+    expect(result).toEqual(
+      'Caution: <img src=x &#111;nerror="&lt;script&gt;alert(&quot;xss&quot;)&lt;&#x2F;script&gt;">'
+    )
+
+    // result should NOT contain executable script tags
+    expect(result).not.toContain('<script>')
+    expect(result).not.toContain('</script>')
+
+    // Restore console.warn
+    console.warn = originalWarn
+  })
+
+  test('vulnerable case - attribute injection attack', () => {
+    const ctx = context({
+      locale: 'en',
+      warnHtmlMessage: false,
+      escapeParameter: true,
+      messages: {
+        en: {
+          message: 'Click <a href="{url}">here</a>'
+        }
+      }
+    })
+
+    const result = translate(ctx, 'message', {
+      url: 'javascript:alert(1)'
+    })
+
+    // with the fix, javascript: URL scheme is neutralized
+    expect(result).toEqual('Click <a href="javascript&#58;alert(1)">here</a>')
+
+    // another attack vector with quotes
+    const result2 = translate(ctx, 'message', {
+      url: '" onclick="alert(1)"'
+    })
+
+    expect(result2).toEqual('Click <a href="&quot; onclick&#x3D;&quot;alert(1)&quot;">here</a>')
+
+    // `onclick` attribute should be escaped
+    expect(result2).not.toContain('onclick=')
   })
 })
 

--- a/packages/core-base/test/translate.test.ts
+++ b/packages/core-base/test/translate.test.ts
@@ -868,8 +868,8 @@ describe('escapeParameter', () => {
       url: 'javascript:alert(1)'
     })
 
-    // with the fix, javascript: URL scheme is neutralized
-    expect(result).toEqual('Click <a href="javascript&#58;alert(1)">here</a>')
+    // with the fix, javascript: URLs are replaced with a non-executable value
+    expect(result).toEqual('Click <a href="about:blank">here</a>')
 
     // another attack vector with quotes
     const result2 = translate(ctx, 'message', {

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -116,18 +116,91 @@ function escapeAttributeValue(value: string): string {
     .replace(/>/g, '&gt;')
 }
 
+const javascriptSchemePattern = /^\s*javascript\s*(?::|&#0*58;?|&#x0*3a;?|&colon;?)/i
+const urlAttributePattern = /^(?:href|src|action|formaction)$/i
+
+function hasJavascriptScheme(value: string): boolean {
+  return javascriptSchemePattern.test(value)
+}
+
+function sanitizeStyleValue(value: string): string {
+  const urlPattern = /url\s*\(/gi
+  let sanitized = ''
+  let cursor = 0
+  let match: RegExpExecArray | null
+
+  while ((match = urlPattern.exec(value)) !== null) {
+    const urlStart = match.index
+    const openParenIndex = urlPattern.lastIndex - 1
+    let index = openParenIndex + 1
+    let depth = 1
+    let quote: '"' | "'" | null = null
+
+    for (; index < value.length; index++) {
+      const char = value[index]
+
+      if (quote) {
+        if (char === quote) {
+          quote = null
+        }
+        continue
+      }
+
+      if (char === '"' || char === "'") {
+        quote = char
+      } else if (char === '(') {
+        depth++
+      } else if (char === ')') {
+        depth--
+        if (depth === 0) {
+          break
+        }
+      }
+    }
+
+    if (depth !== 0) {
+      break
+    }
+
+    const rawUrlValue = value.slice(openParenIndex + 1, index).trim()
+    const unquotedUrlValue =
+      (rawUrlValue.startsWith('"') && rawUrlValue.endsWith('"')) ||
+      (rawUrlValue.startsWith("'") && rawUrlValue.endsWith("'"))
+        ? rawUrlValue.slice(1, -1).trim()
+        : rawUrlValue
+
+    sanitized += value.slice(cursor, urlStart)
+    sanitized += hasJavascriptScheme(unquotedUrlValue)
+      ? 'url(about:blank)'
+      : value.slice(urlStart, index + 1)
+    cursor = index + 1
+  }
+
+  return sanitized + value.slice(cursor)
+}
+
+function sanitizeAttributeValue(attrName: string, value: string): string {
+  if (urlAttributePattern.test(attrName) && hasJavascriptScheme(value)) {
+    return 'about:blank'
+  }
+
+  const sanitizedValue = attrName.toLowerCase() === 'style' ? sanitizeStyleValue(value) : value
+
+  return escapeAttributeValue(sanitizedValue)
+}
+
 export function sanitizeTranslatedHtml(html: string): string {
   // Escape dangerous characters in attribute values
   // Process attributes with double quotes
   html = html.replace(
-    /(\w+)\s*=\s*"([^"]*)"/g,
-    (_, attrName, attrValue) => `${attrName}="${escapeAttributeValue(attrValue)}"`
+    /([\w:-]+)\s*=\s*"([^"]*)"/g,
+    (_, attrName, attrValue) => `${attrName}="${sanitizeAttributeValue(attrName, attrValue)}"`
   )
 
   // Process attributes with single quotes
   html = html.replace(
-    /(\w+)\s*=\s*'([^']*)'/g,
-    (_, attrName, attrValue) => `${attrName}='${escapeAttributeValue(attrValue)}'`
+    /([\w:-]+)\s*=\s*'([^']*)'/g,
+    (_, attrName, attrValue) => `${attrName}='${sanitizeAttributeValue(attrName, attrValue)}'`
   )
 
   // Detect and neutralize event handler attributes
@@ -143,17 +216,11 @@ export function sanitizeTranslatedHtml(html: string): string {
     html = html.replace(/(\s+)on(\w+\s*=)/gi, '$1&#111;n$2')
   }
 
-  // Disable javascript: URLs in various contexts
-  const javascriptUrlPattern = [
-    // In href, src, action, formaction attributes
-    /(\s+(?:href|src|action|formaction)\s*=\s*(?:["']\s*)?)javascript:/gi,
-    // In style attributes within url()
-    /(style\s*=\s*["'][^"']*url\s*\(\s*)javascript:/gi
-  ]
-
-  javascriptUrlPattern.forEach(pattern => {
-    html = html.replace(pattern, '$1javascript&#58;')
-  })
+  // Disable javascript: URLs in unquoted attributes
+  html = html.replace(
+    /(\s+(?:href|src|action|formaction)\s*=\s*)([^\s"'=<>`]+)/gi,
+    (match, prefix, attrValue) => (hasJavascriptScheme(attrValue) ? `${prefix}about:blank` : match)
+  )
 
   return html
 }

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -3,6 +3,8 @@
  * written by kazuya kawaguchi
  */
 
+import { warn } from './warn'
+
 export const inBrowser: boolean = typeof window !== 'undefined'
 
 export let mark: (tag: string) => void | undefined
@@ -96,10 +98,64 @@ export const getGlobalThis = (): any => {
 
 export function escapeHtml(rawText: string): string {
   return rawText
+    .replace(/&/g, '&amp;') // escape `&` first to avoid double escaping
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&apos;')
+    .replace(/\//g, '&#x2F;') // escape `/` to prevent closing tags or JavaScript URLs
+    .replace(/=/g, '&#x3D;') // escape `=` to prevent attribute injection
+}
+
+function escapeAttributeValue(value: string): string {
+  return value
+    .replace(/&(?![a-z0-9#]{2,6};)/gi, '&amp;') // escape unescaped `&`
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+export function sanitizeTranslatedHtml(html: string): string {
+  // Escape dangerous characters in attribute values
+  // Process attributes with double quotes
+  html = html.replace(
+    /(\w+)\s*=\s*"([^"]*)"/g,
+    (_, attrName, attrValue) => `${attrName}="${escapeAttributeValue(attrValue)}"`
+  )
+
+  // Process attributes with single quotes
+  html = html.replace(
+    /(\w+)\s*=\s*'([^']*)'/g,
+    (_, attrName, attrValue) => `${attrName}='${escapeAttributeValue(attrValue)}'`
+  )
+
+  // Detect and neutralize event handler attributes
+  const eventHandlerPattern = /\s*on\w+\s*=\s*["']?[^"'>]+["']?/i
+  if (eventHandlerPattern.test(html)) {
+    if (__DEV__) {
+      warn(
+        'Potentially dangerous event handlers detected in translation. ' +
+          'Consider removing onclick, onerror, etc. from your translation messages.'
+      )
+    }
+    // Neutralize event handler attributes by escaping 'on'
+    html = html.replace(/(\s+)on(\w+\s*=)/gi, '$1&#111;n$2')
+  }
+
+  // Disable javascript: URLs in various contexts
+  const javascriptUrlPattern = [
+    // In href, src, action, formaction attributes
+    /(\s+(?:href|src|action|formaction)\s*=\s*(?:["']\s*)?)javascript:/gi,
+    // In style attributes within url()
+    /(style\s*=\s*["'][^"']*url\s*\(\s*)javascript:/gi
+  ]
+
+  javascriptUrlPattern.forEach(pattern => {
+    html = html.replace(pattern, '$1javascript&#58;')
+  })
+
+  return html
 }
 
 const hasOwnProperty = Object.prototype.hasOwnProperty

--- a/packages/shared/test/utils.test.ts
+++ b/packages/shared/test/utils.test.ts
@@ -1,4 +1,18 @@
-import { format, generateCodeFrame, makeSymbol, join } from '../src/index'
+import { vi } from 'vitest'
+
+// Mock the warn function before importing anything else
+vi.mock('../src/warn', () => ({
+  warn: vi.fn()
+}))
+
+import {
+  escapeHtml,
+  format,
+  generateCodeFrame,
+  join,
+  makeSymbol,
+  sanitizeTranslatedHtml
+} from '../src/index'
 
 test('format', () => {
   expect(format(`foo: {0}`, 'x')).toEqual('foo: x')
@@ -53,4 +67,276 @@ test('join', () => {
     'z'
   ]
   expect(join(longSize, ' ')).toEqual(longSize.join(' '))
+})
+
+describe('escapeHtml', () => {
+  test('escape `<` and `>`', () => {
+    expect(escapeHtml('<div>test</div>')).toBe('&lt;div&gt;test&lt;&#x2F;div&gt;')
+  })
+
+  test('escape quotes', () => {
+    expect(escapeHtml(`"double" and 'single'`)).toBe('&quot;double&quot; and &apos;single&apos;')
+  })
+
+  test('escape `&` correctly', () => {
+    expect(escapeHtml('&lt;')).toBe('&amp;lt;')
+    expect(escapeHtml('&amp;')).toBe('&amp;amp;')
+  })
+
+  test('escape `/` for preventing closing tags', () => {
+    expect(escapeHtml('</script>')).toBe('&lt;&#x2F;script&gt;')
+    expect(escapeHtml('javascript://')).toBe('javascript:&#x2F;&#x2F;')
+  })
+
+  test('escape `=` for preventing attribute injection', () => {
+    expect(escapeHtml('onerror=alert(1)')).toBe('onerror&#x3D;alert(1)')
+    expect(escapeHtml('src=x onerror=alert(1)')).toBe('src&#x3D;x onerror&#x3D;alert(1)')
+  })
+
+  test('prevent img `onerror` attack', () => {
+    expect(escapeHtml('<img src=x onerror=alert(1)>')).toBe(
+      '&lt;img src&#x3D;x onerror&#x3D;alert(1)&gt;'
+    )
+  })
+
+  test('prevent script injection', () => {
+    expect(escapeHtml('</script><script>alert(1)</script>')).toBe(
+      '&lt;&#x2F;script&gt;&lt;script&gt;alert(1)&lt;&#x2F;script&gt;'
+    )
+  })
+
+  test('handle complex XSS payloads', () => {
+    expect(escapeHtml('<img src="x" onerror="alert(\'XSS\')">')).toBe(
+      '&lt;img src&#x3D;&quot;x&quot; onerror&#x3D;&quot;alert(&apos;XSS&apos;)&quot;&gt;'
+    )
+  })
+
+  test('handle empty string', () => {
+    expect(escapeHtml('')).toBe('')
+  })
+
+  test('handle normal text without special characters', () => {
+    expect(escapeHtml('Hello World')).toBe('Hello World')
+  })
+
+  test('escape all special characters in order', () => {
+    expect(escapeHtml('&<>"\'/=')).toBe('&amp;&lt;&gt;&quot;&apos;&#x2F;&#x3D;')
+  })
+})
+
+describe('sanitizeTranslatedHtml', () => {
+  test('neutralize event handlers', () => {
+    const html = '<a href="#" onclick="alert(1)">Click</a>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<a href="#" &#111;nclick="alert(1)">Click</a>')
+  })
+
+  test('neutralize javascript URLs', () => {
+    const html = '<a href="javascript:alert(1)">Click</a>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<a href="javascript&#58;alert(1)">Click</a>')
+  })
+
+  test('escape dangerous characters in attribute values', () => {
+    const html = '<div title="<script>alert(1)</script>">Test</div>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<div title="&lt;script&gt;alert(1)&lt;/script&gt;">Test</div>')
+  })
+
+  test('handle class attribute with normal values', () => {
+    const html = '<div class="btn btn-primary">Button</div>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<div class="btn btn-primary">Button</div>')
+  })
+
+  test('escape dangerous characters in class attribute', () => {
+    const html = '<div class="normal&quot; onclick=&quot;alert(1)">Test</div>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<div class="normal&quot; &#111;nclick=&quot;alert(1)">Test</div>')
+  })
+
+  test('handle class attribute with script tags', () => {
+    const html = '<div class="<script>alert(1)</script>">Test</div>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<div class="&lt;script&gt;alert(1)&lt;/script&gt;">Test</div>')
+  })
+
+  test('handle multiple attributes including class', () => {
+    const html =
+      '<div id="test" class="btn&quot; onclick=&quot;alert(1)" data-value="<>">Test</div>'
+    const result = sanitizeTranslatedHtml(html)
+    // Check that dangerous characters in attribute values are escaped
+    expect(result).toContain('class="btn&quot;')
+    expect(result).toContain('data-value="&lt;&gt;"')
+    // Check that onclick is neutralized
+    expect(result).toContain('&#111;nclick=')
+  })
+
+  test('handle class attribute with single quotes', () => {
+    const html = "<div class='btn btn-danger'>Alert</div>"
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe("<div class='btn btn-danger'>Alert</div>")
+  })
+
+  test('escape single quotes in class attribute with single quotes', () => {
+    const html = "<div class='btn' onclick='alert(1)'>Test</div>"
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe("<div class='btn' &#111;nclick='alert(1)'>Test</div>")
+  })
+
+  test('handle id attribute with dangerous characters', () => {
+    const html = '<div id="test&quot; onclick=&quot;alert(1)">Test</div>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<div id="test&quot; &#111;nclick=&quot;alert(1)">Test</div>')
+  })
+
+  test('handle id attribute with script injection', () => {
+    const html = '<div id="<script>alert(1)</script>">Test</div>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<div id="&lt;script&gt;alert(1)&lt;/script&gt;">Test</div>')
+  })
+
+  test('handle style attribute with dangerous characters', () => {
+    const html = '<div style="color: red&quot; onclick=&quot;alert(1)">Test</div>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<div style="color: red&quot; &#111;nclick=&quot;alert(1)">Test</div>')
+  })
+
+  test('handle style attribute with javascript URL', () => {
+    const html = '<div style="background: url(javascript:alert(1))">Test</div>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<div style="background: url(javascript&#58;alert(1))">Test</div>')
+  })
+
+  test('handle style attribute with javascript URL with spaces', () => {
+    const html = '<div style="background: url( javascript:alert(1) )">Test</div>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<div style="background: url( javascript&#58;alert(1) )">Test</div>')
+  })
+
+  test('handle style attribute with uppercase JavaScript URL', () => {
+    const html = '<div style="background: url(JAVASCRIPT:alert(1))">Test</div>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<div style="background: url(javascript&#58;alert(1))">Test</div>')
+  })
+
+  test('handle multiple dangerous attributes including id and style', () => {
+    const html = '<div id="test&gt;" style="color: red" class="btn" onclick="alert(1)">Test</div>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toContain('id="test&gt;"')
+    expect(result).toContain('style="color: red"')
+    expect(result).toContain('class="btn"')
+    expect(result).toContain('&#111;nclick=')
+  })
+
+  test('handle formaction attribute with javascript URL', () => {
+    const html = '<button formaction="javascript:alert(1)">Submit</button>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<button formaction="javascript&#58;alert(1)">Submit</button>')
+  })
+
+  test('handle data attributes with javascript URL', () => {
+    const html = '<div data-href="javascript:alert(1)" data-value="safe">Test</div>'
+    const result = sanitizeTranslatedHtml(html)
+    // data-* attributes are not sanitized as they don't execute directly
+    expect(result).toBe('<div data-href="javascript:alert(1)" data-value="safe">Test</div>')
+  })
+
+  test('handle srcdoc attribute', () => {
+    const html = '<iframe srcdoc="<script>alert(1)</script>">Test</iframe>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<iframe srcdoc="&lt;script&gt;alert(1)&lt;/script&gt;">Test</iframe>')
+  })
+
+  test('handle attribute values without quotes', () => {
+    const html = '<img src=x onerror=alert(1)>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<img src=x &#111;nerror=alert(1)>')
+  })
+
+  test('handle mixed quote styles', () => {
+    const html = `<div title='test" onclick="alert(1)'>Test</div>`
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe(`<div title='test&quot; &#111;nclick=&quot;alert(1)'>Test</div>`)
+  })
+
+  test('handle HTML entities in attribute values', () => {
+    const html = '<div title="&lt;script&gt;alert(1)&lt;/script&gt;">Test</div>'
+    const result = sanitizeTranslatedHtml(html)
+    // Already escaped entities should remain as is
+    expect(result).toBe('<div title="&lt;script&gt;alert(1)&lt;/script&gt;">Test</div>')
+  })
+
+  test('handle nested quotes in attributes', () => {
+    const html = `<div title='"hello" onclick="alert(1)"'>Test</div>`
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe(
+      `<div title='&quot;hello&quot; &#111;nclick=&quot;alert(1)&quot;'>Test</div>`
+    )
+  })
+
+  // Accessibility (a11y) attributes tests
+  test('handle aria-label with dangerous characters', () => {
+    const html = '<button aria-label="Click to <script>alert(1)</script>">Button</button>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe(
+      '<button aria-label="Click to &lt;script&gt;alert(1)&lt;/script&gt;">Button</button>'
+    )
+  })
+
+  test('handle aria-describedby with quotes', () => {
+    const html = `<input aria-describedby="desc&quot; onclick=&quot;alert(1)" />`
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<input aria-describedby="desc&quot; &#111;nclick=&quot;alert(1)" />')
+  })
+
+  test('handle role attribute with dangerous characters', () => {
+    const html = '<div role="button&quot; onclick=&quot;alert(1)">Click</div>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<div role="button&quot; &#111;nclick=&quot;alert(1)">Click</div>')
+  })
+
+  test('handle tabindex attribute', () => {
+    const html = '<div tabindex="0&quot; onclick=&quot;alert(1)">Focusable</div>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<div tabindex="0&quot; &#111;nclick=&quot;alert(1)">Focusable</div>')
+  })
+
+  test('handle alt attribute with dangerous content', () => {
+    const html = '<img src="test.jpg" alt="Image of <script>alert(1)</script>" />'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe(
+      '<img src="test.jpg" alt="Image of &lt;script&gt;alert(1)&lt;/script&gt;" />'
+    )
+  })
+
+  test('handle title attribute with dangerous content', () => {
+    const html = '<abbr title="<img src=x onerror=alert(1)>">XSS</abbr>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<abbr title="&lt;img src=x &#111;nerror=alert(1)&gt;">XSS</abbr>')
+  })
+
+  test('handle multiple a11y attributes with dangerous content', () => {
+    const html =
+      '<button aria-label="<script>alert(1)</script>" role="button&quot; onclick=&quot;alert(1)" tabindex="0">Click</button>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toContain('aria-label="&lt;script&gt;alert(1)&lt;/script&gt;"')
+    expect(result).toContain('role="button&quot;')
+    expect(result).toContain('&#111;nclick=')
+    expect(result).toContain('tabindex="0"')
+  })
+
+  test('handle aria-hidden attribute', () => {
+    const html = '<div aria-hidden="true&quot; onclick=&quot;alert(1)">Hidden</div>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<div aria-hidden="true&quot; &#111;nclick=&quot;alert(1)">Hidden</div>')
+  })
+
+  test('handle aria-live attribute', () => {
+    const html = '<div aria-live="polite" aria-label="Status: <b>Active</b>">Status</div>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe(
+      '<div aria-live="polite" aria-label="Status: &lt;b&gt;Active&lt;/b&gt;">Status</div>'
+    )
+  })
 })

--- a/packages/shared/test/utils.test.ts
+++ b/packages/shared/test/utils.test.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest'
+import { JSDOM } from 'jsdom'
 
 // Mock the warn function before importing anything else
 vi.mock('../src/warn', () => ({
@@ -134,7 +135,21 @@ describe('sanitizeTranslatedHtml', () => {
   test('neutralize javascript URLs', () => {
     const html = '<a href="javascript:alert(1)">Click</a>'
     const result = sanitizeTranslatedHtml(html)
-    expect(result).toBe('<a href="javascript&#58;alert(1)">Click</a>')
+    expect(result).toBe('<a href="about:blank">Click</a>')
+  })
+
+  test('neutralize entity-encoded javascript URLs', () => {
+    const html = '<a href="javascript&#58;alert(1)">Click</a>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<a href="about:blank">Click</a>')
+  })
+
+  test('keep javascript URLs inert after DOM parsing', () => {
+    const html = '<a href="javascript:alert(1)">Click</a>'
+    const result = sanitizeTranslatedHtml(html)
+    const dom = new JSDOM(result)
+
+    expect(dom.window.document.querySelector('a')?.getAttribute('href')).toBe('about:blank')
   })
 
   test('escape dangerous characters in attribute values', () => {
@@ -205,19 +220,25 @@ describe('sanitizeTranslatedHtml', () => {
   test('handle style attribute with javascript URL', () => {
     const html = '<div style="background: url(javascript:alert(1))">Test</div>'
     const result = sanitizeTranslatedHtml(html)
-    expect(result).toBe('<div style="background: url(javascript&#58;alert(1))">Test</div>')
+    expect(result).toBe('<div style="background: url(about:blank)">Test</div>')
   })
 
   test('handle style attribute with javascript URL with spaces', () => {
     const html = '<div style="background: url( javascript:alert(1) )">Test</div>'
     const result = sanitizeTranslatedHtml(html)
-    expect(result).toBe('<div style="background: url( javascript&#58;alert(1) )">Test</div>')
+    expect(result).toBe('<div style="background: url(about:blank)">Test</div>')
   })
 
   test('handle style attribute with uppercase JavaScript URL', () => {
     const html = '<div style="background: url(JAVASCRIPT:alert(1))">Test</div>'
     const result = sanitizeTranslatedHtml(html)
-    expect(result).toBe('<div style="background: url(javascript&#58;alert(1))">Test</div>')
+    expect(result).toBe('<div style="background: url(about:blank)">Test</div>')
+  })
+
+  test('handle style attribute with entity-encoded javascript URL', () => {
+    const html = '<div style="background: url(javascript&#58;alert(1))">Test</div>'
+    const result = sanitizeTranslatedHtml(html)
+    expect(result).toBe('<div style="background: url(about:blank)">Test</div>')
   })
 
   test('handle multiple dangerous attributes including id and style', () => {
@@ -232,7 +253,7 @@ describe('sanitizeTranslatedHtml', () => {
   test('handle formaction attribute with javascript URL', () => {
     const html = '<button formaction="javascript:alert(1)">Submit</button>'
     const result = sanitizeTranslatedHtml(html)
-    expect(result).toBe('<button formaction="javascript&#58;alert(1)">Submit</button>')
+    expect(result).toBe('<button formaction="about:blank">Submit</button>')
   })
 
   test('handle data attributes with javascript URL', () => {

--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -468,18 +468,22 @@ export interface ComposerOptions<
   warnHtmlMessage?: boolean
   /**
    * @remarks
-   * If `escapeParameter` is configured as true then interpolation parameters are escaped before the message is translated.
+   * Whether to escape parameters for list or named interpolation values.
+   * When enabled, this option:
+   * - Escapes HTML special characters (`<`, `>`, `"`, `'`, `&`, `/`, `=`) in interpolation parameters
+   * - Sanitizes the final translated HTML to prevent XSS attacks by:
+   *   - Escaping dangerous characters in HTML attribute values
+   *   - Neutralizing event handler attributes (onclick, onerror, etc.)
+   *   - Disabling javascript: URLs in href, src, action, formaction, and style attributes
    *
    * This is useful when translation output is used in `v-html` and the translation resource contains html markup (e.g. around a user provided value).
    *
    * This usage pattern mostly occurs when passing precomputed text strings into UI components.
    *
-   * The escape process involves replacing the following symbols with their respective HTML character entities: `<`, `>`, `"`, `'`.
-   *
    * Setting `escapeParameter` as true should not break existing functionality but provides a safeguard against a subtle type of XSS attack vectors.
    *
    * See about:
-   * - [HTML Message](../../../guide/essentials/syntax#html-message)
+   * - [HTML Message - Using the escapeParameter option](../../../guide/essentials/syntax#using-the-escapeparameter-option)
    *
    * @default `false`
    */


### PR DESCRIPTION
Reapply the CVE-2025-53892 (escapeParameterHtml DOM XSS hardening) fix to master.

This follows the revert of #2470 (#2485). The functional fix itself is sound and matches what is already shipped in v11; the revert was performed only because the original contributor's identity was no longer trustworthy (account renamed and
deleted post-merge.

This PR reapplies the fix as a clean port by the maintainer, sourced directly from the trusted v11 commit `4aad98ee` ("Merge commit from fork") rather than from #2470.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stronger HTML sanitization for translated messages: escapes additional characters, neutralizes inline event handlers, and disables JavaScript URLs in attributes and styles; exposes a sanitization helper for translated HTML.

* **Documentation**
  * Added guide subsection for the escapeParameter option and expanded option docs with detailed sanitization behavior and usage examples.

* **Tests**
  * Added extensive security regression tests covering XSS-related escaping, attribute neutralization, and inert URL handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/intlify/vue-i18n/pull/2486?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->