### PR TITLE
fix(shared): clear performance measures to prevent User Timing API me…

### DIFF
--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -28,6 +28,7 @@ if (__DEV__) {
       perf.measure(name, startTag, endTag)
       perf.clearMarks(startTag)
       perf.clearMarks(endTag)
+      perf.clearMeasures(name)
     }
   }
 }

--- a/packages/shared/test/performance.test.ts
+++ b/packages/shared/test/performance.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mark, measure } from '../src/utils'
+
+describe('performance timing utils', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('mark', () => {
+    it('should be defined in browser environment', () => {
+      expect(mark).toBeDefined()
+    })
+
+    it('should delegate to performance.mark', () => {
+      const spyMark = vi.spyOn(window.performance, 'mark')
+
+      if (!mark) throw new Error('mark is unexpectedly undefined in jsdom')
+
+      mark('test-tag')
+
+      expect(spyMark).toHaveBeenCalledTimes(1)
+      expect(spyMark).toHaveBeenCalledWith('test-tag')
+    })
+  })
+
+  describe('measure', () => {
+    it('should be defined in browser environment', () => {
+      expect(measure).toBeDefined()
+    })
+
+    it('should measure between two marks and clear them', () => {
+      const spyMeasure = vi.spyOn(window.performance, 'measure')
+      const spyClearMarks = vi.spyOn(window.performance, 'clearMarks')
+      const spyClearMeasures = vi.spyOn(window.performance, 'clearMeasures')
+
+      if (!mark) throw new Error('mark is unexpectedly undefined in jsdom')
+      if (!measure) throw new Error('measure is unexpectedly undefined in jsdom')
+
+      // Create marks first (required by the User Timing API spec)
+      mark('start-tag')
+      mark('end-tag')
+
+      measure('test-measure', 'start-tag', 'end-tag')
+
+      expect(spyMeasure).toHaveBeenCalledTimes(1)
+      expect(spyMeasure).toHaveBeenCalledWith('test-measure', 'start-tag', 'end-tag')
+
+      expect(spyClearMarks).toHaveBeenCalledTimes(2)
+      expect(spyClearMarks).toHaveBeenNthCalledWith(1, 'start-tag')
+      expect(spyClearMarks).toHaveBeenNthCalledWith(2, 'end-tag')
+
+      expect(spyClearMeasures).toHaveBeenCalledTimes(1)
+      expect(spyClearMeasures).toHaveBeenCalledWith('test-measure')
+    })
+  })
+})


### PR DESCRIPTION
## Bug Description

The `measure` utility in `@intlify/shared` calls `perf.clearMarks()` for
start/end tags but never calls `perf.clearMeasures()`. This causes
`PerformanceMeasure` entries to accumulate indefinitely in the browser's
performance timeline buffer during development.

In long-running sessions with frequent translations, the buffer grows to
hundreds of thousands of entries, degrading `clearMarks()` and GC
operations to O(N) and consuming significant CPU time (~28% in our case).

## Fix

Add `perf.clearMeasures(name)` immediately after recording each measure
in `packages/shared/src/utils.ts`. This clears the entry from the live
buffer while preserving data already captured by an active DevTools
Performance recording.

## Tests

Added `packages/shared/test/performance.test.ts` — runs in JSDOM
environment, verifies that `mark` and `measure` correctly delegate to
the Performance API and that all marks and measures are cleaned up.

All existing tests pass (`pnpm test:unit` — 811 tests, 0 failures).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance measurement cleanup to ensure measurements are properly cleared after being recorded, preventing potential memory issues and ensuring accurate subsequent measurements.

* **Tests**
  * Added comprehensive test suite for performance timing utilities to verify correct operation and ensure proper cleanup of all performance tracking elements in supported environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/intlify/vue-i18n/pull/2515?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->