### PR TITLE
test: cover Vue 3.6 RC Vapor compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
       - name: Run unit tests
         run: |
           pnpm test:cover
+          pnpm test:vapor
 
   test-e2e:
     name: E2E test

--- a/package.json
+++ b/package.json
@@ -69,10 +69,11 @@
     "preview:size-petite-vue-i18n": "pnpm --filter @intlify/size-check-petite-vue-i18n preview",
     "preview:size-vue-i18n": "pnpm --filter @intlify/size-check-vue-i18n preview",
     "release": "bumpp package.json packages/**/package.json --commit \"release: v\" --push --tag",
-    "test": "pnpm lint && pnpm test:cover && pnpm check-install && pnpm test:e2e",
+    "test": "pnpm lint && pnpm test:cover && pnpm test:vapor && pnpm check-install && pnpm test:e2e",
     "test:cover": "pnpm test:unit --coverage",
     "test:e2e": "cross-env TZ=UTC vitest run -c ./vitest.e2e.config.ts",
-    "test:unit": "cross-env TZ=UTC vitest run -c ./vitest.unit.config.ts --typecheck"
+    "test:unit": "cross-env TZ=UTC vitest run -c ./vitest.unit.config.ts --typecheck",
+    "test:vapor": "cross-env TZ=UTC vitest run -c ./vitest.vapor.config.ts --typecheck"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
@@ -159,7 +160,7 @@
   "packageManager": "pnpm@10.33.2",
   "pnpm": {
     "overrides": {
-      "vue": "3.6.0-alpha.4",
+      "vue": "3.6.0-rc.1",
       "vite": "^6.0.0"
     },
     "onlyBuiltDependencies": [

--- a/packages/vue-i18n-core/test/vapor.test.ts
+++ b/packages/vue-i18n-core/test/vapor.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import {
+  createVaporApp,
+  defineVaporComponent,
+  nextTick,
+  renderEffect
+} from 'vue'
+import { createI18n, useI18n } from 'vue-i18n'
+
+test('uses the Composition API in a Vapor component', async () => {
+  const container = document.createElement('div')
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: {
+      en: { hello: 'Hello from Vapor' },
+      ja: { hello: 'Vaporからこんにちは' }
+    }
+  })
+  const App = defineVaporComponent(() => {
+    const { t } = useI18n()
+    const element = document.createElement('p')
+
+    renderEffect(() => {
+      element.textContent = t('hello')
+    })
+
+    return element
+  })
+  const app = createVaporApp(App)
+
+  app.use(i18n)
+  app.mount(container)
+
+  expect(container.innerHTML).toBe('<p>Hello from Vapor</p>')
+
+  i18n.global.locale.value = 'ja'
+  await nextTick()
+  expect(container.innerHTML).toBe('<p>Vaporからこんにちは</p>')
+
+  app.unmount()
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  vue: 3.6.0-alpha.4
+  vue: 3.6.0-rc.1
   vite: ^6.0.0
 
 importers:
@@ -176,7 +176,7 @@ importers:
         version: 8.4.0(eslint@9.9.1(jiti@1.21.0))(typescript@5.5.4)
       vitepress:
         specifier: 1.5.0
-        version: 1.5.0(@algolia/client-search@4.23.2)(@types/node@22.5.3)(@vue/composition-api@1.7.2(vue@3.6.0-alpha.4(typescript@5.5.4)))(jiti@1.21.0)(postcss@8.5.6)(search-insights@2.13.0)(terser@5.27.0)(tsx@4.11.2)(typescript@5.5.4)(yaml@2.9.0)
+        version: 1.5.0(@algolia/client-search@4.23.2)(@types/node@22.5.3)(@vue/composition-api@1.7.2(vue@3.6.0-rc.1(typescript@5.5.4)))(jiti@1.21.0)(postcss@8.5.20)(search-insights@2.13.0)(terser@5.27.0)(tsx@4.11.2)(typescript@5.5.4)(yaml@2.9.0)
       vitepress-plugin-llms:
         specifier: ^1.1.0
         version: 1.1.0
@@ -184,8 +184,8 @@ importers:
         specifier: ^2.1.5
         version: 2.1.5(@types/node@22.5.3)(jiti@1.21.0)(jsdom@24.0.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0)
       vue:
-        specifier: 3.6.0-alpha.4
-        version: 3.6.0-alpha.4(typescript@5.5.4)
+        specifier: 3.6.0-rc.1
+        version: 3.6.0-rc.1(typescript@5.5.4)
       vue-i18n:
         specifier: workspace:*
         version: link:packages/vue-i18n
@@ -193,18 +193,18 @@ importers:
   examples/backend:
     dependencies:
       vue:
-        specifier: 3.6.0-alpha.4
-        version: 3.6.0-alpha.4(typescript@5.3.3)
+        specifier: 3.6.0-rc.1
+        version: 3.6.0-rc.1(typescript@5.3.3)
       vue-i18n:
         specifier: workspace:*
         version: link:../../packages/vue-i18n
     devDependencies:
       '@intlify/bundle-utils':
         specifier: next
-        version: 12.0.0-alpha.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(petite-vue-i18n@11.4.5(vue@3.6.0-alpha.4(typescript@5.3.3)))(vue-i18n@packages+vue-i18n)
+        version: 12.0.0-alpha.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(petite-vue-i18n@11.4.6(vue@3.6.0-rc.1(typescript@5.3.3)))(vue-i18n@packages+vue-i18n)
       '@intlify/unplugin-vue-i18n':
         specifier: ^0.12.0
-        version: 0.12.3(petite-vue-i18n@11.4.5(vue@3.6.0-alpha.4(typescript@5.3.3)))(rollup@4.59.0)(vue-i18n@packages+vue-i18n)
+        version: 0.12.3(petite-vue-i18n@11.4.6(vue@3.6.0-rc.1(typescript@5.3.3)))(rollup@4.59.0)(vue-i18n@packages+vue-i18n)
       '@types/body-parser':
         specifier: ^1.19.2
         version: 1.19.5
@@ -213,7 +213,7 @@ importers:
         version: 4.17.21
       '@vitejs/plugin-vue':
         specifier: ^4.2.3
-        version: 4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-alpha.4(typescript@5.3.3))
+        version: 4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-rc.1(typescript@5.3.3))
       body-parser:
         specifier: ^1.20.3
         version: 1.20.3
@@ -242,21 +242,21 @@ importers:
   examples/lazy-loading/vite:
     dependencies:
       vue:
-        specifier: 3.6.0-alpha.4
-        version: 3.6.0-alpha.4(typescript@5.3.3)
+        specifier: 3.6.0-rc.1
+        version: 3.6.0-rc.1(typescript@5.3.3)
       vue-i18n:
         specifier: workspace:*
         version: link:../../../packages/vue-i18n
       vue-router:
         specifier: '4'
-        version: 4.2.5(vue@3.6.0-alpha.4(typescript@5.3.3))
+        version: 4.2.5(vue@3.6.0-rc.1(typescript@5.3.3))
     devDependencies:
       '@intlify/unplugin-vue-i18n':
         specifier: ^0.12.0
-        version: 0.12.3(petite-vue-i18n@11.4.5(vue@3.6.0-alpha.4(typescript@5.3.3)))(rollup@4.59.0)(vue-i18n@packages+vue-i18n)
+        version: 0.12.3(petite-vue-i18n@11.4.6(vue@3.6.0-rc.1(typescript@5.3.3)))(rollup@4.59.0)(vue-i18n@packages+vue-i18n)
       '@vitejs/plugin-vue':
         specifier: ^4.2.3
-        version: 4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-alpha.4(typescript@5.3.3))
+        version: 4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-rc.1(typescript@5.3.3))
       typescript:
         specifier: ^5.0.2
         version: 5.3.3
@@ -270,18 +270,18 @@ importers:
   examples/lazy-loading/webpack:
     dependencies:
       vue:
-        specifier: 3.6.0-alpha.4
-        version: 3.6.0-alpha.4(typescript@5.9.3)
+        specifier: 3.6.0-rc.1
+        version: 3.6.0-rc.1(typescript@5.9.3)
       vue-i18n:
         specifier: workspace:*
         version: link:../../../packages/vue-i18n
       vue-router:
         specifier: ^4.0.5
-        version: 4.2.5(vue@3.6.0-alpha.4(typescript@5.9.3))
+        version: 4.2.5(vue@3.6.0-rc.1(typescript@5.9.3))
     devDependencies:
       '@intlify/vue-i18n-loader':
         specifier: ^3.2.0
-        version: 3.3.0(vue@3.6.0-alpha.4(typescript@5.9.3))
+        version: 3.3.0(vue@3.6.0-rc.1(typescript@5.9.3))
       '@vue/compiler-sfc':
         specifier: ^3.2.0
         version: 3.4.19
@@ -299,7 +299,7 @@ importers:
         version: 4.1.1(file-loader@6.2.0(webpack@4.47.0))(webpack@4.47.0)
       vue-loader:
         specifier: ^16.8.0
-        version: 16.8.3(@vue/compiler-sfc@3.4.19)(vue@3.6.0-alpha.4(typescript@5.9.3))(webpack@4.47.0)
+        version: 16.8.3(@vue/compiler-sfc@3.4.19)(vue@3.6.0-rc.1(typescript@5.9.3))(webpack@4.47.0)
       webpack:
         specifier: ^4.44.0
         version: 4.47.0(webpack-cli@3.3.12)
@@ -316,15 +316,15 @@ importers:
         specifier: ^10.5.0
         version: 10.5.11
       vue:
-        specifier: 3.6.0-alpha.4
-        version: 3.6.0-alpha.4(typescript@5.3.3)
+        specifier: 3.6.0-rc.1
+        version: 3.6.0-rc.1(typescript@5.3.3)
       vue-i18n:
         specifier: workspace:*
         version: link:../../packages/vue-i18n
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^4.2.3
-        version: 4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-alpha.4(typescript@5.3.3))
+        version: 4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-rc.1(typescript@5.3.3))
       typescript:
         specifier: ^5.0.2
         version: 5.3.3
@@ -342,18 +342,18 @@ importers:
   examples/tsx:
     dependencies:
       vue:
-        specifier: 3.6.0-alpha.4
-        version: 3.6.0-alpha.4(typescript@5.9.3)
+        specifier: 3.6.0-rc.1
+        version: 3.6.0-rc.1(typescript@5.9.3)
       vue-i18n:
         specifier: workspace:*
         version: link:../../packages/vue-i18n
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^4.2.3
-        version: 4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-alpha.4(typescript@5.9.3))
+        version: 4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-rc.1(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx':
         specifier: ^3.0.2
-        version: 3.1.0(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-alpha.4(typescript@5.9.3))
+        version: 3.1.0(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-rc.1(typescript@5.9.3))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.4.19
@@ -367,15 +367,15 @@ importers:
   examples/type-safe/global-type-definition:
     dependencies:
       vue:
-        specifier: 3.6.0-alpha.4
-        version: 3.6.0-alpha.4(typescript@5.3.3)
+        specifier: 3.6.0-rc.1
+        version: 3.6.0-rc.1(typescript@5.3.3)
       vue-i18n:
         specifier: workspace:*
         version: link:../../../packages/vue-i18n
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^4.2.3
-        version: 4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-alpha.4(typescript@5.3.3))
+        version: 4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-rc.1(typescript@5.3.3))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.4.19
@@ -392,15 +392,15 @@ importers:
   examples/type-safe/type-annotation:
     dependencies:
       vue:
-        specifier: 3.6.0-alpha.4
-        version: 3.6.0-alpha.4(typescript@5.3.3)
+        specifier: 3.6.0-rc.1
+        version: 3.6.0-rc.1(typescript@5.3.3)
       vue-i18n:
         specifier: workspace:*
         version: link:../../../packages/vue-i18n
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^4.2.3
-        version: 4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-alpha.4(typescript@5.3.3))
+        version: 4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-rc.1(typescript@5.3.3))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.4.19
@@ -417,18 +417,18 @@ importers:
   examples/web-components:
     dependencies:
       vue:
-        specifier: 3.6.0-alpha.4
-        version: 3.6.0-alpha.4(typescript@5.3.3)
+        specifier: 3.6.0-rc.1
+        version: 3.6.0-rc.1(typescript@5.3.3)
       vue-i18n:
         specifier: workspace:*
         version: link:../../packages/vue-i18n
     devDependencies:
       '@intlify/unplugin-vue-i18n':
         specifier: ^0.12.0
-        version: 0.12.3(petite-vue-i18n@11.4.5(vue@3.6.0-alpha.4(typescript@5.3.3)))(rollup@4.59.0)(vue-i18n@packages+vue-i18n)
+        version: 0.12.3(petite-vue-i18n@11.4.6(vue@3.6.0-rc.1(typescript@5.3.3)))(rollup@4.59.0)(vue-i18n@packages+vue-i18n)
       '@vitejs/plugin-vue':
         specifier: ^4.2.3
-        version: 4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-alpha.4(typescript@5.3.3))
+        version: 4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-rc.1(typescript@5.3.3))
       typescript:
         specifier: ^5.0.2
         version: 5.3.3
@@ -478,12 +478,12 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       vue:
-        specifier: 3.6.0-alpha.4
-        version: 3.6.0-alpha.4(typescript@5.9.3)
+        specifier: 3.6.0-rc.1
+        version: 3.6.0-rc.1(typescript@5.9.3)
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^5.0.0
-        version: 5.0.4(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-alpha.4(typescript@5.9.3))
+        version: 5.0.4(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-rc.1(typescript@5.9.3))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.4.19
@@ -518,8 +518,8 @@ importers:
         specifier: ^6.5.0
         version: 6.5.1
       vue:
-        specifier: 3.6.0-alpha.4
-        version: 3.6.0-alpha.4(typescript@5.9.3)
+        specifier: 3.6.0-rc.1
+        version: 3.6.0-rc.1(typescript@5.9.3)
 
   packages/shared: {}
 
@@ -539,12 +539,12 @@ importers:
         specifier: workspace:*
         version: link:../petite-vue-i18n
       vue:
-        specifier: 3.6.0-alpha.4
-        version: 3.6.0-alpha.4(typescript@5.9.3)
+        specifier: 3.6.0-rc.1
+        version: 3.6.0-rc.1(typescript@5.9.3)
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^5.0.0
-        version: 5.0.4(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-alpha.4(typescript@5.9.3))
+        version: 5.0.4(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-rc.1(typescript@5.9.3))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.4.19
@@ -558,15 +558,15 @@ importers:
   packages/size-check-vue-i18n:
     dependencies:
       vue:
-        specifier: 3.6.0-alpha.4
-        version: 3.6.0-alpha.4(typescript@5.9.3)
+        specifier: 3.6.0-rc.1
+        version: 3.6.0-rc.1(typescript@5.9.3)
       vue-i18n:
         specifier: workspace:*
         version: link:../vue-i18n
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^5.0.0
-        version: 5.0.4(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-alpha.4(typescript@5.9.3))
+        version: 5.0.4(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-rc.1(typescript@5.9.3))
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.4.19
@@ -592,8 +592,8 @@ importers:
         specifier: ^6.5.0
         version: 6.5.1
       vue:
-        specifier: 3.6.0-alpha.4
-        version: 3.6.0-alpha.4(typescript@5.9.3)
+        specifier: 3.6.0-rc.1
+        version: 3.6.0-rc.1(typescript@5.9.3)
 
   packages/vue-i18n-core:
     dependencies:
@@ -610,8 +610,8 @@ importers:
         specifier: ^6.5.0
         version: 6.5.1
       vue:
-        specifier: 3.6.0-alpha.4
-        version: 3.6.0-alpha.4(typescript@5.9.3)
+        specifier: 3.6.0-rc.1
+        version: 3.6.0-rc.1(typescript@5.9.3)
 
 packages:
 
@@ -789,32 +789,20 @@ packages:
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.23.4':
-    resolution: {integrity: sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-string-parser@7.24.8':
-    resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.22.20':
-    resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.24.7':
-    resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.27.1':
-    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.23.5':
@@ -834,18 +822,13 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@7.25.6':
-    resolution: {integrity: sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.27.2':
-    resolution: {integrity: sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.28.5':
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -879,16 +862,12 @@ packages:
     resolution: {integrity: sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.25.6':
-    resolution: {integrity: sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.27.1':
-    resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -1295,8 +1274,8 @@ packages:
       vue-i18n:
         optional: true
 
-  '@intlify/core-base@11.4.5':
-    resolution: {integrity: sha512-lja3F/iKVIvTa48mIwmrIeDcQUFZ0F0drvFvT8AwINOvbwnAzl/S/p8p2DxILZpWEUHRi1qewfWNIkMvhD3kKA==}
+  '@intlify/core-base@11.4.6':
+    resolution: {integrity: sha512-EOeHO95XESK9IFHgHeZXunsM/WBAoCA0DlaWODvx14vKmetAuS97t+l6Xe9hTUqntPpF93vtVSjjUDafw3wXMw==}
     engines: {node: '>= 22'}
 
   '@intlify/core-base@9.10.2':
@@ -1307,12 +1286,12 @@ packages:
     resolution: {integrity: sha512-t/RVemtM3bTE/wa7zqR+zkumy4dda5skVhxAh+3oYbOyJRw1y3B0FWiuB2Awa1HgoYC0DuPYrsAsQoeLy2eQPQ==}
     engines: {node: '>= 16'}
 
-  '@intlify/devtools-types@11.4.5':
-    resolution: {integrity: sha512-W5vydP9Yq3t82IyWqCM6aR0BTWCZrN5RAwjZEPpH8I2OQWp2RLy03Evh2ANZlSMhcvGAoyDg25k0so85Kwncpw==}
+  '@intlify/devtools-types@11.4.6':
+    resolution: {integrity: sha512-wowQPpNem56b2d43IJmqbrzG2FeBKe5f/kUGlpNuBmXs6OSqncF8m1+1lxHuW8ISZJF0ma2RkW3iLkw0g0G4VA==}
     engines: {node: '>= 22'}
 
-  '@intlify/message-compiler@11.4.5':
-    resolution: {integrity: sha512-IEOZiHtbQopyPc/Dz2M869lOlZYX1SdcniNJwphATDYHhovvIneEKf1EFF37DE7NAABZtza1FNtnwwqZWInfpw==}
+  '@intlify/message-compiler@11.4.6':
+    resolution: {integrity: sha512-5nj3jULqeTAC1WovwMs1LQWgatTa2pM/rXN9T3XW8rdOtXW9ZF6/GLSNFTKDQmPLwclhPdgUWLJ/4w3fMeeC/Q==}
     engines: {node: '>= 22'}
 
   '@intlify/message-compiler@12.0.0-alpha.4':
@@ -1327,8 +1306,8 @@ packages:
     resolution: {integrity: sha512-IHzgEu61/YIpQV5Pc3aRWScDcnFKWvQA9kigcINcCBXN8mbW+vk9SK+lDxA6STzKQsVJxUPg9ACC52pKKo3SVQ==}
     engines: {node: '>= 16'}
 
-  '@intlify/shared@11.4.5':
-    resolution: {integrity: sha512-g/i5mtdUa9ia/8BaJ4w6ZRHgAXYQd9XyCaQPRMvsd8d5qmZwkjoTmHrNsI28Q/7I8h+2ijUkI4uEnnMCziKupQ==}
+  '@intlify/shared@11.4.6':
+    resolution: {integrity: sha512-m1p1HHAMLhqSpTRH7VnXdrN0CQ4y+9vunFkpLkbD8soIuBsnQdawZXqMCgvwI2UVF9Ww7sVaw7g9tV2VO7shoA==}
     engines: {node: '>= 22'}
 
   '@intlify/shared@12.0.0-alpha.4':
@@ -1375,7 +1354,7 @@ packages:
     engines: {node: '>= 12'}
     deprecated: This package no longer supported. About maintenance status, see https://github.com/intlify/bundle-tools?tab=readme-ov-file#-packages
     peerDependencies:
-      vue: 3.6.0-alpha.4
+      vue: 3.6.0-rc.1
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2391,28 +2370,28 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^6.0.0
-      vue: 3.6.0-alpha.4
+      vue: 3.6.0-rc.1
 
   '@vitejs/plugin-vue@4.6.2':
     resolution: {integrity: sha512-kqf7SGFoG+80aZG6Pf+gsZIVvGSCKE98JbiWqcCV9cThtg91Jav0yvYFC9Zb+jKetNGF6ZKeoaxgZfND21fWKw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^6.0.0
-      vue: 3.6.0-alpha.4
+      vue: 3.6.0-rc.1
 
   '@vitejs/plugin-vue@5.0.4':
     resolution: {integrity: sha512-WS3hevEszI6CEVEx28F8RjTX97k3KsrcY6kvTg7+Whm5y3oYvcqzVeGCU3hxSAn4uY2CLCkeokkGKpoctccilQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       vite: ^6.0.0
-      vue: 3.6.0-alpha.4
+      vue: 3.6.0-rc.1
 
   '@vitejs/plugin-vue@5.1.4':
     resolution: {integrity: sha512-N2XSI2n3sQqp5w7Y/AN/L2XDjBIRGqXko+eDp42sydYSBeJuSm5a1sLf8zakmo8u7tA8NmBgoDLA1HeOESjp9A==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       vite: ^6.0.0
-      vue: 3.6.0-alpha.4
+      vue: 3.6.0-rc.1
 
   '@vitest/coverage-v8@2.1.5':
     resolution: {integrity: sha512-/RoopB7XGW7UEkUndRXF87A9CwkoZAJW01pj8/3pgmDVsjMH2IKy6H1A38po9tmUlwhSyYs0az82rbKd9Yaynw==}
@@ -2492,8 +2471,8 @@ packages:
   '@vue/compiler-core@3.5.14':
     resolution: {integrity: sha512-k7qMHMbKvoCXIxPhquKQVw3Twid3Kg4s7+oYURxLGRd56LiuHJVrvFKI4fm2AM3c8apqODPfVJGoh8nePbXMRA==}
 
-  '@vue/compiler-core@3.6.0-alpha.4':
-    resolution: {integrity: sha512-Z2yBj9sxi/C46qKw549dqpb0ZqIH/5FGeLT5inV8cXbbgBn9AfH6+3aIWVd0HJ0oSnHSr/sPE+pn0PXrWOnwoA==}
+  '@vue/compiler-core@3.6.0-rc.1':
+    resolution: {integrity: sha512-0zHxvG8TBoqFYzA35RHEdS5tDt18+CJ6vhwvYKICnGBt04Wrw2hElMyuaoQ9neCdDpTRX0pNOoj8Sr/JPj6wMA==}
 
   '@vue/compiler-dom@3.4.19':
     resolution: {integrity: sha512-vm6+cogWrshjqEHTzIDCp72DKtea8Ry/QVpQRYoyTIg9k7QZDX6D8+HGURjtmatfgM8xgCFtJJaOlCaRYRK3QA==}
@@ -2501,8 +2480,8 @@ packages:
   '@vue/compiler-dom@3.5.14':
     resolution: {integrity: sha512-1aOCSqxGOea5I80U2hQJvXYpPm/aXo95xL/m/mMhgyPUsKe9jhjwWpziNAw7tYRnbz1I61rd9Mld4W9KmmRoug==}
 
-  '@vue/compiler-dom@3.6.0-alpha.4':
-    resolution: {integrity: sha512-PHM00EYjcd1YPyRx9Pe1UbtDKbY3Y7VvuCZFFAMjNJfV9Wx/OfBDBf9F4ChOt+kSD/RZEQfELsSBOWBLrpuS5w==}
+  '@vue/compiler-dom@3.6.0-rc.1':
+    resolution: {integrity: sha512-EZ7LMqPlq1qBAtvlkLinMiDKduj7BrBmsE2pLuKaZDqkYmjdX7xQityGxl9S3Ll5KHc3O8qzOem910Yb8QaT2w==}
 
   '@vue/compiler-sfc@3.4.19':
     resolution: {integrity: sha512-LQ3U4SN0DlvV0xhr1lUsgLCYlwQfUfetyPxkKYu7dkfvx7g3ojrGAkw0AERLOKYXuAGnqFsEuytkdcComei3Yg==}
@@ -2510,8 +2489,8 @@ packages:
   '@vue/compiler-sfc@3.5.14':
     resolution: {integrity: sha512-9T6m/9mMr81Lj58JpzsiSIjBgv2LiVoWjIVa7kuXHICUi8LiDSIotMpPRXYJsXKqyARrzjT24NAwttrMnMaCXA==}
 
-  '@vue/compiler-sfc@3.6.0-alpha.4':
-    resolution: {integrity: sha512-vCjb9thJAqxA6iFDKdD+CM+o5w+NnfcDUZqJxRZniUCVrRFCLEmzN0EN7tn7ksh/suHasxecss/g7Z+ucu6EhQ==}
+  '@vue/compiler-sfc@3.6.0-rc.1':
+    resolution: {integrity: sha512-LNG/uJuCM45I+prqDGre67NsNVHIfU0aHx8Uy/csFXH4SmqvRBC39CRH815g/re/ZwVVkg8gJvsIMlOz7CRUUg==}
 
   '@vue/compiler-ssr@3.4.19':
     resolution: {integrity: sha512-P0PLKC4+u4OMJ8sinba/5Z/iDT84uMRRlrWzadgLA69opCpI1gG4N55qDSC+dedwq2fJtzmGald05LWR5TFfLw==}
@@ -2519,16 +2498,16 @@ packages:
   '@vue/compiler-ssr@3.5.14':
     resolution: {integrity: sha512-Y0G7PcBxr1yllnHuS/NxNCSPWnRGH4Ogrp0tsLA5QemDZuJLs99YjAKQ7KqkHE0vCg4QTKlQzXLKCMF7WPSl7Q==}
 
-  '@vue/compiler-ssr@3.6.0-alpha.4':
-    resolution: {integrity: sha512-p0BOmwfMtcTToqueac4IQvtBTsmtvBn0wRMC8hewjqKhHx5wqd7T+1i9X5oCNx9pEA62HQlrYKGFp6tRDoL57w==}
+  '@vue/compiler-ssr@3.6.0-rc.1':
+    resolution: {integrity: sha512-WyqwSFtU6ntpzF6IV6yRgRQWHkDGPpw/Zry+retpb2qmGXLjbFqmK8wANfDY7sK6LyFxNwEdmvGZJdr16UXj1g==}
 
-  '@vue/compiler-vapor@3.6.0-alpha.4':
-    resolution: {integrity: sha512-DXlmmuNkoXUBY7YqJIG7zvmeueJ23y3FQzpFjiFY63cW/Eefk1pfidn29R/NL7wiQDIzrve92325B74sVcWguQ==}
+  '@vue/compiler-vapor@3.6.0-rc.1':
+    resolution: {integrity: sha512-jbknW7YM1VUx6ZcpXGzc81aN6TKPaWAcAqCG1pDvQ88xCOgAXFgeKAniJtZmWl5PNGvH07XoyclOlykcC4l77A==}
 
   '@vue/composition-api@1.7.2':
     resolution: {integrity: sha512-M8jm9J/laYrYT02665HkZ5l2fWTK4dcVg3BsDHm/pfz+MjDYwX+9FUaZyGwEyXEDonQYRCo0H7aLgdklcIELjw==}
     peerDependencies:
-      vue: 3.6.0-alpha.4
+      vue: 3.6.0-rc.1
 
   '@vue/devtools-api@6.5.1':
     resolution: {integrity: sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA==}
@@ -2561,24 +2540,22 @@ packages:
       typescript:
         optional: true
 
-  '@vue/reactivity@3.6.0-alpha.4':
-    resolution: {integrity: sha512-aStBkVTA+GeaMhyiO26fW8tqQtw88XTKFbcAOs0QvksNG7Qh7NxWmbJiXIcsB1PhEQvEywkOJo88TBAJmPAtpg==}
+  '@vue/reactivity@3.6.0-rc.1':
+    resolution: {integrity: sha512-9B5iBqejQrLIj19ZFEeTVdiBp/KPXWKE+jL77Ccm+df7p0+VaUZih3gFsZ4HkV2qEUTupS+p3FK3kt0GjbxuEw==}
 
-  '@vue/runtime-core@3.6.0-alpha.4':
-    resolution: {integrity: sha512-QtmBbJL8kBfG/TfXkq47ajDJd/N8UvH5jSZHZ1pwiRoVkDLccqjiRCpeJMTbCYJoRw4KhbCiIs4TQR08atHYUA==}
+  '@vue/runtime-core@3.6.0-rc.1':
+    resolution: {integrity: sha512-0fA7pqZg9x9OKbWvRQGF7Hg1DnbvpHDMI4dKVjUt4FfjiFaJV6OspHmWIjFT6KHODzhQFZw+lBVoeCDZHOg7Pw==}
 
-  '@vue/runtime-dom@3.6.0-alpha.4':
-    resolution: {integrity: sha512-bqfLJDX1t1bB07Jd96MNewgZrIGgg6iDbP9ql/sZ/LvQLLbxs0v8JPbe6D+Os/P+shQ9vl4PgYmpg7g59WqINA==}
+  '@vue/runtime-dom@3.6.0-rc.1':
+    resolution: {integrity: sha512-XKJ8sf0uUkCJPTM8WgDVPEieVmXNlwME2h+4Iv00NijUQ3iWqpaCbG1YE0rIwFuH4vts3SqFb+yCb4XwTCzCCQ==}
 
-  '@vue/runtime-vapor@3.6.0-alpha.4':
-    resolution: {integrity: sha512-GqObmtDRxkezsvmUAxeTlPcDxT7ywHRh5UNgttV6xH4ae+kd3NsER4mHThwhYnrH+AIu1OeNLG+Eqfh9B2sKmg==}
+  '@vue/runtime-vapor@3.6.0-rc.1':
+    resolution: {integrity: sha512-gvSI6YHba9M6QSq4roI3DkDwf2lOGISU4KBf1VndvtVEmTYONHspb4E1V38r2ADEF4pB0Xs+7ccey8JPNG6pZQ==}
     peerDependencies:
-      '@vue/runtime-dom': 3.6.0-alpha.4
+      '@vue/runtime-dom': 3.6.0-rc.1
 
-  '@vue/server-renderer@3.6.0-alpha.4':
-    resolution: {integrity: sha512-+3e6sqwmCEjEqhjjHz8BB2V7oL8HJUKO/kaRSNeK0jh8Z/AjKUP9e5VaOwn0PF6oP3r1hAlyuXTA/HD2BN1Fag==}
-    peerDependencies:
-      vue: 3.6.0-alpha.4
+  '@vue/server-renderer@3.6.0-rc.1':
+    resolution: {integrity: sha512-X8NpztlFaZfFMYboohQ3BZLYmUlwAuSj0tPxZx8tEwFW1JFEqB0IwcFjRGmC1NA3fnq3duLJZjzwJ8htvirV/Q==}
 
   '@vue/shared@3.4.19':
     resolution: {integrity: sha512-/KliRRHMF6LoiThEy+4c1Z4KB/gbPrGjWwJR+crg2otgrf/egKzRaCPvJ51S5oetgsgXLfc4Rm5ZgrKHZrtMSw==}
@@ -2589,8 +2566,8 @@ packages:
   '@vue/shared@3.5.14':
     resolution: {integrity: sha512-oXTwNxVfc9EtP1zzXAlSlgARLXNC84frFYkS0HHz0h3E4WZSP9sywqjqzGCP9Y34M8ipNmd380pVgmMuwELDyQ==}
 
-  '@vue/shared@3.6.0-alpha.4':
-    resolution: {integrity: sha512-UWhZp4a/52k/0ptTzDxU2K6pFhUfJXVF+SIPqkIvjF0eKgvrPaLhdeRZ0PH+XxzMmm3tYAP3R78IqioxbLv0hw==}
+  '@vue/shared@3.6.0-rc.1':
+    resolution: {integrity: sha512-G2Y0ePuu7QIZ7eX7I8r0Q6mwO6rwhMXyYY8UAlPvkXsu7IxT5i8wDxiZK8EI5FnYYJKdSWInDnZREDX9w9zdCg==}
 
   '@vueuse/core@11.1.0':
     resolution: {integrity: sha512-P6dk79QYA6sKQnghrUz/1tHi0n9mrb/iO1WTMk/ElLmTyNqgDeSZ3wcDf6fRBGzRJbeG1dxzEOvLENMjr+E3fg==}
@@ -3350,8 +3327,8 @@ packages:
     resolution: {integrity: sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==}
     engines: {node: '>=18'}
 
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   cyclist@1.0.2:
     resolution: {integrity: sha512-0sVXIohTfLqVIW3kb/0n6IiWF3Ifj5nm2XaSrLq2DI6fKIGa2fYAZdk917rUneaeLVpYfFcyXE2ft0fe3remsA==}
@@ -3605,6 +3582,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   errno@0.1.8:
@@ -5260,6 +5241,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -5615,11 +5601,11 @@ packages:
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
-  petite-vue-i18n@11.4.5:
-    resolution: {integrity: sha512-D5oAwIegF2EfCPXRxCEJZ7yE7B4xhrp1YhDGjJdA6LW8EV3VYoFNveAeAYn6ZvN2rYqbrOpmFXsYFKagdo91Ww==}
+  petite-vue-i18n@11.4.6:
+    resolution: {integrity: sha512-cqy8bgxk47aPtU5maSyJXD4fVuREZONIN45H0o2uvnJeC66icxDthrjM9NwO/vAFhSMCQKaGMgMPQqTd2R/UUg==}
     engines: {node: '>= 22'}
     peerDependencies:
-      vue: 3.6.0-alpha.4
+      vue: 3.6.0-rc.1
 
   picocolors@0.2.1:
     resolution: {integrity: sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==}
@@ -5735,8 +5721,8 @@ packages:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.3:
-    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+  postcss@8.5.20:
+    resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
@@ -7009,7 +6995,7 @@ packages:
     hasBin: true
     peerDependencies:
       '@vue/composition-api': ^1.0.0-rc.1
-      vue: 3.6.0-alpha.4
+      vue: 3.6.0-rc.1
     peerDependenciesMeta:
       '@vue/composition-api':
         optional: true
@@ -7024,7 +7010,7 @@ packages:
     resolution: {integrity: sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==}
     peerDependencies:
       '@vue/compiler-sfc': ^3.0.8
-      vue: 3.6.0-alpha.4
+      vue: 3.6.0-rc.1
       webpack: ^4.1.0 || ^5.0.0-0
     peerDependenciesMeta:
       '@vue/compiler-sfc':
@@ -7035,7 +7021,7 @@ packages:
   vue-router@4.2.5:
     resolution: {integrity: sha512-DIUpKcyg4+PTQKfFPX88UWhlagBEBEfJ5A8XDXRJLUnZOvcpMF8o/dnL90vpVkGaPbjvXazV/rC1qBKrZlFugw==}
     peerDependencies:
-      vue: 3.6.0-alpha.4
+      vue: 3.6.0-rc.1
 
   vue-template-compiler@2.7.16:
     resolution: {integrity: sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==}
@@ -7052,8 +7038,8 @@ packages:
     peerDependencies:
       typescript: '*'
 
-  vue@3.6.0-alpha.4:
-    resolution: {integrity: sha512-3Q5/IdK6c4Ro7s9qblbWnyfWs5Zvk4/Gtg4LnXRy22FVQ2LTLlrujhn+mBH67njrFRd9U1dhGlzeHl9rp516ZQ==}
+  vue@3.6.0-rc.1:
+    resolution: {integrity: sha512-CSF6J6iAAaj3f/x5JVgNzePNxE9OHBPMGHXWHvRN0T3YJQCGWOVWIgZL8gNxZwr6bIkNAqoik6UNltcH0eXfjA==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -7491,14 +7477,14 @@ snapshots:
 
   '@babel/generator@7.23.6':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.28.5
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.22
       jsesc: 2.5.2
 
   '@babel/helper-annotate-as-pure@7.22.5':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.28.5
 
   '@babel/helper-compilation-targets@7.23.6':
     dependencies:
@@ -7526,19 +7512,19 @@ snapshots:
   '@babel/helper-function-name@7.23.0':
     dependencies:
       '@babel/template': 7.23.9
-      '@babel/types': 7.25.6
+      '@babel/types': 7.28.5
 
   '@babel/helper-hoist-variables@7.22.5':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.28.5
 
   '@babel/helper-member-expression-to-functions@7.23.0':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.28.5
 
   '@babel/helper-module-imports@7.22.15':
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.28.5
 
   '@babel/helper-module-transforms@7.23.3(@babel/core@7.23.9)':
     dependencies:
@@ -7547,11 +7533,11 @@ snapshots:
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/helper-optimise-call-expression@7.22.5':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.28.5
 
   '@babel/helper-plugin-utils@7.22.5': {}
 
@@ -7564,29 +7550,23 @@ snapshots:
 
   '@babel/helper-simple-access@7.22.5':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.28.5
 
   '@babel/helper-skip-transparent-expression-wrappers@7.22.5':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.28.5
 
   '@babel/helper-split-export-declaration@7.22.6':
     dependencies:
-      '@babel/types': 7.25.6
-
-  '@babel/helper-string-parser@7.23.4': {}
-
-  '@babel/helper-string-parser@7.24.8': {}
+      '@babel/types': 7.28.5
 
   '@babel/helper-string-parser@7.27.1': {}
 
-  '@babel/helper-validator-identifier@7.22.20': {}
-
-  '@babel/helper-validator-identifier@7.24.7': {}
-
-  '@babel/helper-validator-identifier@7.27.1': {}
+  '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.23.5': {}
 
@@ -7594,13 +7574,13 @@ snapshots:
     dependencies:
       '@babel/template': 7.23.9
       '@babel/traverse': 7.23.9
-      '@babel/types': 7.23.9
+      '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
   '@babel/highlight@7.23.4':
     dependencies:
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/helper-validator-identifier': 7.28.5
       chalk: 2.4.2
       js-tokens: 4.0.0
 
@@ -7608,17 +7588,13 @@ snapshots:
     dependencies:
       '@babel/types': 7.23.9
 
-  '@babel/parser@7.25.6':
-    dependencies:
-      '@babel/types': 7.25.6
-
-  '@babel/parser@7.27.2':
-    dependencies:
-      '@babel/types': 7.27.1
-
   '@babel/parser@7.28.5':
     dependencies:
       '@babel/types': 7.28.5
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.23.9)':
     dependencies:
@@ -7641,8 +7617,8 @@ snapshots:
   '@babel/template@7.23.9':
     dependencies:
       '@babel/code-frame': 7.23.5
-      '@babel/parser': 7.25.6
-      '@babel/types': 7.23.9
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
 
   '@babel/traverse@7.23.9':
     dependencies:
@@ -7652,8 +7628,8 @@ snapshots:
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.25.6
-      '@babel/types': 7.23.9
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
       debug: 4.3.7(supports-color@6.1.0)
       globals: 11.12.0
     transitivePeerDependencies:
@@ -7661,25 +7637,19 @@ snapshots:
 
   '@babel/types@7.23.9':
     dependencies:
-      '@babel/helper-string-parser': 7.23.4
-      '@babel/helper-validator-identifier': 7.22.20
-      to-fast-properties: 2.0.0
-
-  '@babel/types@7.25.6':
-    dependencies:
-      '@babel/helper-string-parser': 7.24.8
-      '@babel/helper-validator-identifier': 7.24.7
-      to-fast-properties: 2.0.0
-
-  '@babel/types@7.27.1':
-    dependencies:
       '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+      to-fast-properties: 2.0.0
 
   '@babel/types@7.28.5':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -7937,12 +7907,12 @@ snapshots:
     dependencies:
       '@intlify/core': 9.10.2
       '@intlify/message-compiler': 9.14.5
-      '@intlify/shared': 9.11.0
+      '@intlify/shared': 9.14.5
       jsonc-eslint-parser: 1.4.1
       source-map: 0.6.1
       yaml-eslint-parser: 0.3.2
 
-  '@intlify/bundle-utils@12.0.0-alpha.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(petite-vue-i18n@11.4.5(vue@3.6.0-alpha.4(typescript@5.3.3)))(vue-i18n@packages+vue-i18n)':
+  '@intlify/bundle-utils@12.0.0-alpha.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(petite-vue-i18n@11.4.6(vue@3.6.0-rc.1(typescript@5.3.3)))(vue-i18n@packages+vue-i18n)':
     dependencies:
       '@intlify/message-compiler': 12.0.0-alpha.4
       '@intlify/shared': 12.0.0-alpha.4
@@ -7954,13 +7924,13 @@ snapshots:
       source-map-js: 1.2.1
       yaml-eslint-parser: 1.3.2
     optionalDependencies:
-      petite-vue-i18n: 11.4.5(vue@3.6.0-alpha.4(typescript@5.3.3))
+      petite-vue-i18n: 11.4.6(vue@3.6.0-rc.1(typescript@5.3.3))
       vue-i18n: link:packages/vue-i18n
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@intlify/bundle-utils@7.5.1(petite-vue-i18n@11.4.5(vue@3.6.0-alpha.4(typescript@5.3.3)))(vue-i18n@packages+vue-i18n)':
+  '@intlify/bundle-utils@7.5.1(petite-vue-i18n@11.4.6(vue@3.6.0-rc.1(typescript@5.3.3)))(vue-i18n@packages+vue-i18n)':
     dependencies:
       '@intlify/message-compiler': 9.10.2
       '@intlify/shared': 9.13.1
@@ -7973,14 +7943,14 @@ snapshots:
       source-map-js: 1.0.2
       yaml-eslint-parser: 1.2.2
     optionalDependencies:
-      petite-vue-i18n: 11.4.5(vue@3.6.0-alpha.4(typescript@5.3.3))
+      petite-vue-i18n: 11.4.6(vue@3.6.0-rc.1(typescript@5.3.3))
       vue-i18n: link:packages/vue-i18n
 
-  '@intlify/core-base@11.4.5':
+  '@intlify/core-base@11.4.6':
     dependencies:
-      '@intlify/devtools-types': 11.4.5
-      '@intlify/message-compiler': 11.4.5
-      '@intlify/shared': 11.4.5
+      '@intlify/devtools-types': 11.4.6
+      '@intlify/message-compiler': 11.4.6
+      '@intlify/shared': 11.4.6
     optional: true
 
   '@intlify/core-base@9.10.2':
@@ -7993,15 +7963,15 @@ snapshots:
       '@intlify/core-base': 9.10.2
       '@intlify/shared': 9.10.2
 
-  '@intlify/devtools-types@11.4.5':
+  '@intlify/devtools-types@11.4.6':
     dependencies:
-      '@intlify/core-base': 11.4.5
-      '@intlify/shared': 11.4.5
+      '@intlify/core-base': 11.4.6
+      '@intlify/shared': 11.4.6
     optional: true
 
-  '@intlify/message-compiler@11.4.5':
+  '@intlify/message-compiler@11.4.6':
     dependencies:
-      '@intlify/shared': 11.4.5
+      '@intlify/shared': 11.4.6
       source-map-js: 1.2.1
     optional: true
 
@@ -8020,7 +7990,7 @@ snapshots:
       '@intlify/shared': 9.14.5
       source-map-js: 1.2.1
 
-  '@intlify/shared@11.4.5': {}
+  '@intlify/shared@11.4.6': {}
 
   '@intlify/shared@12.0.0-alpha.4': {}
 
@@ -8034,9 +8004,9 @@ snapshots:
 
   '@intlify/shared@9.3.0-beta.24': {}
 
-  '@intlify/unplugin-vue-i18n@0.12.3(petite-vue-i18n@11.4.5(vue@3.6.0-alpha.4(typescript@5.3.3)))(rollup@4.59.0)(vue-i18n@packages+vue-i18n)':
+  '@intlify/unplugin-vue-i18n@0.12.3(petite-vue-i18n@11.4.6(vue@3.6.0-rc.1(typescript@5.3.3)))(rollup@4.59.0)(vue-i18n@packages+vue-i18n)':
     dependencies:
-      '@intlify/bundle-utils': 7.5.1(petite-vue-i18n@11.4.5(vue@3.6.0-alpha.4(typescript@5.3.3)))(vue-i18n@packages+vue-i18n)
+      '@intlify/bundle-utils': 7.5.1(petite-vue-i18n@11.4.6(vue@3.6.0-rc.1(typescript@5.3.3)))(vue-i18n@packages+vue-i18n)
       '@intlify/shared': 9.3.0-beta.24
       '@rollup/pluginutils': 5.1.0(rollup@4.59.0)
       '@vue/compiler-sfc': 3.4.19
@@ -8049,20 +8019,20 @@ snapshots:
       source-map-js: 1.0.2
       unplugin: 1.7.1
     optionalDependencies:
-      petite-vue-i18n: 11.4.5(vue@3.6.0-alpha.4(typescript@5.3.3))
+      petite-vue-i18n: 11.4.6(vue@3.6.0-rc.1(typescript@5.3.3))
       vue-i18n: link:packages/vue-i18n
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  '@intlify/vue-i18n-loader@3.3.0(vue@3.6.0-alpha.4(typescript@5.9.3))':
+  '@intlify/vue-i18n-loader@3.3.0(vue@3.6.0-rc.1(typescript@5.9.3))':
     dependencies:
       '@intlify/bundle-utils': 1.0.0
       '@intlify/shared': 9.11.0
       js-yaml: 4.1.0
       json5: 2.2.3
       loader-utils: 2.0.4
-      vue: 3.6.0-alpha.4(typescript@5.9.3)
+      vue: 3.6.0-rc.1(typescript@5.9.3)
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -8939,35 +8909,35 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitejs/plugin-vue-jsx@3.1.0(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-alpha.4(typescript@5.9.3))':
+  '@vitejs/plugin-vue-jsx@3.1.0(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-rc.1(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.23.9
       '@babel/plugin-transform-typescript': 7.23.6(@babel/core@7.23.9)
       '@vue/babel-plugin-jsx': 1.2.1(@babel/core@7.23.9)
       vite: 6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0)
-      vue: 3.6.0-alpha.4(typescript@5.9.3)
+      vue: 3.6.0-rc.1(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-alpha.4(typescript@5.3.3))':
+  '@vitejs/plugin-vue@4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-rc.1(typescript@5.3.3))':
     dependencies:
       vite: 6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0)
-      vue: 3.6.0-alpha.4(typescript@5.3.3)
+      vue: 3.6.0-rc.1(typescript@5.3.3)
 
-  '@vitejs/plugin-vue@4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-alpha.4(typescript@5.9.3))':
+  '@vitejs/plugin-vue@4.6.2(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-rc.1(typescript@5.9.3))':
     dependencies:
       vite: 6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0)
-      vue: 3.6.0-alpha.4(typescript@5.9.3)
+      vue: 3.6.0-rc.1(typescript@5.9.3)
 
-  '@vitejs/plugin-vue@5.0.4(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-alpha.4(typescript@5.9.3))':
+  '@vitejs/plugin-vue@5.0.4(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-rc.1(typescript@5.9.3))':
     dependencies:
       vite: 6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0)
-      vue: 3.6.0-alpha.4(typescript@5.9.3)
+      vue: 3.6.0-rc.1(typescript@5.9.3)
 
-  '@vitejs/plugin-vue@5.1.4(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-alpha.4(typescript@5.5.4))':
+  '@vitejs/plugin-vue@5.1.4(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-rc.1(typescript@5.5.4))':
     dependencies:
       vite: 6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0)
-      vue: 3.6.0-alpha.4(typescript@5.5.4)
+      vue: 3.6.0-rc.1(typescript@5.5.4)
 
   '@vitest/coverage-v8@2.1.5(vitest@2.1.5(@types/node@22.5.3)(jiti@1.21.0)(jsdom@24.0.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))':
     dependencies:
@@ -8998,7 +8968,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 2.1.5
       estree-walker: 3.0.3
-      magic-string: 0.30.12
+      magic-string: 0.30.21
     optionalDependencies:
       vite: 6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0)
 
@@ -9014,7 +8984,7 @@ snapshots:
   '@vitest/snapshot@2.1.5':
     dependencies:
       '@vitest/pretty-format': 2.1.5
-      magic-string: 0.30.12
+      magic-string: 0.30.21
       pathe: 1.1.2
 
   '@vitest/spy@2.1.5':
@@ -9079,7 +9049,7 @@ snapshots:
       '@babel/core': 7.23.9
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/parser': 7.25.6
+      '@babel/parser': 7.28.5
       '@vue/compiler-sfc': 3.5.14
 
   '@vue/compiler-core@3.4.19':
@@ -9092,17 +9062,17 @@ snapshots:
 
   '@vue/compiler-core@3.5.14':
     dependencies:
-      '@babel/parser': 7.27.2
+      '@babel/parser': 7.28.5
       '@vue/shared': 3.5.14
       entities: 4.5.0
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-core@3.6.0-alpha.4':
+  '@vue/compiler-core@3.6.0-rc.1':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@vue/shared': 3.6.0-alpha.4
-      entities: 4.5.0
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.6.0-rc.1
+      entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
@@ -9116,10 +9086,10 @@ snapshots:
       '@vue/compiler-core': 3.5.14
       '@vue/shared': 3.5.14
 
-  '@vue/compiler-dom@3.6.0-alpha.4':
+  '@vue/compiler-dom@3.6.0-rc.1':
     dependencies:
-      '@vue/compiler-core': 3.6.0-alpha.4
-      '@vue/shared': 3.6.0-alpha.4
+      '@vue/compiler-core': 3.6.0-rc.1
+      '@vue/shared': 3.6.0-rc.1
 
   '@vue/compiler-sfc@3.4.19':
     dependencies:
@@ -9135,27 +9105,27 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.14':
     dependencies:
-      '@babel/parser': 7.27.2
+      '@babel/parser': 7.28.5
       '@vue/compiler-core': 3.5.14
       '@vue/compiler-dom': 3.5.14
       '@vue/compiler-ssr': 3.5.14
       '@vue/shared': 3.5.14
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.3
+      postcss: 8.5.6
       source-map-js: 1.2.1
 
-  '@vue/compiler-sfc@3.6.0-alpha.4':
+  '@vue/compiler-sfc@3.6.0-rc.1':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@vue/compiler-core': 3.6.0-alpha.4
-      '@vue/compiler-dom': 3.6.0-alpha.4
-      '@vue/compiler-ssr': 3.6.0-alpha.4
-      '@vue/compiler-vapor': 3.6.0-alpha.4
-      '@vue/shared': 3.6.0-alpha.4
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.6.0-rc.1
+      '@vue/compiler-dom': 3.6.0-rc.1
+      '@vue/compiler-ssr': 3.6.0-rc.1
+      '@vue/compiler-vapor': 3.6.0-rc.1
+      '@vue/shared': 3.6.0-rc.1
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.6
+      postcss: 8.5.20
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.4.19':
@@ -9168,22 +9138,22 @@ snapshots:
       '@vue/compiler-dom': 3.5.14
       '@vue/shared': 3.5.14
 
-  '@vue/compiler-ssr@3.6.0-alpha.4':
+  '@vue/compiler-ssr@3.6.0-rc.1':
     dependencies:
-      '@vue/compiler-dom': 3.6.0-alpha.4
-      '@vue/shared': 3.6.0-alpha.4
+      '@vue/compiler-dom': 3.6.0-rc.1
+      '@vue/shared': 3.6.0-rc.1
 
-  '@vue/compiler-vapor@3.6.0-alpha.4':
+  '@vue/compiler-vapor@3.6.0-rc.1':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@vue/compiler-dom': 3.6.0-alpha.4
-      '@vue/shared': 3.6.0-alpha.4
+      '@babel/parser': 7.29.7
+      '@vue/compiler-dom': 3.6.0-rc.1
+      '@vue/shared': 3.6.0-rc.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/composition-api@1.7.2(vue@3.6.0-alpha.4(typescript@5.5.4))':
+  '@vue/composition-api@1.7.2(vue@3.6.0-rc.1(typescript@5.5.4))':
     dependencies:
-      vue: 3.6.0-alpha.4(typescript@5.5.4)
+      vue: 3.6.0-rc.1(typescript@5.5.4)
     optional: true
 
   '@vue/devtools-api@6.5.1': {}
@@ -9249,45 +9219,33 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@vue/reactivity@3.6.0-alpha.4':
+  '@vue/reactivity@3.6.0-rc.1':
     dependencies:
-      '@vue/shared': 3.6.0-alpha.4
+      '@vue/shared': 3.6.0-rc.1
 
-  '@vue/runtime-core@3.6.0-alpha.4':
+  '@vue/runtime-core@3.6.0-rc.1':
     dependencies:
-      '@vue/reactivity': 3.6.0-alpha.4
-      '@vue/shared': 3.6.0-alpha.4
+      '@vue/reactivity': 3.6.0-rc.1
+      '@vue/shared': 3.6.0-rc.1
 
-  '@vue/runtime-dom@3.6.0-alpha.4':
+  '@vue/runtime-dom@3.6.0-rc.1':
     dependencies:
-      '@vue/reactivity': 3.6.0-alpha.4
-      '@vue/runtime-core': 3.6.0-alpha.4
-      '@vue/shared': 3.6.0-alpha.4
-      csstype: 3.1.3
+      '@vue/reactivity': 3.6.0-rc.1
+      '@vue/runtime-core': 3.6.0-rc.1
+      '@vue/shared': 3.6.0-rc.1
+      csstype: 3.2.3
 
-  '@vue/runtime-vapor@3.6.0-alpha.4(@vue/runtime-dom@3.6.0-alpha.4)':
+  '@vue/runtime-vapor@3.6.0-rc.1(@vue/runtime-dom@3.6.0-rc.1)':
     dependencies:
-      '@vue/reactivity': 3.6.0-alpha.4
-      '@vue/runtime-dom': 3.6.0-alpha.4
-      '@vue/shared': 3.6.0-alpha.4
+      '@vue/reactivity': 3.6.0-rc.1
+      '@vue/runtime-dom': 3.6.0-rc.1
+      '@vue/shared': 3.6.0-rc.1
 
-  '@vue/server-renderer@3.6.0-alpha.4(vue@3.6.0-alpha.4(typescript@5.3.3))':
+  '@vue/server-renderer@3.6.0-rc.1':
     dependencies:
-      '@vue/compiler-ssr': 3.6.0-alpha.4
-      '@vue/shared': 3.6.0-alpha.4
-      vue: 3.6.0-alpha.4(typescript@5.3.3)
-
-  '@vue/server-renderer@3.6.0-alpha.4(vue@3.6.0-alpha.4(typescript@5.5.4))':
-    dependencies:
-      '@vue/compiler-ssr': 3.6.0-alpha.4
-      '@vue/shared': 3.6.0-alpha.4
-      vue: 3.6.0-alpha.4(typescript@5.5.4)
-
-  '@vue/server-renderer@3.6.0-alpha.4(vue@3.6.0-alpha.4(typescript@5.9.3))':
-    dependencies:
-      '@vue/compiler-ssr': 3.6.0-alpha.4
-      '@vue/shared': 3.6.0-alpha.4
-      vue: 3.6.0-alpha.4(typescript@5.9.3)
+      '@vue/compiler-ssr': 3.6.0-rc.1
+      '@vue/runtime-dom': 3.6.0-rc.1
+      '@vue/shared': 3.6.0-rc.1
 
   '@vue/shared@3.4.19': {}
 
@@ -9295,23 +9253,23 @@ snapshots:
 
   '@vue/shared@3.5.14': {}
 
-  '@vue/shared@3.6.0-alpha.4': {}
+  '@vue/shared@3.6.0-rc.1': {}
 
-  '@vueuse/core@11.1.0(@vue/composition-api@1.7.2(vue@3.6.0-alpha.4(typescript@5.5.4)))(vue@3.6.0-alpha.4(typescript@5.5.4))':
+  '@vueuse/core@11.1.0(@vue/composition-api@1.7.2(vue@3.6.0-rc.1(typescript@5.5.4)))(vue@3.6.0-rc.1(typescript@5.5.4))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 11.1.0
-      '@vueuse/shared': 11.1.0(@vue/composition-api@1.7.2(vue@3.6.0-alpha.4(typescript@5.5.4)))(vue@3.6.0-alpha.4(typescript@5.5.4))
-      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.6.0-alpha.4(typescript@5.5.4)))(vue@3.6.0-alpha.4(typescript@5.5.4))
+      '@vueuse/shared': 11.1.0(@vue/composition-api@1.7.2(vue@3.6.0-rc.1(typescript@5.5.4)))(vue@3.6.0-rc.1(typescript@5.5.4))
+      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.6.0-rc.1(typescript@5.5.4)))(vue@3.6.0-rc.1(typescript@5.5.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/integrations@11.1.0(@vue/composition-api@1.7.2(vue@3.6.0-alpha.4(typescript@5.5.4)))(focus-trap@7.6.0)(vue@3.6.0-alpha.4(typescript@5.5.4))':
+  '@vueuse/integrations@11.1.0(@vue/composition-api@1.7.2(vue@3.6.0-rc.1(typescript@5.5.4)))(focus-trap@7.6.0)(vue@3.6.0-rc.1(typescript@5.5.4))':
     dependencies:
-      '@vueuse/core': 11.1.0(@vue/composition-api@1.7.2(vue@3.6.0-alpha.4(typescript@5.5.4)))(vue@3.6.0-alpha.4(typescript@5.5.4))
-      '@vueuse/shared': 11.1.0(@vue/composition-api@1.7.2(vue@3.6.0-alpha.4(typescript@5.5.4)))(vue@3.6.0-alpha.4(typescript@5.5.4))
-      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.6.0-alpha.4(typescript@5.5.4)))(vue@3.6.0-alpha.4(typescript@5.5.4))
+      '@vueuse/core': 11.1.0(@vue/composition-api@1.7.2(vue@3.6.0-rc.1(typescript@5.5.4)))(vue@3.6.0-rc.1(typescript@5.5.4))
+      '@vueuse/shared': 11.1.0(@vue/composition-api@1.7.2(vue@3.6.0-rc.1(typescript@5.5.4)))(vue@3.6.0-rc.1(typescript@5.5.4))
+      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.6.0-rc.1(typescript@5.5.4)))(vue@3.6.0-rc.1(typescript@5.5.4))
     optionalDependencies:
       focus-trap: 7.6.0
     transitivePeerDependencies:
@@ -9320,9 +9278,9 @@ snapshots:
 
   '@vueuse/metadata@11.1.0': {}
 
-  '@vueuse/shared@11.1.0(@vue/composition-api@1.7.2(vue@3.6.0-alpha.4(typescript@5.5.4)))(vue@3.6.0-alpha.4(typescript@5.5.4))':
+  '@vueuse/shared@11.1.0(@vue/composition-api@1.7.2(vue@3.6.0-rc.1(typescript@5.5.4)))(vue@3.6.0-rc.1(typescript@5.5.4))':
     dependencies:
-      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.6.0-alpha.4(typescript@5.5.4)))(vue@3.6.0-alpha.4(typescript@5.5.4))
+      vue-demi: 0.14.10(@vue/composition-api@1.7.2(vue@3.6.0-rc.1(typescript@5.5.4)))(vue@3.6.0-rc.1(typescript@5.5.4))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -9538,7 +9496,7 @@ snapshots:
 
   api-docs-gen@0.4.0(@types/node@22.5.3):
     dependencies:
-      '@intlify/shared': 11.4.5
+      '@intlify/shared': 11.4.6
       '@microsoft/api-extractor-model': 7.28.9(@types/node@22.5.3)
       '@microsoft/tsdoc': 0.13.2
       '@microsoft/tsdoc-config': 0.15.2
@@ -10194,7 +10152,7 @@ snapshots:
     dependencies:
       rrweb-cssom: 0.6.0
 
-  csstype@3.1.3: {}
+  csstype@3.2.3: {}
 
   cyclist@1.0.2: {}
 
@@ -10420,6 +10378,8 @@ snapshots:
       tapable: 1.1.3
 
   entities@4.5.0: {}
+
+  entities@7.0.1: {}
 
   errno@0.1.8:
     dependencies:
@@ -11968,8 +11928,8 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.25.6
-      '@babel/types': 7.25.6
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
       source-map-js: 1.2.1
 
   make-dir@2.1.0:
@@ -12446,6 +12406,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.16: {}
+
   nanoid@3.3.7: {}
 
   nanomatch@1.2.13(supports-color@6.1.0):
@@ -12839,13 +12801,13 @@ snapshots:
 
   perfect-debounce@1.0.0: {}
 
-  petite-vue-i18n@11.4.5(vue@3.6.0-alpha.4(typescript@5.3.3)):
+  petite-vue-i18n@11.4.6(vue@3.6.0-rc.1(typescript@5.3.3)):
     dependencies:
-      '@intlify/core-base': 11.4.5
-      '@intlify/devtools-types': 11.4.5
-      '@intlify/shared': 11.4.5
+      '@intlify/core-base': 11.4.6
+      '@intlify/devtools-types': 11.4.6
+      '@intlify/shared': 11.4.6
       '@vue/devtools-api': 6.6.4
-      vue: 3.6.0-alpha.4(typescript@5.3.3)
+      vue: 3.6.0-rc.1(typescript@5.3.3)
     optional: true
 
   picocolors@0.2.1: {}
@@ -12967,9 +12929,9 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.3:
+  postcss@8.5.20:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -14322,7 +14284,7 @@ snapshots:
       - '@75lb/nature'
       - supports-color
 
-  vitepress@1.5.0(@algolia/client-search@4.23.2)(@types/node@22.5.3)(@vue/composition-api@1.7.2(vue@3.6.0-alpha.4(typescript@5.5.4)))(jiti@1.21.0)(postcss@8.5.6)(search-insights@2.13.0)(terser@5.27.0)(tsx@4.11.2)(typescript@5.5.4)(yaml@2.9.0):
+  vitepress@1.5.0(@algolia/client-search@4.23.2)(@types/node@22.5.3)(@vue/composition-api@1.7.2(vue@3.6.0-rc.1(typescript@5.5.4)))(jiti@1.21.0)(postcss@8.5.20)(search-insights@2.13.0)(terser@5.27.0)(tsx@4.11.2)(typescript@5.5.4)(yaml@2.9.0):
     dependencies:
       '@docsearch/css': 3.6.2
       '@docsearch/js': 3.6.2(@algolia/client-search@4.23.2)(search-insights@2.13.0)
@@ -14331,19 +14293,19 @@ snapshots:
       '@shikijs/transformers': 1.22.2
       '@shikijs/types': 1.22.2
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.1.4(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-alpha.4(typescript@5.5.4))
+      '@vitejs/plugin-vue': 5.1.4(vite@6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0))(vue@3.6.0-rc.1(typescript@5.5.4))
       '@vue/devtools-api': 7.6.3
       '@vue/shared': 3.5.12
-      '@vueuse/core': 11.1.0(@vue/composition-api@1.7.2(vue@3.6.0-alpha.4(typescript@5.5.4)))(vue@3.6.0-alpha.4(typescript@5.5.4))
-      '@vueuse/integrations': 11.1.0(@vue/composition-api@1.7.2(vue@3.6.0-alpha.4(typescript@5.5.4)))(focus-trap@7.6.0)(vue@3.6.0-alpha.4(typescript@5.5.4))
+      '@vueuse/core': 11.1.0(@vue/composition-api@1.7.2(vue@3.6.0-rc.1(typescript@5.5.4)))(vue@3.6.0-rc.1(typescript@5.5.4))
+      '@vueuse/integrations': 11.1.0(@vue/composition-api@1.7.2(vue@3.6.0-rc.1(typescript@5.5.4)))(focus-trap@7.6.0)(vue@3.6.0-rc.1(typescript@5.5.4))
       focus-trap: 7.6.0
       mark.js: 8.11.1
       minisearch: 7.1.0
       shiki: 1.22.2
       vite: 6.0.0(@types/node@22.5.3)(jiti@1.21.0)(terser@5.27.0)(tsx@4.11.2)(yaml@2.9.0)
-      vue: 3.6.0-alpha.4(typescript@5.5.4)
+      vue: 3.6.0-rc.1(typescript@5.5.4)
     optionalDependencies:
-      postcss: 8.5.6
+      postcss: 8.5.20
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/node'
@@ -14418,11 +14380,11 @@ snapshots:
 
   vm-browserify@1.1.2: {}
 
-  vue-demi@0.14.10(@vue/composition-api@1.7.2(vue@3.6.0-alpha.4(typescript@5.5.4)))(vue@3.6.0-alpha.4(typescript@5.5.4)):
+  vue-demi@0.14.10(@vue/composition-api@1.7.2(vue@3.6.0-rc.1(typescript@5.5.4)))(vue@3.6.0-rc.1(typescript@5.5.4)):
     dependencies:
-      vue: 3.6.0-alpha.4(typescript@5.5.4)
+      vue: 3.6.0-rc.1(typescript@5.5.4)
     optionalDependencies:
-      '@vue/composition-api': 1.7.2(vue@3.6.0-alpha.4(typescript@5.5.4))
+      '@vue/composition-api': 1.7.2(vue@3.6.0-rc.1(typescript@5.5.4))
 
   vue-eslint-parser@9.4.3(eslint@9.9.1(jiti@1.21.0)):
     dependencies:
@@ -14437,7 +14399,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-loader@16.8.3(@vue/compiler-sfc@3.4.19)(vue@3.6.0-alpha.4(typescript@5.9.3))(webpack@4.47.0):
+  vue-loader@16.8.3(@vue/compiler-sfc@3.4.19)(vue@3.6.0-rc.1(typescript@5.9.3))(webpack@4.47.0):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
@@ -14445,17 +14407,17 @@ snapshots:
       webpack: 4.47.0(webpack-cli@3.3.12)
     optionalDependencies:
       '@vue/compiler-sfc': 3.4.19
-      vue: 3.6.0-alpha.4(typescript@5.9.3)
+      vue: 3.6.0-rc.1(typescript@5.9.3)
 
-  vue-router@4.2.5(vue@3.6.0-alpha.4(typescript@5.3.3)):
+  vue-router@4.2.5(vue@3.6.0-rc.1(typescript@5.3.3)):
     dependencies:
       '@vue/devtools-api': 6.5.1
-      vue: 3.6.0-alpha.4(typescript@5.3.3)
+      vue: 3.6.0-rc.1(typescript@5.3.3)
 
-  vue-router@4.2.5(vue@3.6.0-alpha.4(typescript@5.9.3)):
+  vue-router@4.2.5(vue@3.6.0-rc.1(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-api': 6.5.1
-      vue: 3.6.0-alpha.4(typescript@5.9.3)
+      vue: 3.6.0-rc.1(typescript@5.9.3)
 
   vue-template-compiler@2.7.16:
     dependencies:
@@ -14483,36 +14445,36 @@ snapshots:
       semver: 7.6.0
       typescript: 5.9.3
 
-  vue@3.6.0-alpha.4(typescript@5.3.3):
+  vue@3.6.0-rc.1(typescript@5.3.3):
     dependencies:
-      '@vue/compiler-dom': 3.6.0-alpha.4
-      '@vue/compiler-sfc': 3.6.0-alpha.4
-      '@vue/runtime-dom': 3.6.0-alpha.4
-      '@vue/runtime-vapor': 3.6.0-alpha.4(@vue/runtime-dom@3.6.0-alpha.4)
-      '@vue/server-renderer': 3.6.0-alpha.4(vue@3.6.0-alpha.4(typescript@5.3.3))
-      '@vue/shared': 3.6.0-alpha.4
+      '@vue/compiler-dom': 3.6.0-rc.1
+      '@vue/compiler-sfc': 3.6.0-rc.1
+      '@vue/runtime-dom': 3.6.0-rc.1
+      '@vue/runtime-vapor': 3.6.0-rc.1(@vue/runtime-dom@3.6.0-rc.1)
+      '@vue/server-renderer': 3.6.0-rc.1
+      '@vue/shared': 3.6.0-rc.1
     optionalDependencies:
       typescript: 5.3.3
 
-  vue@3.6.0-alpha.4(typescript@5.5.4):
+  vue@3.6.0-rc.1(typescript@5.5.4):
     dependencies:
-      '@vue/compiler-dom': 3.6.0-alpha.4
-      '@vue/compiler-sfc': 3.6.0-alpha.4
-      '@vue/runtime-dom': 3.6.0-alpha.4
-      '@vue/runtime-vapor': 3.6.0-alpha.4(@vue/runtime-dom@3.6.0-alpha.4)
-      '@vue/server-renderer': 3.6.0-alpha.4(vue@3.6.0-alpha.4(typescript@5.5.4))
-      '@vue/shared': 3.6.0-alpha.4
+      '@vue/compiler-dom': 3.6.0-rc.1
+      '@vue/compiler-sfc': 3.6.0-rc.1
+      '@vue/runtime-dom': 3.6.0-rc.1
+      '@vue/runtime-vapor': 3.6.0-rc.1(@vue/runtime-dom@3.6.0-rc.1)
+      '@vue/server-renderer': 3.6.0-rc.1
+      '@vue/shared': 3.6.0-rc.1
     optionalDependencies:
       typescript: 5.5.4
 
-  vue@3.6.0-alpha.4(typescript@5.9.3):
+  vue@3.6.0-rc.1(typescript@5.9.3):
     dependencies:
-      '@vue/compiler-dom': 3.6.0-alpha.4
-      '@vue/compiler-sfc': 3.6.0-alpha.4
-      '@vue/runtime-dom': 3.6.0-alpha.4
-      '@vue/runtime-vapor': 3.6.0-alpha.4(@vue/runtime-dom@3.6.0-alpha.4)
-      '@vue/server-renderer': 3.6.0-alpha.4(vue@3.6.0-alpha.4(typescript@5.9.3))
-      '@vue/shared': 3.6.0-alpha.4
+      '@vue/compiler-dom': 3.6.0-rc.1
+      '@vue/compiler-sfc': 3.6.0-rc.1
+      '@vue/runtime-dom': 3.6.0-rc.1
+      '@vue/runtime-vapor': 3.6.0-rc.1(@vue/runtime-dom@3.6.0-rc.1)
+      '@vue/server-renderer': 3.6.0-rc.1
+      '@vue/shared': 3.6.0-rc.1
     optionalDependencies:
       typescript: 5.9.3
 

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -7,6 +7,6 @@ export default {
     ...config.test,
     environmentMatchGlobs: [['packages/vue-i18n-core/**', 'jsdom']],
     globalSetup: ['./scripts/vitest.unit.globalSetup.ts'],
-    exclude: [...configDefaults.exclude, '**/e2e/**']
+    exclude: [...configDefaults.exclude, '**/e2e/**', '**/vapor.test.ts']
   }
 } as UserConfig

--- a/vitest.vapor.config.ts
+++ b/vitest.vapor.config.ts
@@ -1,0 +1,49 @@
+import { createRequire } from 'node:module'
+import { dirname, resolve } from 'node:path'
+import { defineConfig, mergeConfig } from 'vitest/config'
+import config from './vitest.config'
+
+// Keep all Vapor imports on the ESM runtime from the overridden Vue version.
+// Vitest's Node entry does not expose the Vapor APIs.
+const rootRequire = createRequire(import.meta.url)
+const vuePackage = rootRequire.resolve('vue/package.json')
+const vueRequire = createRequire(vuePackage)
+const resolveVueRuntime = (id: string, file: string): string =>
+  resolve(dirname(vueRequire.resolve(`${id}/package.json`)), 'dist', file)
+
+export default mergeConfig(
+  config,
+  defineConfig({
+    define: {
+      __VUE_OPTIONS_API__: true,
+      __VUE_PROD_DEVTOOLS__: false,
+      __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false
+    },
+    resolve: {
+      alias: {
+        vue: resolve(dirname(vuePackage), 'dist/vue.runtime.esm-bundler.js'),
+        '@vue/runtime-vapor': resolveVueRuntime(
+          '@vue/runtime-vapor',
+          'runtime-vapor.esm-bundler.js'
+        ),
+        '@vue/runtime-dom': resolveVueRuntime(
+          '@vue/runtime-dom',
+          'runtime-dom.esm-bundler.js'
+        ),
+        '@vue/runtime-core': resolveVueRuntime(
+          '@vue/runtime-core',
+          'runtime-core.esm-bundler.js'
+        ),
+        '@vue/reactivity': resolveVueRuntime(
+          '@vue/reactivity',
+          'reactivity.esm-bundler.js'
+        ),
+        '@vue/shared': resolveVueRuntime('@vue/shared', 'shared.esm-bundler.js')
+      }
+    },
+    test: {
+      environment: 'jsdom',
+      include: ['./packages/vue-i18n-core/test/vapor.test.ts']
+    }
+  })
+)


### PR DESCRIPTION
## Summary

- update the Vue override from `3.6.0-alpha.4` to `3.6.0-rc.1`
- add a smoke test that exercises `useI18n()` in a real Vapor component
- run the Vapor smoke test in CI with Vue's matching ESM runtime packages

## Why

Vue 3.6 has reached RC with the new reactivity implementation and feature-complete Vapor mode. The v11 branch already includes Vapor compatibility, but it was still tested against an early alpha and did not have coverage using an actual Vapor component.

## Impact

There are no vue-i18n runtime changes. This keeps v11's test dependency current and protects translation rendering and reactive locale switching in Vapor components.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm test:cover`
- `pnpm test:vapor`
- `pnpm build`
- `pnpm test:e2e`
