### PR TITLE
refactor: unify intl formatting pipeline

### DIFF
--- a/packages/core-base/src/datetime.ts
+++ b/packages/core-base/src/datetime.ts
@@ -1,33 +1,21 @@
-import {
-  assign,
-  create,
-  isBoolean,
-  isDate,
-  isKeylessObject,
-  isNumber,
-  isPlainObject,
-  isString
-} from '@intlify/shared'
-import {
-  handleMissing,
-  isTranslateFallbackWarn,
-  MISSING_RESOLVE_VALUE,
-  NOT_RESOLVED
-} from './context'
+import { assign, create, isBoolean, isDate, isNumber, isString } from '@intlify/shared'
+import { MISSING_RESOLVE_VALUE, NOT_RESOLVED } from './context'
 import { CoreErrorCodes, createCoreError } from './errors'
 import { getLocale } from './fallbacker'
+import {
+  clearFormatCache,
+  getFormatterCacheKey,
+  parseFormatArgs,
+  resolveFormatLocale
+} from './formatter'
 import { Availabilities } from './intl'
 import { CoreWarnCodes, getWarnMessage } from './warnings'
 
 import type { CoreContext, CoreInternalContext } from './context'
 import type { LocaleOptions } from './fallbacker'
-import type { FallbackLocale, Locale } from './runtime'
-import type {
-  DateTimeFormat,
-  DateTimeFormatOptions,
-  DateTimeFormats as DateTimeFormatsType,
-  PickupFormatKeys
-} from './types/index'
+import type { Locale } from './runtime'
+import type { DateTimeFormat, DateTimeFormatOptions, PickupFormatKeys } from './types/index'
+import type { FormatResources } from './formatter'
 
 /**
  *  # datetime
@@ -175,7 +163,7 @@ export function datetime<Context extends CoreContext<Message, {}, {}, {}>, Messa
   context: Context,
   ...args: unknown[]
 ): string | number | Intl.DateTimeFormatPart[] {
-  const { datetimeFormats, unresolving, fallbackLocale, onWarn, localeFallbacker } = context
+  const { datetimeFormats, unresolving, onWarn } = context
   const { __datetimeFormatters } = context as unknown as CoreInternalContext
 
   if (__DEV__ && !Availabilities.dateTimeFormat) {
@@ -195,64 +183,29 @@ export function datetime<Context extends CoreContext<Message, {}, {}, {}>, Messa
   const fallbackWarn = isBoolean(options.fallbackWarn) ? options.fallbackWarn : context.fallbackWarn
   const part = !!options.part
   const locale = getLocale(context, options)
-  const locales = localeFallbacker(context as any, fallbackLocale as FallbackLocale, locale)
 
   if (!isString(key) || key === '') {
     const formatter = new Intl.DateTimeFormat(locale.replace(/!/g, ''), overrides)
     return !part ? formatter.format(value) : formatter.formatToParts(value)
   }
 
-  // resolve format
-  let datetimeFormat: DateTimeFormat = {}
-  let targetLocale: Locale | undefined
-  let format: DateTimeFormatOptions | null = null
-  let from: Locale = locale
-  let to: Locale | null = null
-  const type = 'datetime format'
-
-  for (let i = 0; i < locales.length; i++) {
-    targetLocale = to = locales[i]
-    if (__DEV__ && locale !== targetLocale && isTranslateFallbackWarn(fallbackWarn, key)) {
-      onWarn(
-        getWarnMessage(CoreWarnCodes.FALLBACK_TO_DATE_FORMAT, {
-          key,
-          target: targetLocale
-        })
-      )
-    }
-
-    // for vue-devtools timeline event
-    if (__DEV__ && locale !== targetLocale) {
-      const emitter = (context as unknown as CoreInternalContext).__v_emitter
-      if (emitter) {
-        emitter.emit('fallback', {
-          type,
-          key,
-          from,
-          to,
-          groupId: `${type}:${key}`
-        })
-      }
-    }
-
-    datetimeFormat = (datetimeFormats as unknown as DateTimeFormatsType)[targetLocale] || {}
-    format = datetimeFormat[key]
-
-    if (isPlainObject(format)) break
-    handleMissing(context as any, key, targetLocale, missingWarn, type)
-    from = to
-  }
-
-  // checking format and target locale
-  if (!isPlainObject(format) || !isString(targetLocale)) {
+  const targetLocale = resolveFormatLocale(
+    context,
+    key,
+    locale,
+    datetimeFormats as unknown as FormatResources<DateTimeFormatOptions>,
+    missingWarn,
+    fallbackWarn,
+    'datetime format'
+  )
+  if (!isString(targetLocale)) {
     return unresolving ? NOT_RESOLVED : key
   }
+  const format = (datetimeFormats as unknown as FormatResources<DateTimeFormatOptions>)[
+    targetLocale
+  ][key]
 
-  let id = `${targetLocale}__${key}`
-  if (isPlainObject(overrides) && !isKeylessObject(overrides)) {
-    id = `${id}__${JSON.stringify(overrides)}`
-  }
-
+  const id = getFormatterCacheKey(targetLocale, key, overrides)
   let formatter = __datetimeFormatters.get(id)
   if (!formatter) {
     formatter = new Intl.DateTimeFormat(targetLocale, assign({}, format, overrides))
@@ -289,9 +242,9 @@ export const DATETIME_FORMAT_OPTIONS_KEYS: string[] = [
 export function parseDateTimeArgs(
   ...args: unknown[]
 ): [string, number | Date, DateTimeOptions, Intl.DateTimeFormatOptions] {
-  const [arg1, arg2, arg3, arg4] = args
+  const [arg1] = args
   const options = create() as DateTimeOptions
-  let overrides = create() as Intl.DateTimeFormatOptions
+  const initialOverrides = create() as Intl.DateTimeFormatOptions
 
   let value: number | Date
   if (isString(arg1)) {
@@ -327,27 +280,12 @@ export function parseDateTimeArgs(
     throw createCoreError(CoreErrorCodes.INVALID_ARGUMENT)
   }
 
-  if (isString(arg2)) {
-    options.key = arg2
-  } else if (isPlainObject(arg2)) {
-    Object.keys(arg2).forEach(key => {
-      if (DATETIME_FORMAT_OPTIONS_KEYS.includes(key)) {
-        ;(overrides as any)[key] = (arg2 as any)[key]
-      } else {
-        ;(options as any)[key] = (arg2 as any)[key]
-      }
-    })
-  }
-
-  if (isString(arg3)) {
-    options.locale = arg3
-  } else if (isPlainObject(arg3)) {
-    overrides = arg3
-  }
-
-  if (isPlainObject(arg4)) {
-    overrides = arg4
-  }
+  const overrides = parseFormatArgs<DateTimeOptions, Intl.DateTimeFormatOptions>(
+    args,
+    options,
+    initialOverrides,
+    DATETIME_FORMAT_OPTIONS_KEYS
+  )
 
   return [options.key || '', value, options, overrides]
 }
@@ -359,11 +297,5 @@ export function clearDateTimeFormat<DateTimeFormats = {}, Message = string>(
   format: DateTimeFormat
 ): void {
   const context = ctx as unknown as CoreInternalContext
-  for (const key in format) {
-    const id = `${locale}__${key}`
-    if (!context.__datetimeFormatters.has(id)) {
-      continue
-    }
-    context.__datetimeFormatters.delete(id)
-  }
+  clearFormatCache(context.__datetimeFormatters, locale, format)
 }

--- a/packages/core-base/src/formatter.ts
+++ b/packages/core-base/src/formatter.ts
@@ -77,11 +77,12 @@ export function clearFormatCache<Formatter>(
   format: Record<string, unknown>
 ): void {
   for (const key in format) {
-    const id = `${locale}__${key}`
-    if (!formatters.has(id)) {
-      continue
+    const prefix = `${locale}__${key}`
+    for (const id of formatters.keys()) {
+      if (id === prefix || id.startsWith(`${prefix}__`)) {
+        formatters.delete(id)
+      }
     }
-    formatters.delete(id)
   }
 }
 

--- a/packages/core-base/src/formatter.ts
+++ b/packages/core-base/src/formatter.ts
@@ -1,0 +1,120 @@
+import { isKeylessObject, isPlainObject, isString } from '@intlify/shared'
+import { handleMissing, isTranslateFallbackWarn } from './context'
+import { CoreWarnCodes, getWarnMessage } from './warnings'
+
+import type { CoreContext, CoreInternalContext } from './context'
+import type { CoreMissingType, FallbackLocale, Locale } from './runtime'
+
+type FormatType = Extract<CoreMissingType, 'datetime format' | 'number format'>
+
+export type FormatResources<Format> = Record<string, Record<string, Format>>
+
+export function resolveFormatLocale<Format, Message = string>(
+  context: CoreContext<Message>,
+  key: string,
+  locale: Locale,
+  formats: FormatResources<Format>,
+  missingWarn: boolean | RegExp,
+  fallbackWarn: boolean | RegExp,
+  type: FormatType
+): Locale | null {
+  const { fallbackLocale, localeFallbacker, onWarn } = context
+  const locales = localeFallbacker(context as any, fallbackLocale as FallbackLocale, locale)
+  let from = locale
+
+  for (let i = 0; i < locales.length; i++) {
+    const targetLocale = locales[i]
+    if (__DEV__ && locale !== targetLocale && isTranslateFallbackWarn(fallbackWarn, key)) {
+      onWarn(
+        getWarnMessage(
+          type === 'datetime format'
+            ? CoreWarnCodes.FALLBACK_TO_DATE_FORMAT
+            : CoreWarnCodes.FALLBACK_TO_NUMBER_FORMAT,
+          {
+            key,
+            target: targetLocale
+          }
+        )
+      )
+    }
+
+    if (__DEV__ && locale !== targetLocale) {
+      const emitter = (context as unknown as CoreInternalContext).__v_emitter
+      if (emitter) {
+        emitter.emit('fallback', {
+          type,
+          key,
+          from,
+          to: targetLocale,
+          groupId: `${type}:${key}`
+        })
+      }
+    }
+
+    const format = (formats[targetLocale] || {})[key]
+    if (isPlainObject(format) && isString(targetLocale)) {
+      return targetLocale
+    }
+
+    handleMissing(context, key, targetLocale, missingWarn, type)
+    from = targetLocale
+  }
+
+  return null
+}
+
+export function getFormatterCacheKey(locale: Locale, key: string, overrides: unknown): string {
+  let id = `${locale}__${key}`
+  if (isPlainObject(overrides) && !isKeylessObject(overrides)) {
+    id = `${id}__${JSON.stringify(overrides)}`
+  }
+  return id
+}
+
+export function clearFormatCache<Formatter>(
+  formatters: Map<string, Formatter>,
+  locale: Locale,
+  format: Record<string, unknown>
+): void {
+  for (const key in format) {
+    const id = `${locale}__${key}`
+    if (!formatters.has(id)) {
+      continue
+    }
+    formatters.delete(id)
+  }
+}
+
+export function parseFormatArgs<Options extends { key?: string }, Overrides>(
+  args: unknown[],
+  options: Options,
+  initialOverrides: Overrides,
+  optionsKeys: readonly string[]
+): Overrides {
+  const [, arg2, arg3, arg4] = args
+  let overrides = initialOverrides
+
+  if (isString(arg2)) {
+    options.key = arg2
+  } else if (isPlainObject(arg2)) {
+    Object.keys(arg2).forEach(key => {
+      if (optionsKeys.includes(key)) {
+        ;(overrides as any)[key] = (arg2 as any)[key]
+      } else {
+        ;(options as any)[key] = (arg2 as any)[key]
+      }
+    })
+  }
+
+  if (isString(arg3)) {
+    ;(options as any).locale = arg3
+  } else if (isPlainObject(arg3)) {
+    overrides = arg3 as Overrides
+  }
+
+  if (isPlainObject(arg4)) {
+    overrides = arg4 as Overrides
+  }
+
+  return overrides
+}

--- a/packages/core-base/src/number.ts
+++ b/packages/core-base/src/number.ts
@@ -1,32 +1,21 @@
-import {
-  assign,
-  create,
-  isBoolean,
-  isKeylessObject,
-  isNumber,
-  isPlainObject,
-  isString
-} from '@intlify/shared'
-import {
-  handleMissing,
-  isTranslateFallbackWarn,
-  MISSING_RESOLVE_VALUE,
-  NOT_RESOLVED
-} from './context'
+import { assign, create, isBoolean, isNumber, isString } from '@intlify/shared'
+import { MISSING_RESOLVE_VALUE, NOT_RESOLVED } from './context'
 import { CoreErrorCodes, createCoreError } from './errors'
 import { getLocale } from './fallbacker'
+import {
+  clearFormatCache,
+  getFormatterCacheKey,
+  parseFormatArgs,
+  resolveFormatLocale
+} from './formatter'
 import { Availabilities } from './intl'
 import { CoreWarnCodes, getWarnMessage } from './warnings'
 
 import type { CoreContext, CoreInternalContext } from './context'
 import type { LocaleOptions } from './fallbacker'
-import type { FallbackLocale, Locale } from './runtime'
-import type {
-  NumberFormat,
-  NumberFormatOptions,
-  NumberFormats as NumberFormatsType,
-  PickupFormatKeys
-} from './types'
+import type { Locale } from './runtime'
+import type { NumberFormat, NumberFormatOptions, PickupFormatKeys } from './types'
+import type { FormatResources } from './formatter'
 
 /**
  *  # number
@@ -173,7 +162,7 @@ export function number<Context extends CoreContext<Message, {}, {}, {}>, Message
   context: Context,
   ...args: unknown[]
 ): string | number | Intl.NumberFormatPart[] {
-  const { numberFormats, unresolving, fallbackLocale, onWarn, localeFallbacker } = context
+  const { numberFormats, unresolving, onWarn } = context
   const { __numberFormatters } = context as unknown as CoreInternalContext
 
   if (__DEV__ && !Availabilities.numberFormat) {
@@ -193,64 +182,29 @@ export function number<Context extends CoreContext<Message, {}, {}, {}>, Message
   const fallbackWarn = isBoolean(options.fallbackWarn) ? options.fallbackWarn : context.fallbackWarn
   const part = !!options.part
   const locale = getLocale(context, options)
-  const locales = localeFallbacker(context as any, fallbackLocale as FallbackLocale, locale)
 
   if (!isString(key) || key === '') {
     const formatter = new Intl.NumberFormat(locale.replace(/!/g, ''), overrides)
     return !part ? formatter.format(value) : formatter.formatToParts(value)
   }
 
-  // resolve format
-  let numberFormat: NumberFormat = {}
-  let targetLocale: Locale | undefined
-  let format: NumberFormatOptions | null = null
-  let from: Locale = locale
-  let to: Locale | null = null
-  const type = 'number format'
-
-  for (let i = 0; i < locales.length; i++) {
-    targetLocale = to = locales[i]
-    if (__DEV__ && locale !== targetLocale && isTranslateFallbackWarn(fallbackWarn, key)) {
-      onWarn(
-        getWarnMessage(CoreWarnCodes.FALLBACK_TO_NUMBER_FORMAT, {
-          key,
-          target: targetLocale
-        })
-      )
-    }
-
-    // for vue-devtools timeline event
-    if (__DEV__ && locale !== targetLocale) {
-      const emitter = (context as unknown as CoreInternalContext).__v_emitter
-      if (emitter) {
-        emitter.emit('fallback', {
-          type,
-          key,
-          from,
-          to,
-          groupId: `${type}:${key}`
-        })
-      }
-    }
-
-    numberFormat = (numberFormats as unknown as NumberFormatsType)[targetLocale] || {}
-
-    format = numberFormat[key]
-    if (isPlainObject(format)) break
-    handleMissing(context as any, key, targetLocale, missingWarn, type)
-    from = to
-  }
-
-  // checking format and target locale
-  if (!isPlainObject(format) || !isString(targetLocale)) {
+  const targetLocale = resolveFormatLocale(
+    context,
+    key,
+    locale,
+    numberFormats as unknown as FormatResources<NumberFormatOptions>,
+    missingWarn,
+    fallbackWarn,
+    'number format'
+  )
+  if (!isString(targetLocale)) {
     return unresolving ? NOT_RESOLVED : key
   }
+  const format = (numberFormats as unknown as FormatResources<NumberFormatOptions>)[targetLocale][
+    key
+  ]
 
-  let id = `${targetLocale}__${key}`
-  if (isPlainObject(overrides) && !isKeylessObject(overrides)) {
-    id = `${id}__${JSON.stringify(overrides)}`
-  }
-
+  const id = getFormatterCacheKey(targetLocale, key, overrides)
   let formatter = __numberFormatters.get(id)
   if (!formatter) {
     formatter = new Intl.NumberFormat(targetLocale, assign({}, format, overrides))
@@ -287,36 +241,21 @@ export const NUMBER_FORMAT_OPTIONS_KEYS: string[] = [
 export function parseNumberArgs(
   ...args: unknown[]
 ): [string, number, NumberOptions, Intl.NumberFormatOptions] {
-  const [arg1, arg2, arg3, arg4] = args
+  const [arg1] = args
   const options = create() as NumberOptions
-  let overrides = create() as Intl.NumberFormatOptions
+  const initialOverrides = create() as Intl.NumberFormatOptions
 
   if (!isNumber(arg1)) {
     throw createCoreError(CoreErrorCodes.INVALID_ARGUMENT)
   }
   const value = arg1
 
-  if (isString(arg2)) {
-    options.key = arg2
-  } else if (isPlainObject(arg2)) {
-    Object.keys(arg2).forEach(key => {
-      if (NUMBER_FORMAT_OPTIONS_KEYS.includes(key)) {
-        ;(overrides as any)[key] = (arg2 as any)[key]
-      } else {
-        ;(options as any)[key] = (arg2 as any)[key]
-      }
-    })
-  }
-
-  if (isString(arg3)) {
-    options.locale = arg3
-  } else if (isPlainObject(arg3)) {
-    overrides = arg3
-  }
-
-  if (isPlainObject(arg4)) {
-    overrides = arg4
-  }
+  const overrides = parseFormatArgs<NumberOptions, Intl.NumberFormatOptions>(
+    args,
+    options,
+    initialOverrides,
+    NUMBER_FORMAT_OPTIONS_KEYS
+  )
 
   return [options.key || '', value, options, overrides]
 }
@@ -328,11 +267,5 @@ export function clearNumberFormat<NumberFormats, Message = string>(
   format: NumberFormat
 ): void {
   const context = ctx as unknown as CoreInternalContext
-  for (const key in format) {
-    const id = `${locale}__${key}`
-    if (!context.__numberFormatters.has(id)) {
-      continue
-    }
-    context.__numberFormatters.delete(id)
-  }
+  clearFormatCache(context.__numberFormatters, locale, format)
 }

--- a/packages/core-base/test/formatter.test.ts
+++ b/packages/core-base/test/formatter.test.ts
@@ -109,7 +109,8 @@ describe.each(formatContracts)('$name formatting pipeline', contract => {
     })
 
     contract.format(context, 'target')
-    expect(contract.cache(context).size).toBe(1)
+    contract.format(context, 'target', contract.overrides)
+    expect(contract.cache(context).size).toBe(2)
 
     contract.clear(context, formats['en-US'])
     expect(contract.cache(context).size).toBe(0)

--- a/packages/core-base/test/formatter.test.ts
+++ b/packages/core-base/test/formatter.test.ts
@@ -1,0 +1,117 @@
+import { createEmitter } from '@intlify/shared'
+
+import { createCoreContext } from '../src/context'
+import { clearDateTimeFormat, datetime } from '../src/datetime'
+import { fallbackWithSimple } from '../src/fallbacker'
+import { clearNumberFormat, number } from '../src/number'
+
+import type { VueDevToolsEmitterEvents } from '@intlify/devtools-types'
+import type { CoreInternalContext } from '../src/context'
+
+const date = new Date(Date.UTC(2020, 0, 2))
+
+const formatContracts = [
+  {
+    name: 'datetime',
+    type: 'datetime format',
+    resource: 'datetimeFormats',
+    formatOptions: { year: 'numeric', timeZone: 'UTC' },
+    overrides: { month: '2-digit' },
+    format: (context: any, key: string, overrides?: Intl.DateTimeFormatOptions) =>
+      overrides ? datetime(context, date, key, overrides) : datetime(context, date, key),
+    cache: (context: any) => (context as CoreInternalContext).__datetimeFormatters,
+    clear: (context: any, formats: any) => clearDateTimeFormat(context, 'en-US', formats)
+  },
+  {
+    name: 'number',
+    type: 'number format',
+    resource: 'numberFormats',
+    formatOptions: { style: 'decimal' },
+    overrides: { minimumFractionDigits: 2 },
+    format: (context: any, key: string, overrides?: Intl.NumberFormatOptions) =>
+      overrides ? number(context, 1000, key, overrides) : number(context, 1000, key),
+    cache: (context: any) => (context as CoreInternalContext).__numberFormatters,
+    clear: (context: any, formats: any) => clearNumberFormat(context, 'en-US', formats)
+  }
+] as const
+
+describe.each(formatContracts)('$name formatting pipeline', contract => {
+  test('preserve fallback and missing event metadata', () => {
+    const emitter = createEmitter<VueDevToolsEmitterEvents>()
+    const onFallback = vi.fn()
+    const onMissing = vi.fn()
+    const missing = vi.fn()
+    emitter.on('fallback', onFallback)
+    emitter.on('missing', onMissing)
+
+    const context = createCoreContext({
+      locale: 'en-US',
+      fallbackLocale: ['ja-JP'],
+      localeFallbacker: fallbackWithSimple,
+      fallbackWarn: false,
+      missingWarn: false,
+      missing,
+      __v_emitter: emitter,
+      [contract.resource]: {
+        'en-US': {},
+        'ja-JP': { target: contract.formatOptions }
+      }
+    })
+
+    contract.format(context, 'target')
+
+    expect(missing).toHaveBeenCalledWith(context, 'en-US', 'target', contract.type)
+    expect(onMissing).toHaveBeenCalledWith({
+      locale: 'en-US',
+      key: 'target',
+      type: contract.type,
+      groupId: `${contract.type}:target`
+    })
+    expect(onFallback).toHaveBeenCalledWith({
+      type: contract.type,
+      key: 'target',
+      from: 'en-US',
+      to: 'ja-JP',
+      groupId: `${contract.type}:target`
+    })
+  })
+
+  test('reuse cached formatters and partition caches by overrides', () => {
+    const formats = {
+      'en-US': { target: contract.formatOptions }
+    }
+    const context = createCoreContext({
+      locale: 'en-US',
+      localeFallbacker: fallbackWithSimple,
+      [contract.resource]: formats
+    })
+
+    contract.format(context, 'target')
+    const cache = contract.cache(context)
+    const cached = cache.get('en-US__target')
+
+    contract.format(context, 'target')
+    expect(cache.get('en-US__target')).toBe(cached)
+
+    contract.format(context, 'target', contract.overrides)
+    expect(cache.size).toBe(2)
+    expect(cache.has(`en-US__target__${JSON.stringify(contract.overrides)}`)).toBe(true)
+  })
+
+  test('clear cached formatters for replaced resources', () => {
+    const formats = {
+      'en-US': { target: contract.formatOptions }
+    }
+    const context = createCoreContext({
+      locale: 'en-US',
+      localeFallbacker: fallbackWithSimple,
+      [contract.resource]: formats
+    })
+
+    contract.format(context, 'target')
+    expect(contract.cache(context).size).toBe(1)
+
+    contract.clear(context, formats['en-US'])
+    expect(contract.cache(context).size).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

This consolidates the duplicated number and datetime formatting pipeline into an internal formatter module. Shared handling now covers locale fallback resolution, missing and DevTools events, option partitioning, and formatter cache keys and invalidation, while each public API keeps its existing overloads, validation, and `Intl` constructor.

Contract tests verify both paths preserve fallback metadata and cache behavior. Public declarations are unchanged, production bundles shrink slightly, and `build:type`, 838 unit tests, and 93 E2E tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale fallback and missing-format handling across date/time and number formatting, with consistent dev warnings/events.
  * Refined formatter caching so cache reuse/partitioning correctly respects formatting options and overrides.
  * Improved cache invalidation when formatter resources are replaced.

* **Tests**
  * Added coverage for fallback and missing-format dev events, correct invocation of missing handlers, formatter cache reuse/partitioning by options, and cache clearing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->