### PR TITLE
chore: exclude auto-generated CHANGELOG.md from oxfmt

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ packages/size-check-petite-vue-i18n/index.html
 packages/size-check-vue-i18n/index.html
 package.json
 packages/**/package.json
+CHANGELOG.md


### PR DESCRIPTION
`CHANGELOG.md` is auto-generated (gh-changelogen) and fails `lint:oxfmt`. Exclude it.