### PR TITLE
refactor: unify scoped Composer lifecycle

### DIFF
--- a/packages/vue-i18n-core/src/i18n.ts
+++ b/packages/vue-i18n-core/src/i18n.ts
@@ -453,6 +453,54 @@ export function createI18n(options: any = {}): any {
   return i18n
 }
 
+type ScopedComposerOptions = ComposerOptions & ComposerInternalOptions
+
+function createScopedComposerOptions(
+  options: UseI18nOptions,
+  i18n: I18nInternal
+): ScopedComposerOptions {
+  const composerOptions = assign({}, options) as ScopedComposerOptions
+
+  if (i18n.__messageCompiler) {
+    composerOptions.messageCompiler = i18n.__messageCompiler
+  }
+  if (i18n.__messageResolver) {
+    composerOptions.messageResolver = i18n.__messageResolver
+  }
+  if (i18n.__localeFallbacker) {
+    composerOptions.localeFallbacker = i18n.__localeFallbacker
+  }
+
+  return composerOptions
+}
+
+function extendComposer(composer: ComposerInternalInstance, i18n: I18nInternal): void {
+  if (i18n.__composerExtend) {
+    composer[DisposeSymbol] = i18n.__composerExtend(composer)
+  }
+}
+
+function attachComposerDevtools(composer: ComposerInternalInstance): Disposer | undefined {
+  if ((__DEV__ || __FEATURE_PROD_VUE_DEVTOOLS__) && !__NODE_JS__) {
+    const emitter = createEmitter<VueDevToolsEmitterEvents>()
+    composer[EnableEmitter]?.(emitter)
+    emitter.on('*', addTimelineEvent)
+
+    return () => {
+      emitter.off('*', addTimelineEvent)
+      composer[DisableEmitter]?.()
+    }
+  }
+}
+
+function disposeComposer(composer: ComposerInternalInstance): void {
+  const dispose = composer[DisposeSymbol]
+  if (dispose) {
+    dispose()
+    delete composer[DisposeSymbol]
+  }
+}
+
 export function useI18n<Options extends UseI18nOptions = UseI18nOptions>(
   options?: Options
 ): Composer<
@@ -582,98 +630,34 @@ export function useI18n<
     >
   }
 
-  // Isolated scope - independent composer not tied to component uid
-  if (scope === 'isolated') {
-    const i18nInternal = i18n as unknown as I18nInternal
-
-    const composerOptions = assign({}, options) as ComposerOptions & ComposerInternalOptions
-
-    // Inherit messageCompiler, messageResolver, localeFallbacker from createI18n
-    if (i18nInternal.__messageCompiler) {
-      composerOptions.messageCompiler = i18nInternal.__messageCompiler
-    }
-    if (i18nInternal.__messageResolver) {
-      composerOptions.messageResolver = i18nInternal.__messageResolver
-    }
-    if (i18nInternal.__localeFallbacker) {
-      composerOptions.localeFallbacker = i18nInternal.__localeFallbacker
-    }
-
-    // Set parent Composer as fallback root
-    const parentComposer = inject(I18nComposerKey, null)
-    composerOptions.__root = parentComposer || gl
-
-    const composer = createComposer(composerOptions) as ComposerInternalInstance
-
-    // ComposerExtend
-    if (i18nInternal.__composerExtend) {
-      composer[DisposeSymbol] = i18nInternal.__composerExtend(composer)
-    }
-
-    // DevTools emitter setup
-    let emitter: VueDevToolsEmitter | null = null
-    if ((__DEV__ || __FEATURE_PROD_VUE_DEVTOOLS__) && !__NODE_JS__) {
-      emitter = createEmitter<VueDevToolsEmitterEvents>()
-      composer[EnableEmitter]?.(emitter)
-      emitter.on('*', addTimelineEvent)
-    }
-
-    // Lifecycle management via onScopeDispose
-    const currentScope = getCurrentScope()
-    if (currentScope) {
-      onScopeDispose(() => {
-        if ((__DEV__ || __FEATURE_PROD_VUE_DEVTOOLS__) && !__NODE_JS__) {
-          emitter?.off('*', addTimelineEvent)
-          composer[DisableEmitter]?.()
-        }
-        const dispose = composer[DisposeSymbol]
-        if (dispose) {
-          dispose()
-          delete composer[DisposeSymbol]
-        }
-      })
-    }
-
-    return composer as unknown as Composer<Messages, DateTimeFormats, NumberFormats, OptionLocale>
-  }
-
-  // Local scope
   const i18nInternal = i18n as unknown as I18nInternal
+  let localUid: number | undefined
 
-  // Duplicate call detection via uid
-  const { value: uid } = useInstanceOption('uid', true)
-  if (!isNumber(uid)) {
-    throw createI18nError(I18nErrorCodes.UNEXPECTED_ERROR)
-  }
-  const existingEntry = i18nInternal.__getInstance(uid)
-  if (existingEntry != null) {
-    if (__DEV__) {
-      throw createI18nError(I18nErrorCodes.DUPLICATE_USE_I18N_CALLING)
+  if (scope !== 'isolated') {
+    // Duplicate call detection via uid
+    const { value: uid } = useInstanceOption('uid', true)
+    if (!isNumber(uid)) {
+      throw createI18nError(I18nErrorCodes.UNEXPECTED_ERROR)
     }
-    return existingEntry.composer as unknown as Composer<
-      Messages,
-      DateTimeFormats,
-      NumberFormats,
-      OptionLocale
-    >
+    const existingEntry = i18nInternal.__getInstance(uid)
+    if (existingEntry != null) {
+      if (__DEV__) {
+        throw createI18nError(I18nErrorCodes.DUPLICATE_USE_I18N_CALLING)
+      }
+      return existingEntry.composer as unknown as Composer<
+        Messages,
+        DateTimeFormats,
+        NumberFormats,
+        OptionLocale
+      >
+    }
+    localUid = uid
   }
 
-  // Create Composer
-  const composerOptions = assign({}, options) as ComposerOptions & ComposerInternalOptions
-
-  // Inherit messageCompiler, messageResolver, localeFallbacker from createI18n
-  if (i18nInternal.__messageCompiler) {
-    composerOptions.messageCompiler = i18nInternal.__messageCompiler
-  }
-  if (i18nInternal.__messageResolver) {
-    composerOptions.messageResolver = i18nInternal.__messageResolver
-  }
-  if (i18nInternal.__localeFallbacker) {
-    composerOptions.localeFallbacker = i18nInternal.__localeFallbacker
-  }
+  const composerOptions = createScopedComposerOptions(options, i18nInternal)
 
   // SFC i18n custom blocks
-  if ('__i18n' in type) {
+  if (localUid !== undefined && '__i18n' in type) {
     composerOptions.__i18n = type.__i18n as CustomBlocks
   }
 
@@ -682,45 +666,32 @@ export function useI18n<
   composerOptions.__root = parentComposer || gl
 
   const composer = createComposer(composerOptions) as ComposerInternalInstance
+  extendComposer(composer, i18nInternal)
 
-  // ComposerExtend
-  if (i18nInternal.__composerExtend) {
-    composer[DisposeSymbol] = i18nInternal.__composerExtend(composer)
+  if (localUid !== undefined) {
+    // Register instance
+    const label = type.name || type.__name || type.__file || 'Anonymous'
+    i18nInternal.__setInstance(localUid, { composer, label })
   }
 
-  // Register instance
-  const label = type.name || type.__name || type.__file || 'Anonymous'
-  i18nInternal.__setInstance(uid, { composer, label })
-
-  // DevTools emitter setup
-  let emitter: VueDevToolsEmitter | null = null
-  if ((__DEV__ || __FEATURE_PROD_VUE_DEVTOOLS__) && !__NODE_JS__) {
-    emitter = createEmitter<VueDevToolsEmitterEvents>()
-    composer[EnableEmitter]?.(emitter)
-    emitter.on('*', addTimelineEvent)
-  }
+  const disposeDevtools = attachComposerDevtools(composer)
 
   // Lifecycle management via onScopeDispose
   const currentScope = getCurrentScope()
   if (currentScope) {
     onScopeDispose(() => {
-      // DevTools cleanup
-      if ((__DEV__ || __FEATURE_PROD_VUE_DEVTOOLS__) && !__NODE_JS__) {
-        emitter?.off('*', addTimelineEvent)
-        composer[DisableEmitter]?.()
+      disposeDevtools?.()
+      if (localUid !== undefined) {
+        i18nInternal.__deleteInstance(localUid)
       }
-
-      i18nInternal.__deleteInstance(uid)
-      const dispose = composer[DisposeSymbol]
-      if (dispose) {
-        dispose()
-        delete composer[DisposeSymbol]
-      }
+      disposeComposer(composer)
     })
   }
 
   // Provide to child components
-  provide(I18nComposerKey, composer)
+  if (localUid !== undefined) {
+    provide(I18nComposerKey, composer)
+  }
 
   return composer as unknown as Composer<Messages, DateTimeFormats, NumberFormats, OptionLocale>
 }

--- a/packages/vue-i18n-core/test/i18n.test.ts
+++ b/packages/vue-i18n-core/test/i18n.test.ts
@@ -24,11 +24,19 @@ import {
 } from 'vue'
 import { errorMessages, I18nErrorCodes } from '../src/errors'
 import { createI18n, useI18n } from '../src/i18n'
+import { DisposeSymbol } from '../src/symbols'
 import { pluralRules as _pluralRules, mount, randStr } from './helper'
 
+import type {
+  LocaleFallbacker,
+  MessageFunction,
+  Path,
+  PathValue,
+  ResourceNode
+} from '@intlify/core-base'
 import type { App, ComponentOptions } from 'vue'
-import type { Composer } from '../src/composer'
-import type { I18n } from '../src/i18n'
+import type { Composer, ComposerInternalInstance } from '../src/composer'
+import type { I18n, I18nInternal } from '../src/i18n'
 
 // allow any in error
 const container = document.createElement('div')
@@ -495,6 +503,32 @@ describe('useI18n', () => {
       expect(composableResult!.status).toEqual('composable status')
     })
 
+    test('does not provide itself to child components', async () => {
+      const i18n = createI18n({})
+
+      let isolatedComposer: Composer
+      let childComposer: Composer
+      const Child = defineComponent({
+        setup() {
+          childComposer = useI18n({ useScope: 'parent' })
+          return {}
+        },
+        template: `<p>child</p>`
+      })
+      const App = defineComponent({
+        components: { Child },
+        setup() {
+          isolatedComposer = useI18n({ useScope: 'isolated' })
+          return {}
+        },
+        template: `<Child />`
+      })
+      await mount(App, i18n)
+
+      expect(childComposer!).toBe(i18n.global)
+      expect(childComposer!).not.toBe(isolatedComposer!)
+    })
+
     test('inherits locale from global', async () => {
       const i18n = createI18n({
         locale: 'ja',
@@ -523,8 +557,10 @@ describe('useI18n', () => {
       expect((composer as Composer).locale.value).toEqual('ja')
       expect((composer as Composer).t('greeting')).toEqual('やあ！')
     })
+  })
 
-    test('falls back to root for missing keys', async () => {
+  describe.each(['local', 'isolated'] as const)('%s scoped Composer contract', scope => {
+    test('falls back to the root Composer', async () => {
       const i18n = createI18n({
         locale: 'en',
         messages: {
@@ -536,9 +572,9 @@ describe('useI18n', () => {
       const App = defineComponent({
         setup() {
           composer = useI18n({
-            useScope: 'isolated',
+            useScope: scope,
             messages: {
-              en: { localKey: 'from isolated' }
+              en: { localKey: `from ${scope}` }
             }
           })
           return {}
@@ -547,8 +583,94 @@ describe('useI18n', () => {
       })
       await mount(App, i18n)
 
-      expect((composer as Composer).t('localKey')).toEqual('from isolated')
-      expect((composer as Composer).t('globalKey')).toEqual('from global')
+      expect((composer as Composer).t('localKey')).toBe(`from ${scope}`)
+      expect((composer as Composer).t('globalKey')).toBe('from global')
+    })
+
+    test('inherits runtime dependencies', async () => {
+      const messageCompiler = vi.fn((message: string | ResourceNode): MessageFunction => {
+        const source = typeof message === 'string' ? message : 'resource'
+        return () => `compiled: ${source}`
+      })
+      const messageResolver = vi.fn(
+        (messages: unknown, path: Path): PathValue => (messages as Record<string, PathValue>)[path]
+      )
+      const localeFallbacker = vi.fn(
+        (_context: unknown, _fallbackLocale: unknown, start: string) => [start]
+      )
+      const i18n = createI18n({
+        locale: 'en',
+        messageCompiler,
+        messageResolver,
+        localeFallbacker: localeFallbacker as LocaleFallbacker
+      })
+
+      let translated = ''
+      const App = defineComponent({
+        setup() {
+          const composer = useI18n({
+            useScope: scope,
+            messages: {
+              en: { message: 'hello' }
+            }
+          })
+          translated = composer.t('message')
+          return {}
+        },
+        template: `<p>foo</p>`
+      })
+      await mount(App, i18n)
+
+      expect(translated).toBe('compiled: hello')
+      expect(messageCompiler).toHaveBeenCalled()
+      expect(messageResolver).toHaveBeenCalled()
+      expect(localeFallbacker).toHaveBeenCalled()
+    })
+
+    test('extends and disposes with its scope', async () => {
+      const composerDispose = vi.fn()
+      const composerExtend = vi.fn(() => composerDispose)
+      const i18n = createI18n({})
+      const i18nInternal = i18n as unknown as I18nInternal
+
+      let composer: ComposerInternalInstance
+      let uid = -1
+      const App = defineComponent({
+        name: 'ScopedComposer',
+        setup() {
+          const instance = getCurrentInstance()
+          if (instance == null) {
+            throw new Error()
+          }
+          uid = instance.uid
+          composer = useI18n({ useScope: scope }) as ComposerInternalInstance
+          return {}
+        },
+        template: `<p>foo</p>`
+      })
+      const { app } = await mount(App, i18n, {
+        pluginOptions: {
+          __composerExtend: composerExtend
+        } as any
+      })
+
+      expect(composerExtend).toHaveBeenCalledOnce()
+      expect(composerExtend).toHaveBeenCalledWith(composer!)
+      expect(composer![DisposeSymbol]).toBe(composerDispose)
+      if (scope === 'local') {
+        expect(i18nInternal.__getInstance(uid)).toEqual({
+          composer: composer!,
+          label: 'ScopedComposer'
+        })
+      } else {
+        expect(i18nInternal.__getInstance(uid)).toBeNull()
+      }
+
+      app.unmount()
+
+      expect(i18nInternal.__getInstance(uid)).toBeNull()
+      expect(composerDispose).toHaveBeenCalledOnce()
+      expect(composer![DisposeSymbol]).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
## Summary

This refactors `useI18n` so local and isolated scoped Composers share one lifecycle pipeline. Option inheritance, root fallback, Composer extension, DevTools wiring, and disposal now use focused internal helpers, while local-only registration, SFC resources, and injection stay unchanged.

Contract tests cover fallback, runtime dependencies, extension cleanup, instance registration, and isolated child behavior for both scopes. Public declarations remain unchanged.

Validated with `pnpm build:type`, `pnpm test:unit`, and `E2E_BROWSER=chromium pnpm test:e2e`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved isolated-scope internationalization behavior to prevent composers from being unintentionally exposed to child components.
  * Ensured scoped composers consistently inherit fallback behavior and runtime configuration.
  * Improved cleanup when components or composers are disposed.

* **Tests**
  * Expanded coverage for local and isolated scopes, inheritance, extension hooks, and disposal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->