### PR TITLE
chore!: drop Node.js 20 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node: [20, 22, 24]
+        node: [22, 24]
 
     runs-on: ${{ matrix.os }}
 
@@ -124,7 +124,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node: [20, 22, 24]
+        node: [22, 24]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "packageManager": "pnpm@10.30.1",
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "scripts": {
     "bench": "node ./benchmark/index.mjs",

--- a/packages/core-base/package.json
+++ b/packages/core-base/package.json
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 22"
   },
   "type": "module",
   "sideEffects": false,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 22"
   },
   "type": "module",
   "sideEffects": false,

--- a/packages/devtools-types/package.json
+++ b/packages/devtools-types/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 22"
   },
   "type": "module",
   "sideEffects": false,

--- a/packages/message-compiler/package.json
+++ b/packages/message-compiler/package.json
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 22"
   },
   "type": "module",
   "sideEffects": false,

--- a/packages/petite-vue-i18n/package.json
+++ b/packages/petite-vue-i18n/package.json
@@ -27,7 +27,7 @@
   ],
   "homepage": "https://github.com/intlify/vue-i18n/tree/master/packages/petite-vue-i18n#readme",
   "engines": {
-    "node": ">= 16"
+    "node": ">= 22"
   },
   "type": "module",
   "sideEffects": false,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 22"
   },
   "type": "module",
   "sideEffects": false,

--- a/packages/vue-i18n-core/package.json
+++ b/packages/vue-i18n-core/package.json
@@ -29,7 +29,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 22"
   },
   "type": "module",
   "sideEffects": false,

--- a/packages/vue-i18n/package.json
+++ b/packages/vue-i18n/package.json
@@ -26,7 +26,7 @@
   ],
   "homepage": "https://github.com/intlify/vue-i18n/tree/master/packages/vue-i18n#readme",
   "engines": {
-    "node": ">= 16"
+    "node": ">= 22"
   },
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Node.js version requirement to 22 across all packages and the root project
  * Updated GitHub Actions CI workflows to test against Node.js 22 and 24 (removed Node.js 20 from test matrix)
  * Updated nightly release workflow to use Node.js 22

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/intlify/vue-i18n/pull/2487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->