### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -21,6 +21,10 @@ yarn add vue-i18n@11
 pnpm add vue-i18n@11
 ```
 
+```sh [deno]
+deno add vue-i18n@11
+```
+
 :::
 
 When using with a module system, you must explicitly install the `vue-i18n`


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install code-group lists the usual package managers. Since Deno is a drop-in replacement for npm these days, this adds a Deno entry in parity:

```sh
deno add vue-i18n@11
```

Docs-only change. Totally fine to close this if you'd rather not. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Deno as a supported installation option in the installation guide, providing an additional package manager choice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->