### PR TITLE
fix: isolate fallback context per i18n instance

### DIFF
--- a/packages/core-base/src/context.ts
+++ b/packages/core-base/src/context.ts
@@ -418,14 +418,6 @@ export function registerLocaleFallbacker(fallbacker: LocaleFallbacker): void {
   _fallbacker = fallbacker
 }
 
-let _fallbackContext: CoreContext | null = null
-
-export const setFallbackContext = (context: CoreContext | null): void => {
-  _fallbackContext = context
-}
-
-export const getFallbackContext = (): CoreContext | null => _fallbackContext
-
 // ID for CoreContext
 let _cid = 0
 

--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -8,7 +8,6 @@ import {
   createCoreContext,
   datetime,
   fallbackWithLocaleChain,
-  getFallbackContext,
   isMessageAST,
   isMessageFunction,
   isTranslateFallbackWarn,
@@ -18,7 +17,6 @@ import {
   parseNumberArgs,
   parseTranslateArgs,
   resolveValue,
-  setFallbackContext,
   translate,
   updateFallbackLocale
 } from '@intlify/core-base'
@@ -43,6 +41,7 @@ import { useInstanceOption } from 'vue'
 import { I18nErrorCodes, createI18nError } from './errors'
 import { VERSION } from './misc'
 import {
+  CoreContextSymbol,
   DatetimePartsSymbol,
   DisableEmitter,
   EnableEmitter,
@@ -1844,6 +1843,7 @@ export interface Composer<
  * @internal
  */
 export interface ComposerInternal {
+  [CoreContextSymbol]: CoreContext
   __translateVNode(...args: unknown[]): VNodeArrayChildren
   __numberParts(...args: unknown[]): string | Intl.NumberFormatPart[]
   __datetimeParts(...args: unknown[]): string | Intl.DateTimeFormatPart[]
@@ -2028,8 +2028,6 @@ export function createComposer(options: any = {}): any {
   let _context: CoreContext
 
   const getCoreContext = (): CoreContext => {
-    _isGlobal && setFallbackContext(null)
-
     const ctxOptions = {
       version: VERSION,
       locale: _locale.value,
@@ -2074,8 +2072,6 @@ export function createComposer(options: any = {}): any {
     }
 
     const ctx = createCoreContext(ctxOptions as any)
-    _isGlobal && setFallbackContext(ctx)
-
     return ctx
   }
 
@@ -2169,7 +2165,9 @@ export function createComposer(options: any = {}): any {
     let ret: unknown
     try {
       if (!_isGlobal) {
-        _context.fallbackContext = __root ? (getFallbackContext() as any) : undefined
+        _context.fallbackContext = __root
+          ? (__root as unknown as ComposerInternal)[CoreContextSymbol]
+          : undefined
       }
       ret = fn(_context)
     } finally {
@@ -2491,6 +2489,7 @@ export function createComposer(options: any = {}): any {
 
   // define basic composition API!
   const composer = {
+    [CoreContextSymbol]: _context,
     id: composerID,
     locale,
     fallbackLocale,

--- a/packages/vue-i18n-core/src/symbols.ts
+++ b/packages/vue-i18n-core/src/symbols.ts
@@ -1,5 +1,6 @@
 import { makeSymbol } from '@intlify/shared'
 
+export const CoreContextSymbol = /* #__PURE__*/ Symbol('__coreContext')
 export const TranslateVNodeSymbol: symbol = /* #__PURE__*/ makeSymbol('__translateVNode')
 export const DatetimePartsSymbol: symbol = /* #__PURE__*/ makeSymbol('__datetimeParts')
 export const NumberPartsSymbol: symbol = /* #__PURE__*/ makeSymbol('__numberParts')

--- a/packages/vue-i18n-core/test/composer.test.ts
+++ b/packages/vue-i18n-core/test/composer.test.ts
@@ -2072,6 +2072,37 @@ describe('root', () => {
     expect(t('hello')).toEqual('hello!')
   })
 
+  test('linked messages use the matching root context', () => {
+    const rootA = createComposer({
+      locale: 'en',
+      messages: {
+        en: {
+          root: 'A'
+        }
+      }
+    })
+    const localA = createComposer({
+      locale: 'en',
+      messages: {
+        en: {
+          linked: '@:root'
+        }
+      },
+      __root: rootA
+    })
+
+    createComposer({
+      locale: 'en',
+      messages: {
+        en: {
+          root: 'B'
+        }
+      }
+    })
+
+    expect(localA.t('linked')).toEqual('A')
+  })
+
   test('d', () => {
     const __root = createComposer({
       locale: 'en-US',

--- a/packages/vue-i18n-core/test/i18n.test.ts
+++ b/packages/vue-i18n-core/test/i18n.test.ts
@@ -701,18 +701,18 @@ test('slot reactivity', async () => {
 
 test('multi instance', async () => {
   const i18n1 = createI18n({
-    locale: 'ja',
+    locale: 'en',
     messages: {
       en: {
-        hello: 'hello!'
+        root: 'A'
       }
     }
   })
   const i18n2 = createI18n({
     locale: 'en',
     messages: {
-      ja: {
-        hello: 'こんにちは！'
+      en: {
+        root: 'B'
       }
     }
   })
@@ -723,19 +723,21 @@ test('multi instance', async () => {
         locale: 'en',
         messages: {
           en: {
-            hello: 'hello!'
+            linked: '@:root'
           }
         }
       })
       return { ...i18n }
     },
-    template: `<p>foo</p>`
+    template: `<p>{{ t('linked') }}</p>`
   })
-  const { app: app1 } = await mount(App, i18n1)
-  const { app: app2 } = await mount(App, i18n2)
+  const { app: app1, html: html1 } = await mount(App, i18n1)
+  const { app: app2, html: html2 } = await mount(App, i18n2)
 
   expect(app1.__VUE_I18N_SYMBOL__).not.toEqual(app2.__VUE_I18N_SYMBOL__)
   expect(i18n1.global).not.toEqual(i18n2.global)
+  expect(html1()).toEqual('<p>A</p>')
+  expect(html2()).toEqual('<p>B</p>')
 })
 
 test('merge useI18n resources to global scope', async () => {


### PR DESCRIPTION
## Summary

This fixes cross-instance linked-message fallback in Vue I18n. The fallback CoreContext was stored in module-global state, so creating another I18n instance could make a local Composer resolve linked messages against the wrong root.

The global getter and setter are removed. Each root Composer now owns its CoreContext through an internal symbol, and local Composers use only their matching root context. Regression tests cover both Composer and createI18n paths. Type builds, unit and e2e tests, install checks, size checks, and benchmarks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed linked message resolution when multiple i18n instances are used, ensuring each composer references the correct root context.
  * Improved fallback context handling for nested and linked translations.

* **Tests**
  * Added coverage verifying correct root-specific linked messages across separate i18n instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->