### PR TITLE
fix(core-base): respect `part` option when format key is omitted in `number`/`datetime`

### DIFF
--- a/packages/core-base/src/datetime.ts
+++ b/packages/core-base/src/datetime.ts
@@ -235,9 +235,11 @@ export function datetime<
   )
 
   if (!isString(key) || key === '') {
-    return new Intl.DateTimeFormat(locale.replace(/!/g, ''), overrides).format(
-      value
+    const formatter = new Intl.DateTimeFormat(
+      locale.replace(/!/g, ''),
+      overrides
     )
+    return !part ? formatter.format(value) : formatter.formatToParts(value)
   }
 
   // resolve format

--- a/packages/core-base/src/number.ts
+++ b/packages/core-base/src/number.ts
@@ -230,9 +230,8 @@ export function number<
   )
 
   if (!isString(key) || key === '') {
-    return new Intl.NumberFormat(locale.replace(/!/g, ''), overrides).format(
-      value
-    )
+    const formatter = new Intl.NumberFormat(locale.replace(/!/g, ''), overrides)
+    return !part ? formatter.format(value) : formatter.formatToParts(value)
   }
 
   // resolve format

--- a/packages/core-base/test/datetime.test.ts
+++ b/packages/core-base/test/datetime.test.ts
@@ -313,6 +313,20 @@ test('part', () => {
   ])
 })
 
+test('part without key', () => {
+  const mockAvailabilities = Availabilities
+  mockAvailabilities.dateTimeFormat = true
+
+  const ctx = context({
+    locale: 'en-US',
+    datetimeFormats
+  })
+
+  expect(
+    datetime(ctx, dt, { year: 'numeric', timeZone: 'UTC', part: true })
+  ).toEqual([{ type: 'year', value: '2012' }])
+})
+
 test('not available Intl API', () => {
   const mockWarn = vi.spyOn(shared, 'warn')
   mockWarn.mockImplementation(() => {})

--- a/packages/core-base/test/number.test.ts
+++ b/packages/core-base/test/number.test.ts
@@ -281,6 +281,22 @@ test('part', () => {
   ])
 })
 
+test('part without key', () => {
+  const mockAvailabilities = Availabilities
+  mockAvailabilities.numberFormat = true
+
+  const ctx = context({
+    locale: 'en-US',
+    numberFormats
+  })
+
+  expect(number(ctx, 1000, { useGrouping: true, part: true })).toEqual([
+    { type: 'integer', value: '1' },
+    { type: 'group', value: ',' },
+    { type: 'integer', value: '000' }
+  ])
+})
+
 test('not available Intl API', () => {
   const mockWarn = vi.spyOn(shared, 'warn')
   mockWarn.mockImplementation(() => {})


### PR DESCRIPTION
ref #2518 #2520 

The keyless early-return path always called `format()` and ignored the `part` option, so `n(1000, { part: true })` returned a string while its type was narrowed to `Intl.NumberFormatPart[]`.

(cherry picked from commit 81f6c1bbd6f408ef6e130ca0d6e6c8485ae625de)