### PR TITLE
fix: avoid retaining array message references

### DIFF
--- a/packages/core-base/test/context.test.ts
+++ b/packages/core-base/test/context.test.ts
@@ -181,6 +181,25 @@ describe('getLocaleMessage', () => {
     expect(messages).toEqual({ hello: 'hello' })
   })
 
+  test('returns an isolated copy of array messages', () => {
+    const ctx = context({
+      messages: {
+        en: {
+          list: [{ value: 'stored' }]
+        }
+      }
+    })
+    const messages = getLocaleMessage(ctx, 'en')!
+
+    expect(messages.list).not.toBe(ctx.messages.en.list)
+    expect(messages.list[0]).not.toBe(ctx.messages.en.list[0])
+
+    messages.list[0].value = 'changed'
+    messages.list.push({ value: 'added' })
+
+    expect(ctx.messages.en.list).toEqual([{ value: 'stored' }])
+  })
+
   test('not exist locale', () => {
     const ctx = context({
       locale: 'en',

--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -17,20 +17,21 @@ export function deepCopy(src: any, des: any): void {
       if (key === '__proto__') {
         return
       }
-      // if src[key] is an object/array, set des[key]
-      // to empty object/array to prevent setting by reference
-      if (isObject(src[key]) && !isObject(des[key])) {
-        des[key] = Array.isArray(src[key]) ? [] : create()
-      }
 
-      if (isNotObjectOrIsArray(des[key]) || isNotObjectOrIsArray(src[key])) {
-        // replace with src[key] when:
-        // src[key] or des[key] is not an object, or
-        // src[key] or des[key] is an array
-        des[key] = src[key]
+      const value = src[key]
+      if (isArray(value)) {
+        // replace arrays instead of merging them, without retaining source references
+        const copied: unknown[] = []
+        copied.length = value.length
+        des[key] = copied
+        stack.push({ src: value, des: copied })
+      } else if (isObject(value)) {
+        if (!isObject(des[key]) || isArray(des[key])) {
+          des[key] = create()
+        }
+        stack.push({ src: value, des: des[key] })
       } else {
-        // src[key] and des[key] are both objects, merge them
-        stack.push({ src: src[key], des: des[key] })
+        des[key] = value
       }
     })
   }

--- a/packages/shared/test/messages.test.ts
+++ b/packages/shared/test/messages.test.ts
@@ -49,6 +49,34 @@ test('deepCopy merges without mutating src argument', () => {
   expect(msg1).toStrictEqual(copy1)
 })
 
+test('deepCopy replaces arrays without retaining source references', () => {
+  const source = {
+    fruit: [{ name: 'Apple' }],
+    nested: [['value']]
+  }
+  const destination = {
+    fruit: [{ name: 'Strawberry' }, { name: 'Banana' }],
+    nested: [['old']]
+  }
+
+  deepCopy(source, destination)
+
+  expect(destination).toEqual(source)
+  expect(destination.fruit).not.toBe(source.fruit)
+  expect(destination.fruit[0]).not.toBe(source.fruit[0])
+  expect(destination.nested).not.toBe(source.nested)
+  expect(destination.nested[0]).not.toBe(source.nested[0])
+
+  source.fruit[0].name = 'Pear'
+  source.fruit.push({ name: 'Orange' })
+  source.nested[0].push('new value')
+
+  expect(destination).toEqual({
+    fruit: [{ name: 'Apple' }],
+    nested: [['value']]
+  })
+})
+
 describe('CVE-2024-52810', () => {
   test('__proto__', () => {
     const source = '{ "__proto__": { "pollutedKey": 123 } }'
@@ -77,5 +105,15 @@ describe('CVE-2024-52810', () => {
     deepCopy(JSON.parse(source), dest)
     // @ts-ignore -- initialize polluted property
     expect({}.polluted).toBeUndefined()
+  })
+
+  test('__proto__ nested in array', () => {
+    const source = '{ "list": [{ "__proto__": { "pollutedKey": 123 } }] }'
+    const dest = {}
+
+    deepCopy(JSON.parse(source), dest)
+    expect(dest).toEqual({ list: [{}] })
+    // @ts-ignore -- initialize polluted property
+    expect(JSON.parse(JSON.stringify({}.__proto__))).toEqual({})
   })
 })

--- a/packages/vue-i18n-core/test/composer.test.ts
+++ b/packages/vue-i18n-core/test/composer.test.ts
@@ -1588,6 +1588,28 @@ describe('getLocaleMessage / setLocaleMessage / mergeLocaleMessage', () => {
       }
     })
   })
+
+  test('does not retain array references when merging messages', () => {
+    const { getLocaleMessage, mergeLocaleMessage } = createComposer({
+      messages: {
+        en: {}
+      }
+    })
+    const source = {
+      list: [{ value: 'stored' }]
+    }
+
+    mergeLocaleMessage('en', source)
+    const messages = getLocaleMessage<typeof source>('en')
+
+    expect(messages.list).not.toBe(source.list)
+    expect(messages.list[0]).not.toBe(source.list[0])
+
+    source.list[0].value = 'changed'
+    source.list.push({ value: 'added' })
+
+    expect(messages.list).toEqual([{ value: 'stored' }])
+  })
 })
 
 describe('getDateTimeFormat / setDateTimeFormat / mergeDateTimeFormat', () => {


### PR DESCRIPTION
## Summary

This fixes #2551 by preventing `deepCopy` from retaining references to array-valued locale messages. Arrays continue to replace existing arrays instead of being merged, while nested arrays and objects are now copied through the iterative traversal.

Regression tests cover the shared helper, core locale retrieval, and Composer message merging. They also verify that `__proto__` keys inside arrays remain filtered. Type generation, 842 unit tests, 93 E2E tests, scoped lint checks, and bundle-size checks all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale message copying so arrays and nested values are isolated from their sources.
  * Prevented later changes to source messages from unexpectedly altering stored or retrieved locale data.
  * Strengthened protection against unsafe `__proto__` values during copying.

* **Tests**
  * Added coverage for deep-copy behavior, locale message retrieval, and message merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->