### PR TITLE
Mark Composer te as context-independent

### DIFF
--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -1492,6 +1492,7 @@ export interface Composer<
    * @returns If found locale message, `true`, else `false`, Note that `false` is returned even if the value present in the key is not translatable, yet if `translateExistCompatible` is set to `true`, it will return `true` if the key is available, even if the value is not translatable.
    */
   te<Str extends string, Key extends PickupKeys<Messages> = PickupKeys<Messages>>(
+    this: void,
     key: Str | Key,
     locale?: Locales
   ): boolean

--- a/packages/vue-i18n-core/test/composer.test-d.ts
+++ b/packages/vue-i18n-core/test/composer.test-d.ts
@@ -104,6 +104,7 @@ test('loose composer', () => {
   expectTypeOf(looseComposer.t(1, { foo: 1 }, { locale: 'en' })).toEqualTypeOf<string>()
   expectTypeOf(looseComposer.t('nest', { foo: 1 }, 'msg')).toEqualTypeOf<string>()
   expectTypeOf(looseComposer.te('errors', 'en')).toEqualTypeOf<boolean>()
+  expectTypeOf<ThisParameterType<typeof looseComposer.te>>().toEqualTypeOf<void>()
   expectTypeOf(looseComposer.tm('nest')).toEqualTypeOf<{ bar: string }>()
   expectTypeOf(looseComposer.tm('errors')).toEqualTypeOf<
     | string


### PR DESCRIPTION
`Composer.te` is implemented as a context-independent closure, but its type declaration does not express that. As a result, safely destructuring it triggers `@typescript-eslint/unbound-method`:

```ts
const { te } = useI18n()
te('some.key')
```

This adds this: void to the te declaration so its type matches the runtime implementation. It also adds a type test for the context-independent contract. There are no runtime changes.

Related:
- https://github.com/intlify/vue-i18n/issues/324
- https://typescript-eslint.io/rules/unbound-method/




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript type checking for the translation-existence method when called or passed as a callback.

* **Tests**
  * Added type coverage to verify the method can be used without an implicit `this` context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->