### PR TITLE
Return NumberFormat part if no translation message key is provided

### DIFF
--- a/packages/core-base/src/number.ts
+++ b/packages/core-base/src/number.ts
@@ -196,8 +196,8 @@ export function number<Context extends CoreContext<Message, {}, {}, {}>, Message
   const locales = localeFallbacker(context as any, fallbackLocale as FallbackLocale, locale)
 
   if (!isString(key) || key === '') {
-    let formatter = new Intl.NumberFormat(locale.replace(/!/g, ''), overrides);
-    return !part ? formatter.format(value) : formatter.formatToParts(value);
+    let formatter = new Intl.NumberFormat(locale.replace(/!/g, ''), overrides)
+    return !part ? formatter.format(value) : formatter.formatToParts(value)
   }
 
   // resolve format

--- a/packages/core-base/src/number.ts
+++ b/packages/core-base/src/number.ts
@@ -196,7 +196,8 @@ export function number<Context extends CoreContext<Message, {}, {}, {}>, Message
   const locales = localeFallbacker(context as any, fallbackLocale as FallbackLocale, locale)
 
   if (!isString(key) || key === '') {
-    return new Intl.NumberFormat(locale.replace(/!/g, ''), overrides).format(value)
+    let formatter = new Intl.NumberFormat(locale.replace(/!/g, ''), overrides);
+    return !part ? formatter.format(value) : formatter.formatToParts(value);
   }
 
   // resolve format


### PR DESCRIPTION
Fixes a check in vuetify i18n implementation (see [here](https://github.com/vuetifyjs/vuetify/blob/ecabcc54d9c3d9a4f359f8c78dfa49f7a1e46865/packages/vuetify/src/locale/adapters/vue-i18n.ts#L35)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Number formatting now consistently respects the `part` option across all cases, returning either a formatted string or formatted parts as requested. This resolves inconsistent outputs and ensures predictable formatting behavior for consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->