### PR TITLE
fix(core-base): respect `part` option when format key is omitted in `number`/`datetime`

### DIFF
--- a/packages/core-base/src/datetime.ts
+++ b/packages/core-base/src/datetime.ts
@@ -198,7 +198,8 @@ export function datetime<Context extends CoreContext<Message, {}, {}, {}>, Messa
   const locales = localeFallbacker(context as any, fallbackLocale as FallbackLocale, locale)
 
   if (!isString(key) || key === '') {
-    return new Intl.DateTimeFormat(locale.replace(/!/g, ''), overrides).format(value)
+    const formatter = new Intl.DateTimeFormat(locale.replace(/!/g, ''), overrides)
+    return !part ? formatter.format(value) : formatter.formatToParts(value)
   }
 
   // resolve format

--- a/packages/core-base/src/number.ts
+++ b/packages/core-base/src/number.ts
@@ -196,7 +196,8 @@ export function number<Context extends CoreContext<Message, {}, {}, {}>, Message
   const locales = localeFallbacker(context as any, fallbackLocale as FallbackLocale, locale)
 
   if (!isString(key) || key === '') {
-    return new Intl.NumberFormat(locale.replace(/!/g, ''), overrides).format(value)
+    const formatter = new Intl.NumberFormat(locale.replace(/!/g, ''), overrides)
+    return !part ? formatter.format(value) : formatter.formatToParts(value)
   }
 
   // resolve format

--- a/packages/core-base/test/datetime.test.ts
+++ b/packages/core-base/test/datetime.test.ts
@@ -304,6 +304,20 @@ test('part', () => {
   ])
 })
 
+test('part without key', () => {
+  const mockAvailabilities = Availabilities
+  mockAvailabilities.dateTimeFormat = true
+
+  const ctx = context({
+    locale: 'en-US',
+    datetimeFormats
+  })
+
+  expect(datetime(ctx, dt, { year: 'numeric', timeZone: 'UTC', part: true })).toEqual([
+    { type: 'year', value: '2012' }
+  ])
+})
+
 test('not available Intl API', () => {
   const mockWarn = vi.spyOn(shared, 'warn')
   mockWarn.mockImplementation(() => {})

--- a/packages/core-base/test/number.test.ts
+++ b/packages/core-base/test/number.test.ts
@@ -267,6 +267,22 @@ test('part', () => {
   ])
 })
 
+test('part without key', () => {
+  const mockAvailabilities = Availabilities
+  mockAvailabilities.numberFormat = true
+
+  const ctx = context({
+    locale: 'en-US',
+    numberFormats
+  })
+
+  expect(number(ctx, 1000, { useGrouping: true, part: true })).toEqual([
+    { type: 'integer', value: '1' },
+    { type: 'group', value: ',' },
+    { type: 'integer', value: '000' }
+  ])
+})
+
 test('not available Intl API', () => {
   const mockWarn = vi.spyOn(shared, 'warn')
   mockWarn.mockImplementation(() => {})


### PR DESCRIPTION
Closes #2518

`n()` / `d()` with `part: true` returned a string instead of parts when no format key was given. Fixed in both `number.ts` and `datetime.ts`. Tests added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed datetime formatting to properly support parts output in fast-path execution when format key is not provided
  * Fixed number formatting to properly support parts output in fast-path execution when format key is not provided

* **Tests**
  * Added test coverage for datetime parts formatting without a format key
  * Added test coverage for number parts formatting without a format key

<!-- end of auto-generated comment: release notes by coderabbit.ai -->