### PR TITLE
refactor: type internal symbol protocol

### DIFF
--- a/packages/vue-i18n-core/src/components/DatetimeFormat.ts
+++ b/packages/vue-i18n-core/src/components/DatetimeFormat.ts
@@ -8,7 +8,7 @@ import { renderFormatter } from './formatRenderer'
 
 import type { DateTimeOptions } from '@intlify/core-base'
 import type { ComponentOptions, SetupContext, VNodeProps } from 'vue'
-import type { Composer, ComposerInternal } from '../composer'
+import type { ComposerInternalInstance } from '../composer'
 import type { BaseFormatProps } from './base'
 import type { FormattableProps } from './formatRenderer'
 
@@ -38,11 +38,10 @@ export const DatetimeFormatImpl: ComponentOptions<DatetimeFormatProps> =
     ),
 
     setup(props: DatetimeFormatProps, context: SetupContext) {
-      const i18n =
-        props.i18n ||
-        (useI18n({
+      const i18n = (props.i18n ||
+        useI18n({
           useScope: props.scope as 'global' | 'parent'
-        }) as unknown as Composer & ComposerInternal)
+        })) as ComposerInternalInstance
 
       return renderFormatter<
         FormattableProps<number | Date, Intl.DateTimeFormatOptions>,
@@ -51,7 +50,7 @@ export const DatetimeFormatImpl: ComponentOptions<DatetimeFormatProps> =
         DateTimeOptions,
         Intl.DateTimeFormatPart
       >(props as DatetimeFormatProps, context, DATETIME_FORMAT_OPTIONS_KEYS, (...args: unknown[]) =>
-        (i18n as any)[DatetimePartsSymbol](...args)
+        i18n[DatetimePartsSymbol](...args)
       )
     }
   })

--- a/packages/vue-i18n-core/src/components/NumberFormat.ts
+++ b/packages/vue-i18n-core/src/components/NumberFormat.ts
@@ -8,7 +8,7 @@ import { renderFormatter } from './formatRenderer'
 
 import type { NumberOptions } from '@intlify/core-base'
 import type { ComponentOptions, SetupContext, VNodeProps } from 'vue'
-import type { Composer, ComposerInternal } from '../composer'
+import type { ComposerInternalInstance } from '../composer'
 import type { BaseFormatProps } from './base'
 import type { FormattableProps } from './formatRenderer'
 
@@ -37,11 +37,10 @@ export const NumberFormatImpl: ComponentOptions<NumberFormatProps> = /* #__PURE_
       BaseFormatPropsValidators
     ),
     setup(props: NumberFormatProps, context: SetupContext) {
-      const i18n =
-        props.i18n ||
-        (useI18n({
+      const i18n = (props.i18n ||
+        useI18n({
           useScope: props.scope as 'global' | 'parent'
-        }) as unknown as Composer & ComposerInternal)
+        })) as ComposerInternalInstance
 
       return renderFormatter<
         FormattableProps<number, Intl.NumberFormatOptions>,
@@ -50,7 +49,7 @@ export const NumberFormatImpl: ComponentOptions<NumberFormatProps> = /* #__PURE_
         NumberOptions,
         Intl.NumberFormatPart
       >(props as NumberFormatProps, context, NUMBER_FORMAT_OPTIONS_KEYS, (...args: unknown[]) =>
-        (i18n as any)[NumberPartsSymbol](...args)
+        i18n[NumberPartsSymbol](...args)
       )
     }
   }

--- a/packages/vue-i18n-core/src/components/Translation.ts
+++ b/packages/vue-i18n-core/src/components/Translation.ts
@@ -13,7 +13,7 @@ import type {
   VNodeChild,
   VNodeProps
 } from 'vue'
-import type { Composer, ComposerInternal } from '../composer'
+import type { ComposerInternalInstance } from '../composer'
 import type { BaseFormatProps } from './base'
 
 /**
@@ -55,11 +55,10 @@ export const TranslationImpl: ComponentOptions<TranslationProps> = /* #__PURE__*
   setup(props: TranslationProps, context: SetupContext) {
     const { slots, attrs } = context
     // NOTE: avoid https://github.com/microsoft/rushstack/issues/1050
-    const i18n =
-      props.i18n ||
-      (useI18n({
+    const i18n = (props.i18n ||
+      useI18n({
         useScope: props.scope as 'global' | 'parent'
-      }) as unknown as Composer & ComposerInternal)
+      })) as ComposerInternalInstance
 
     return (): VNodeChild => {
       const renderChildren = (): VNodeArrayChildren => {
@@ -73,7 +72,7 @@ export const TranslationImpl: ComponentOptions<TranslationProps> = /* #__PURE__*
         }
         const arg = getInterpolateArg(context, keys)
 
-        return (i18n as any)[TranslateVNodeSymbol](props.keypath, arg, options)
+        return i18n[TranslateVNodeSymbol](props.keypath, arg, options)
       }
       const assignedAttrs = assign(create(), attrs)
       const tag = isString(props.tag) || isObject(props.tag) ? props.tag : getFragmentableTag()

--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -44,6 +44,7 @@ import {
   CoreContextSymbol,
   DatetimePartsSymbol,
   DisableEmitter,
+  DisposeSymbol,
   EnableEmitter,
   NumberPartsSymbol,
   TranslateVNodeSymbol
@@ -54,8 +55,10 @@ import { I18nWarnCodes, getWarnMessage } from './warnings'
 import type {
   CoreContext,
   CoreInternalContext,
+  CoreInternalOptions,
   CoreMissingHandler,
   CoreMissingType,
+  CoreOptions,
   DateTimeFormat,
   DateTimeFormats as DateTimeFormatsType,
   DateTimeOptions,
@@ -84,6 +87,7 @@ import type {
   NumberFormats as NumberFormatsType,
   NumberOptions,
   Path,
+  PathValue,
   PickupFormatKeys,
   PickupFormatPathKeys,
   PickupKeys,
@@ -619,7 +623,7 @@ export interface ComposerInternalOptions<
 > {
   __i18n?: CustomBlocks<VueMessageType>
   __i18nGlobal?: CustomBlocks<VueMessageType>
-  __root?: Composer<Messages, DateTimeFormats, NumberFormats>
+  __root?: ComposerInternalInstance<Messages, DateTimeFormats, NumberFormats>
 }
 
 /**
@@ -1832,13 +1836,24 @@ export interface Composer<
  * @internal
  */
 export interface ComposerInternal {
-  [CoreContextSymbol]: CoreContext
-  __translateVNode(...args: unknown[]): VNodeArrayChildren
-  __numberParts(...args: unknown[]): string | Intl.NumberFormatPart[]
-  __datetimeParts(...args: unknown[]): string | Intl.DateTimeFormatPart[]
-  __enableEmitter?: (emitter: VueDevToolsEmitter) => void
-  __disableEmitter?: () => void
+  [CoreContextSymbol]: CoreContext<VueMessageType>
+  [TranslateVNodeSymbol](...args: unknown[]): VNodeArrayChildren
+  [NumberPartsSymbol](...args: unknown[]): string | Intl.NumberFormatPart[]
+  [DatetimePartsSymbol](...args: unknown[]): string | Intl.DateTimeFormatPart[]
+  [EnableEmitter]?(emitter: VueDevToolsEmitter): void
+  [DisableEmitter]?(): void
+  [DisposeSymbol]?: () => void
 }
+
+/**
+ * @internal
+ */
+export type ComposerInternalInstance<
+  Messages extends Record<string, any> = {},
+  DateTimeFormats extends Record<string, any> = {},
+  NumberFormats extends Record<string, any> = {},
+  OptionLocale = _Locale
+> = Composer<Messages, DateTimeFormats, NumberFormats, OptionLocale> & ComposerInternal
 
 type ComposerWarnType = CoreMissingType
 
@@ -1847,12 +1862,17 @@ const NOOP_RETURN_FALSE = () => false
 
 let composerID = 0
 
-function defineCoreMissingHandler(missing: MissingHandler): CoreMissingHandler {
-  return ((_ctx: CoreContext, locale: Locale, key: Path, type: string): string | void => {
+function defineCoreMissingHandler(missing: MissingHandler): CoreMissingHandler<VueMessageType> {
+  return ((
+    _ctx: CoreContext<VueMessageType>,
+    locale: Locale,
+    key: Path,
+    type: string
+  ): string | void => {
     // eslint-disable-next-line vue-composable/composable-placement -- not composable
     const { value: uid } = useInstanceOption('uid', true)
     return missing(locale, key, uid, type)
-  }) as CoreMissingHandler
+  }) as CoreMissingHandler<VueMessageType>
 }
 
 export function createComposer<
@@ -1901,7 +1921,7 @@ export function createComposer<
  * @internal
  */
 
-export function createComposer(options: any = {}): any {
+export function createComposer(options: any = {}): ComposerInternalInstance {
   type Message = VueMessageType
   const { __root } = options as ComposerInternalOptions<
     LocaleMessages<LocaleMessage<Message>>,
@@ -2013,9 +2033,9 @@ export function createComposer(options: any = {}): any {
 
   // runtime context
 
-  let _context: CoreContext
+  let _context: CoreContext<Message>
 
-  const getCoreContext = (): CoreContext => {
+  const getCoreContext = (): CoreContext<Message> => {
     const ctxOptions = {
       version: VERSION,
       locale: _locale.value,
@@ -2035,31 +2055,31 @@ export function createComposer(options: any = {}): any {
       messageCompiler: options.messageCompiler,
       localeFallbacker: options.localeFallbacker,
       __meta: { framework: 'vue' }
-    }
+    } as CoreOptions<Message> & CoreInternalOptions
 
     // set default message compiler
-    ;(ctxOptions as any).messageCompiler = options.messageCompiler || compile
+    ctxOptions.messageCompiler = options.messageCompiler || compile
 
     if (!__LITE__) {
       // set default message resolver and locale fallbacker for full vue-i18n
-      ;(ctxOptions as any).messageResolver = options.messageResolver || resolveValue
-      ;(ctxOptions as any).localeFallbacker = options.localeFallbacker || fallbackWithLocaleChain
-      ;(ctxOptions as any).datetimeFormats = _datetimeFormats.value
-      ;(ctxOptions as any).numberFormats = _numberFormats.value
-      ;(ctxOptions as any).__datetimeFormatters = isPlainObject(_context)
+      ctxOptions.messageResolver = options.messageResolver || resolveValue
+      ctxOptions.localeFallbacker = options.localeFallbacker || fallbackWithLocaleChain
+      ctxOptions.datetimeFormats = _datetimeFormats.value
+      ctxOptions.numberFormats = _numberFormats.value
+      ctxOptions.__datetimeFormatters = isPlainObject(_context)
         ? (_context as unknown as CoreInternalContext).__datetimeFormatters
         : undefined
-      ;(ctxOptions as any).__numberFormatters = isPlainObject(_context)
+      ctxOptions.__numberFormatters = isPlainObject(_context)
         ? (_context as unknown as CoreInternalContext).__numberFormatters
         : undefined
     }
     if (__DEV__) {
-      ;(ctxOptions as any).__v_emitter = isPlainObject(_context)
+      ctxOptions.__v_emitter = isPlainObject(_context)
         ? (_context as unknown as CoreInternalContext).__v_emitter
         : undefined
     }
 
-    const ctx = createCoreContext(ctxOptions as any)
+    const ctx = createCoreContext<Message>(ctxOptions) as unknown as CoreContext<Message>
     return ctx
   }
 
@@ -2100,7 +2120,7 @@ export function createComposer(options: any = {}): any {
 
   // messages
   const messages = computed<LocaleMessages<LocaleMessage<Message>, Message>>(
-    () => _messages.value as any
+    () => _messages.value as unknown as LocaleMessages<LocaleMessage<Message>, Message>
   )
 
   // availableLocales
@@ -2118,7 +2138,7 @@ export function createComposer(options: any = {}): any {
   }
 
   // setPostTranslationHandler
-  function setPostTranslationHandler(handler: PostTranslationHandler | null): void {
+  function setPostTranslationHandler(handler: PostTranslationHandler<Message> | null): void {
     _postTranslation = handler
     _context.postTranslation = handler
   }
@@ -2153,9 +2173,7 @@ export function createComposer(options: any = {}): any {
     let ret: unknown
     try {
       if (!_isGlobal) {
-        _context.fallbackContext = __root
-          ? (__root as unknown as ComposerInternal)[CoreContextSymbol]
-          : undefined
+        _context.fallbackContext = __root ? __root[CoreContextSymbol] : undefined
       }
       ret = fn(_context)
     } finally {
@@ -2282,7 +2300,7 @@ export function createComposer(options: any = {}): any {
       () => parseTranslateArgs(...args),
       'translate',
 
-      root => (root as any)[TranslateVNodeSymbol](...args),
+      root => root[TranslateVNodeSymbol](...args),
       key => [createTextNode(key as string)],
       val => isArray(val)
     )
@@ -2295,7 +2313,7 @@ export function createComposer(options: any = {}): any {
       () => parseNumberArgs(...args),
       'number format',
 
-      root => (root as any)[NumberPartsSymbol](...args),
+      root => root[NumberPartsSymbol](...args),
       NOOP_RETURN_ARRAY,
       val => isString(val) || isArray(val)
     )
@@ -2308,7 +2326,7 @@ export function createComposer(options: any = {}): any {
       () => parseDateTimeArgs(...args),
       'datetime format',
 
-      root => (root as any)[DatetimePartsSymbol](...args),
+      root => root[DatetimePartsSymbol](...args),
       NOOP_RETURN_ARRAY,
       val => isString(val) || isArray(val)
     )
@@ -2332,7 +2350,7 @@ export function createComposer(options: any = {}): any {
           let resolved = _context.messageResolver(message, key)
           // if null, resolve with object key path (for flat keys containing dots)
           if (resolved === null) {
-            resolved = (message as any)[key]
+            resolved = (message as Record<string, PathValue>)[key]
           }
           if (isMessageAST(resolved) || isMessageFunction(resolved) || isString(resolved)) {
             return true
@@ -2547,32 +2565,41 @@ export function createComposer(options: any = {}): any {
     setPostTranslationHandler,
     getMissingHandler,
     setMissingHandler
-  }
+  } as ComposerInternalInstance
 
   if (!__LITE__) {
-    ;(composer as any).datetimeFormats = datetimeFormats
-    ;(composer as any).numberFormats = numberFormats
-    ;(composer as any).rt = rt
-    ;(composer as any).te = te
-    ;(composer as any).tm = tm
-    ;(composer as any).d = d
-    ;(composer as any).n = n
-    ;(composer as any).getDateTimeFormat = getDateTimeFormat
-    ;(composer as any).setDateTimeFormat = setDateTimeFormat
-    ;(composer as any).mergeDateTimeFormat = mergeDateTimeFormat
-    ;(composer as any).getNumberFormat = getNumberFormat
-    ;(composer as any).setNumberFormat = setNumberFormat
-    ;(composer as any).mergeNumberFormat = mergeNumberFormat
-    ;(composer as any)[TranslateVNodeSymbol] = translateVNode
-    ;(composer as any)[DatetimePartsSymbol] = datetimeParts
-    ;(composer as any)[NumberPartsSymbol] = numberParts
+    ;(
+      composer as ComposerInternalInstance & {
+        datetimeFormats: typeof datetimeFormats
+      }
+    ).datetimeFormats = datetimeFormats
+    ;(
+      composer as ComposerInternalInstance & {
+        numberFormats: typeof numberFormats
+      }
+    ).numberFormats = numberFormats
+    composer.rt = rt
+    composer.te = te
+    composer.tm = tm as ComposerInternalInstance['tm']
+    composer.d = d as ComposerInternalInstance['d']
+    composer.n = n as ComposerInternalInstance['n']
+    composer.getDateTimeFormat = getDateTimeFormat as ComposerInternalInstance['getDateTimeFormat']
+    composer.setDateTimeFormat = setDateTimeFormat as ComposerInternalInstance['setDateTimeFormat']
+    composer.mergeDateTimeFormat =
+      mergeDateTimeFormat as ComposerInternalInstance['mergeDateTimeFormat']
+    composer.getNumberFormat = getNumberFormat as ComposerInternalInstance['getNumberFormat']
+    composer.setNumberFormat = setNumberFormat as ComposerInternalInstance['setNumberFormat']
+    composer.mergeNumberFormat = mergeNumberFormat as ComposerInternalInstance['mergeNumberFormat']
+    composer[TranslateVNodeSymbol] = translateVNode
+    composer[DatetimePartsSymbol] = datetimeParts
+    composer[NumberPartsSymbol] = numberParts
   }
   // for vue-devtools timeline event
   if (__DEV__) {
-    ;(composer as any)[EnableEmitter] = (emitter: VueDevToolsEmitter): void => {
+    composer[EnableEmitter] = (emitter: VueDevToolsEmitter): void => {
       ;(_context as unknown as CoreInternalContext).__v_emitter = emitter
     }
-    ;(composer as any)[DisableEmitter] = (): void => {
+    composer[DisableEmitter] = (): void => {
       ;(_context as unknown as CoreInternalContext).__v_emitter = undefined
     }
   }

--- a/packages/vue-i18n-core/src/i18n.ts
+++ b/packages/vue-i18n-core/src/i18n.ts
@@ -40,6 +40,7 @@ import type { VueDevToolsEmitter, VueDevToolsEmitterEvents } from '@intlify/devt
 import type { App, EffectScope, InjectionKey } from 'vue'
 import type {
   Composer,
+  ComposerInternalInstance,
   ComposerInternalOptions,
   ComposerOptions,
   CustomBlocks,
@@ -156,7 +157,7 @@ export interface ComposerEntry<
   NumberFormats extends Record<string, unknown> = {},
   OptionLocale = Locale
 > {
-  composer: Composer<Messages, DateTimeFormats, NumberFormats, OptionLocale>
+  composer: ComposerInternalInstance<Messages, DateTimeFormats, NumberFormats, OptionLocale>
   label: string
 }
 
@@ -260,7 +261,8 @@ export const I18nInjectionKey: InjectionKey<I18n> | string =
  *
  * @internal
  */
-const I18nComposerKey: InjectionKey<Composer> = /* #__PURE__*/ Symbol('vue-i18n-composer')
+const I18nComposerKey: InjectionKey<ComposerInternalInstance> =
+  /* #__PURE__*/ Symbol('vue-i18n-composer')
 
 export function createI18n<
   Options extends I18nOptions = I18nOptions,
@@ -422,8 +424,7 @@ export function createI18n(options: any = {}): any {
         }
         const emitter: VueDevToolsEmitter = createEmitter<VueDevToolsEmitterEvents>()
 
-        const _composer = __global as any
-        _composer[EnableEmitter]?.(emitter)
+        __global[EnableEmitter]?.(emitter)
         emitter.on('*', addTimelineEvent)
       }
     },
@@ -555,7 +556,7 @@ export function useI18n<
     )
   }
 
-  const gl = i18n.global
+  const gl = i18n.global as ComposerInternalInstance
   const scope = getScope(options, type)
 
   // Global scope
@@ -602,19 +603,18 @@ export function useI18n<
     const parentComposer = inject(I18nComposerKey, null)
     composerOptions.__root = parentComposer || gl
 
-    const composer = createComposer(composerOptions) as Composer
+    const composer = createComposer(composerOptions) as ComposerInternalInstance
 
     // ComposerExtend
     if (i18nInternal.__composerExtend) {
-      ;(composer as any)[DisposeSymbol] = i18nInternal.__composerExtend(composer)
+      composer[DisposeSymbol] = i18nInternal.__composerExtend(composer)
     }
 
     // DevTools emitter setup
     let emitter: VueDevToolsEmitter | null = null
     if ((__DEV__ || __FEATURE_PROD_VUE_DEVTOOLS__) && !__NODE_JS__) {
       emitter = createEmitter<VueDevToolsEmitterEvents>()
-      const _composer = composer as any
-      _composer[EnableEmitter]?.(emitter)
+      composer[EnableEmitter]?.(emitter)
       emitter.on('*', addTimelineEvent)
     }
 
@@ -624,13 +624,12 @@ export function useI18n<
       onScopeDispose(() => {
         if ((__DEV__ || __FEATURE_PROD_VUE_DEVTOOLS__) && !__NODE_JS__) {
           emitter?.off('*', addTimelineEvent)
-          const _composer = composer as any
-          _composer[DisableEmitter]?.()
+          composer[DisableEmitter]?.()
         }
-        const dispose = (composer as any)[DisposeSymbol]
+        const dispose = composer[DisposeSymbol]
         if (dispose) {
           dispose()
-          delete (composer as any)[DisposeSymbol]
+          delete composer[DisposeSymbol]
         }
       })
     }
@@ -682,11 +681,11 @@ export function useI18n<
   const parentComposer = inject(I18nComposerKey, null)
   composerOptions.__root = parentComposer || gl
 
-  const composer = createComposer(composerOptions) as Composer
+  const composer = createComposer(composerOptions) as ComposerInternalInstance
 
   // ComposerExtend
   if (i18nInternal.__composerExtend) {
-    ;(composer as any)[DisposeSymbol] = i18nInternal.__composerExtend(composer)
+    composer[DisposeSymbol] = i18nInternal.__composerExtend(composer)
   }
 
   // Register instance
@@ -697,8 +696,7 @@ export function useI18n<
   let emitter: VueDevToolsEmitter | null = null
   if ((__DEV__ || __FEATURE_PROD_VUE_DEVTOOLS__) && !__NODE_JS__) {
     emitter = createEmitter<VueDevToolsEmitterEvents>()
-    const _composer = composer as any
-    _composer[EnableEmitter]?.(emitter)
+    composer[EnableEmitter]?.(emitter)
     emitter.on('*', addTimelineEvent)
   }
 
@@ -709,15 +707,14 @@ export function useI18n<
       // DevTools cleanup
       if ((__DEV__ || __FEATURE_PROD_VUE_DEVTOOLS__) && !__NODE_JS__) {
         emitter?.off('*', addTimelineEvent)
-        const _composer = composer as any
-        _composer[DisableEmitter]?.()
+        composer[DisableEmitter]?.()
       }
 
       i18nInternal.__deleteInstance(uid)
-      const dispose = (composer as any)[DisposeSymbol]
+      const dispose = composer[DisposeSymbol]
       if (dispose) {
         dispose()
-        delete (composer as any)[DisposeSymbol]
+        delete composer[DisposeSymbol]
       }
     })
   }
@@ -728,9 +725,9 @@ export function useI18n<
   return composer as unknown as Composer<Messages, DateTimeFormats, NumberFormats, OptionLocale>
 }
 
-function createGlobal(options: I18nOptions): [EffectScope, Composer] {
+function createGlobal(options: I18nOptions): [EffectScope, ComposerInternalInstance] {
   const scope = effectScope()
-  const obj = scope.run(() => createComposer(options))
+  const obj = scope.run(() => createComposer(options) as ComposerInternalInstance)
   if (obj == null) {
     throw createI18nError(I18nErrorCodes.UNEXPECTED_ERROR)
   }

--- a/packages/vue-i18n-core/src/symbols.ts
+++ b/packages/vue-i18n-core/src/symbols.ts
@@ -1,9 +1,7 @@
-import { makeSymbol } from '@intlify/shared'
-
-export const CoreContextSymbol = /* #__PURE__*/ Symbol('__coreContext')
-export const TranslateVNodeSymbol: symbol = /* #__PURE__*/ makeSymbol('__translateVNode')
-export const DatetimePartsSymbol: symbol = /* #__PURE__*/ makeSymbol('__datetimeParts')
-export const NumberPartsSymbol: symbol = /* #__PURE__*/ makeSymbol('__numberParts')
-export const EnableEmitter: symbol = /* #__PURE__*/ makeSymbol('__enableEmitter')
-export const DisableEmitter: symbol = /* #__PURE__*/ makeSymbol('__disableEmitter')
-export const DisposeSymbol: symbol = /* #__PURE__*/ makeSymbol('__dispose')
+export const CoreContextSymbol: unique symbol = /* #__PURE__*/ Symbol('__coreContext')
+export const TranslateVNodeSymbol: unique symbol = /* #__PURE__*/ Symbol('__translateVNode')
+export const DatetimePartsSymbol: unique symbol = /* #__PURE__*/ Symbol('__datetimeParts')
+export const NumberPartsSymbol: unique symbol = /* #__PURE__*/ Symbol('__numberParts')
+export const EnableEmitter: unique symbol = /* #__PURE__*/ Symbol('__enableEmitter')
+export const DisableEmitter: unique symbol = /* #__PURE__*/ Symbol('__disableEmitter')
+export const DisposeSymbol: unique symbol = /* #__PURE__*/ Symbol('__dispose')

--- a/packages/vue-i18n-core/test/composer.test.ts
+++ b/packages/vue-i18n-core/test/composer.test.ts
@@ -19,7 +19,12 @@ import { DatetimePartsSymbol, NumberPartsSymbol, TranslateVNodeSymbol } from '..
 import { getWarnMessage, I18nWarnCodes } from '../src/warnings'
 
 import type { Locale, MessageContext, MessageFunction, Path, PathValue } from '@intlify/core-base'
-import type { ComposerOptions, MissingHandler, VueMessageType } from '../src/composer'
+import type {
+  ComposerInternalInstance,
+  ComposerOptions,
+  MissingHandler,
+  VueMessageType
+} from '../src/composer'
 
 afterEach(() => {
   vi.clearAllMocks()
@@ -1922,7 +1927,7 @@ describe('__translateVNode', () => {
       }
     })
     expect(
-      (composer as any)[TranslateVNodeSymbol]('hello', {
+      (composer as unknown as ComposerInternalInstance)[TranslateVNodeSymbol]('hello', {
         name: createVNode(Text, null, 'kazupon', 0)
       })
     ).toMatchObject([{ children: 'hello, ' }, { children: 'kazupon' }, { children: '!' }])
@@ -1936,7 +1941,7 @@ describe('__translateVNode', () => {
       }
     })
     expect(
-      (composer as any)[TranslateVNodeSymbol]('hello', {
+      (composer as unknown as ComposerInternalInstance)[TranslateVNodeSymbol]('hello', {
         name: createVNode(Text, null, 'kazupon', 0)
       })
     ).toMatchSnapshot()
@@ -1957,7 +1962,7 @@ describe('__numberParts', () => {
       }
     })
     expect(
-      (composer as any)[NumberPartsSymbol](0.99, {
+      (composer as unknown as ComposerInternalInstance)[NumberPartsSymbol](0.99, {
         key: 'percent',
         part: true
       })
@@ -1972,7 +1977,7 @@ describe('__numberParts', () => {
       }
     })
     expect(
-      (composer as any)[NumberPartsSymbol](0.99, {
+      (composer as unknown as ComposerInternalInstance)[NumberPartsSymbol](0.99, {
         key: 'percent',
         part: true
       })
@@ -2000,7 +2005,7 @@ describe('__datetimeParts', () => {
     })
     const dt = new Date(Date.UTC(2012, 11, 20, 3, 0, 0))
     expect(
-      (composer as any)[DatetimePartsSymbol](dt, {
+      (composer as unknown as ComposerInternalInstance)[DatetimePartsSymbol](dt, {
         key: 'short',
         part: true
       })
@@ -2028,7 +2033,7 @@ describe('__datetimeParts', () => {
     })
     const dt = new Date(Date.UTC(2012, 11, 20, 3, 0, 0))
     expect(
-      (composer as any)[DatetimePartsSymbol](dt, {
+      (composer as unknown as ComposerInternalInstance)[DatetimePartsSymbol](dt, {
         key: 'short',
         part: true
       })

--- a/packages/vue-i18n-core/test/symbols.test-d.ts
+++ b/packages/vue-i18n-core/test/symbols.test-d.ts
@@ -1,0 +1,54 @@
+import {
+  CoreContextSymbol,
+  DatetimePartsSymbol,
+  DisableEmitter,
+  DisposeSymbol,
+  EnableEmitter,
+  NumberPartsSymbol,
+  TranslateVNodeSymbol
+} from '../src/symbols'
+
+import type { CoreContext } from '@intlify/core-base'
+import type { VueDevToolsEmitter } from '@intlify/devtools-types'
+import type { VNodeArrayChildren } from 'vue'
+import type { ComposerInternal, ComposerInternalInstance, VueMessageType } from '../src/composer'
+
+type IsUniqueSymbol<T extends symbol> = symbol extends T ? false : true
+type LegacyComposerInternalKeys =
+  | '__translateVNode'
+  | '__numberParts'
+  | '__datetimeParts'
+  | '__enableEmitter'
+  | '__disableEmitter'
+
+test('uses unique symbols for the internal protocol', () => {
+  expectTypeOf<IsUniqueSymbol<typeof CoreContextSymbol>>().toEqualTypeOf<true>()
+  expectTypeOf<IsUniqueSymbol<typeof TranslateVNodeSymbol>>().toEqualTypeOf<true>()
+  expectTypeOf<IsUniqueSymbol<typeof NumberPartsSymbol>>().toEqualTypeOf<true>()
+  expectTypeOf<IsUniqueSymbol<typeof DatetimePartsSymbol>>().toEqualTypeOf<true>()
+  expectTypeOf<IsUniqueSymbol<typeof EnableEmitter>>().toEqualTypeOf<true>()
+  expectTypeOf<IsUniqueSymbol<typeof DisableEmitter>>().toEqualTypeOf<true>()
+  expectTypeOf<IsUniqueSymbol<typeof DisposeSymbol>>().toEqualTypeOf<true>()
+})
+
+test('describes Composer internals with computed symbol keys', () => {
+  expectTypeOf<Extract<keyof ComposerInternal, LegacyComposerInternalKeys>>().toEqualTypeOf<never>()
+  expectTypeOf<ComposerInternal[typeof CoreContextSymbol]>().toEqualTypeOf<
+    CoreContext<VueMessageType>
+  >()
+  expectTypeOf<ComposerInternal[typeof TranslateVNodeSymbol]>().toEqualTypeOf<
+    (...args: unknown[]) => VNodeArrayChildren
+  >()
+  expectTypeOf<ComposerInternal[typeof NumberPartsSymbol]>().toEqualTypeOf<
+    (...args: unknown[]) => string | Intl.NumberFormatPart[]
+  >()
+  expectTypeOf<ComposerInternal[typeof DatetimePartsSymbol]>().toEqualTypeOf<
+    (...args: unknown[]) => string | Intl.DateTimeFormatPart[]
+  >()
+  expectTypeOf<ComposerInternal[typeof EnableEmitter]>().toEqualTypeOf<
+    ((emitter: VueDevToolsEmitter) => void) | undefined
+  >()
+  expectTypeOf<ComposerInternal[typeof DisableEmitter]>().toEqualTypeOf<(() => void) | undefined>()
+  expectTypeOf<ComposerInternal[typeof DisposeSymbol]>().toEqualTypeOf<(() => void) | undefined>()
+  expectTypeOf<ComposerInternalInstance>().toMatchTypeOf<ComposerInternal>()
+})


### PR DESCRIPTION
## Summary

This refactor gives Vue I18n's private Composer protocol explicit type safety without changing the public API. Runtime symbols are now unique symbols and computed keys of `ComposerInternal`, and `createComposer` returns a dedicated internal intersection type.

Consumers in i18n and format components no longer rely on broad `any` casts. A focused type fixture protects symbol uniqueness, signatures, and the removal of legacy string keys. Generated declarations remain unchanged. Validated with the type build, 822 unit tests, and 93 e2e tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **TypeScript Improvements**
  * Strengthened internal typing across translation, number formatting, and date-time formatting APIs.
  * Improved type safety for composer lifecycle, devtools integration, and internal formatting helpers.
  * Refined exported symbol types for more accurate compile-time checks.

* **Testing**
  * Added compile-time coverage for internal symbol contracts and composer typings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->