### PR TITLE
fix(core-base): use requested locale for Intl when formats fall back

### DIFF
--- a/packages/core-base/src/datetime.ts
+++ b/packages/core-base/src/datetime.ts
@@ -189,7 +189,7 @@ export function datetime<Context extends CoreContext<Message, {}, {}, {}>, Messa
     return !part ? formatter.format(value) : formatter.formatToParts(value)
   }
 
-  const targetLocale = resolveFormatLocale(
+  const formatLocale = resolveFormatLocale(
     context,
     key,
     locale,
@@ -198,17 +198,18 @@ export function datetime<Context extends CoreContext<Message, {}, {}, {}>, Messa
     fallbackWarn,
     'datetime format'
   )
-  if (!isString(targetLocale)) {
+  if (!isString(formatLocale)) {
     return unresolving ? NOT_RESOLVED : key
   }
   const format = (datetimeFormats as unknown as FormatResources<DateTimeFormatOptions>)[
-    targetLocale
+    formatLocale
   ][key]
 
-  const id = getFormatterCacheKey(targetLocale, key, overrides)
+  const intlLocale = locale.replace(/!/g, '')
+  const id = getFormatterCacheKey(intlLocale, formatLocale, key, overrides)
   let formatter = __datetimeFormatters.get(id)
   if (!formatter) {
-    formatter = new Intl.DateTimeFormat(targetLocale, assign({}, format, overrides))
+    formatter = new Intl.DateTimeFormat(intlLocale, assign({}, format, overrides))
     __datetimeFormatters.set(id, formatter)
   }
   return !part ? formatter.format(value) : formatter.formatToParts(value)

--- a/packages/core-base/src/formatter.ts
+++ b/packages/core-base/src/formatter.ts
@@ -63,8 +63,13 @@ export function resolveFormatLocale<Format, Message = string>(
   return null
 }
 
-export function getFormatterCacheKey(locale: Locale, key: string, overrides: unknown): string {
-  let id = `${locale}__${key}`
+export function getFormatterCacheKey(
+  intlLocale: Locale,
+  formatLocale: Locale,
+  key: string,
+  overrides: unknown
+): string {
+  let id = `${intlLocale}::${formatLocale}::${key}`
   if (isPlainObject(overrides) && !isKeylessObject(overrides)) {
     id = `${id}__${JSON.stringify(overrides)}`
   }
@@ -77,9 +82,14 @@ export function clearFormatCache<Formatter>(
   format: Record<string, unknown>
 ): void {
   for (const key in format) {
-    const prefix = `${locale}__${key}`
+    const segment = `::${locale}::${key}`
     for (const id of formatters.keys()) {
-      if (id === prefix || id.startsWith(`${prefix}__`)) {
+      const index = id.indexOf(segment)
+      if (index === -1) {
+        continue
+      }
+      const after = id.slice(index + segment.length)
+      if (after === '' || after.startsWith('__')) {
         formatters.delete(id)
       }
     }

--- a/packages/core-base/src/number.ts
+++ b/packages/core-base/src/number.ts
@@ -188,7 +188,7 @@ export function number<Context extends CoreContext<Message, {}, {}, {}>, Message
     return !part ? formatter.format(value) : formatter.formatToParts(value)
   }
 
-  const targetLocale = resolveFormatLocale(
+  const formatLocale = resolveFormatLocale(
     context,
     key,
     locale,
@@ -197,17 +197,18 @@ export function number<Context extends CoreContext<Message, {}, {}, {}>, Message
     fallbackWarn,
     'number format'
   )
-  if (!isString(targetLocale)) {
+  if (!isString(formatLocale)) {
     return unresolving ? NOT_RESOLVED : key
   }
-  const format = (numberFormats as unknown as FormatResources<NumberFormatOptions>)[targetLocale][
+  const format = (numberFormats as unknown as FormatResources<NumberFormatOptions>)[formatLocale][
     key
   ]
 
-  const id = getFormatterCacheKey(targetLocale, key, overrides)
+  const intlLocale = locale.replace(/!/g, '')
+  const id = getFormatterCacheKey(intlLocale, formatLocale, key, overrides)
   let formatter = __numberFormatters.get(id)
   if (!formatter) {
-    formatter = new Intl.NumberFormat(targetLocale, assign({}, format, overrides))
+    formatter = new Intl.NumberFormat(intlLocale, assign({}, format, overrides))
     __numberFormatters.set(id, formatter)
   }
   return !part ? formatter.format(value) : formatter.formatToParts(value)

--- a/packages/core-base/test/datetime.test.ts
+++ b/packages/core-base/test/datetime.test.ts
@@ -195,7 +195,7 @@ test('fallback', () => {
     datetimeFormats
   })
 
-  expect(datetime(ctx, dt, 'long')).toEqual('2012/12/20 12:00:00')
+  expect(datetime(ctx, dt, 'long')).toEqual('12/20/2012, 12:00:00 PM')
   expect(mockWarn).toHaveBeenCalledTimes(2)
   expect(mockWarn.mock.calls[0][0]).toEqual(
     `Fall back to datetime format 'long' key with 'en' locale.`
@@ -219,9 +219,9 @@ test(`context fallbackWarn 'false' option`, () => {
     datetimeFormats
   })
 
-  expect(datetime(ctx, dt, 'long')).toEqual('2012/12/20 12:00:00')
+  expect(datetime(ctx, dt, 'long')).toEqual('12/20/2012, 12:00:00 PM')
   dts.forEach(dt => {
-    expect(datetime(ctx, dt, 'long')).toEqual('2012/12/20 12:00:00')
+    expect(datetime(ctx, dt, 'long')).toEqual('12/20/2012, 12:00:00 PM')
   })
   expect(mockWarn).not.toHaveBeenCalled()
 })
@@ -239,7 +239,7 @@ test(`datetime function fallbackWarn 'false' option`, () => {
     datetimeFormats
   })
 
-  expect(datetime(ctx, dt, { key: 'long', fallbackWarn: false })).toEqual('2012/12/20 12:00:00')
+  expect(datetime(ctx, dt, { key: 'long', fallbackWarn: false })).toEqual('12/20/2012, 12:00:00 PM')
   expect(mockWarn).not.toHaveBeenCalled()
 })
 
@@ -334,6 +334,54 @@ test('not available Intl API', () => {
   expect(mockWarn.mock.calls[0][0]).toEqual(
     `Cannot format a date value due to not supported Intl.DateTimeFormat.`
   )
+})
+
+test('uses requested locale for Intl when format falls back to language code', () => {
+  const mockWarn = vi.spyOn(shared, 'warn')
+  mockWarn.mockImplementation(() => {})
+  const mockAvailabilities = Availabilities
+  mockAvailabilities.dateTimeFormat = true
+
+  const sample = new Date('2026-01-31T00:00:00Z')
+  const short = {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    timeZone: 'UTC'
+  }
+
+  const ctx = context({
+    locale: 'en-GB',
+    fallbackWarn: false,
+    missingWarn: false,
+    datetimeFormats: {
+      en: { short }
+    }
+  })
+
+  expect(datetime(ctx, sample, 'short')).toEqual('31/01/2026')
+  expect(datetime(ctx, sample, 'short', 'en-GB')).toEqual('31/01/2026')
+  expect(datetime(ctx, sample, { key: 'short', locale: 'en-GB' })).toEqual('31/01/2026')
+
+  const enCtx = context({
+    locale: 'en',
+    fallbackWarn: false,
+    missingWarn: false,
+    datetimeFormats: {
+      en: { short }
+    }
+  })
+  expect(datetime(enCtx, sample, 'short')).toEqual('01/31/2026')
+
+  const usCtx = context({
+    locale: 'en-US',
+    fallbackWarn: false,
+    missingWarn: false,
+    datetimeFormats: {
+      en: { short }
+    }
+  })
+  expect(datetime(usCtx, sample, 'short')).toEqual('01/31/2026')
 })
 
 describe('error', () => {

--- a/packages/core-base/test/formatter.test.ts
+++ b/packages/core-base/test/formatter.test.ts
@@ -88,14 +88,14 @@ describe.each(formatContracts)('$name formatting pipeline', contract => {
 
     contract.format(context, 'target')
     const cache = contract.cache(context)
-    const cached = cache.get('en-US__target')
+    const cached = cache.get('en-US::en-US::target')
 
     contract.format(context, 'target')
-    expect(cache.get('en-US__target')).toBe(cached)
+    expect(cache.get('en-US::en-US::target')).toBe(cached)
 
     contract.format(context, 'target', contract.overrides)
     expect(cache.size).toBe(2)
-    expect(cache.has(`en-US__target__${JSON.stringify(contract.overrides)}`)).toBe(true)
+    expect(cache.has(`en-US::en-US::target__${JSON.stringify(contract.overrides)}`)).toBe(true)
   })
 
   test('clear cached formatters for replaced resources', () => {

--- a/packages/core-base/test/number.test.ts
+++ b/packages/core-base/test/number.test.ts
@@ -301,6 +301,42 @@ test('not available Intl API', () => {
   )
 })
 
+test('uses requested locale for Intl when format falls back to language code', () => {
+  const mockWarn = vi.spyOn(shared, 'warn')
+  mockWarn.mockImplementation(() => {})
+  const mockAvailabilities = Availabilities
+  mockAvailabilities.numberFormat = true
+
+  const decimal = {
+    style: 'decimal',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  }
+
+  const ctx = context({
+    locale: 'de-CH',
+    fallbackWarn: false,
+    missingWarn: false,
+    numberFormats: {
+      de: { decimal }
+    }
+  })
+
+  expect(number(ctx, 1234.5, 'decimal')).toEqual("1'234.50")
+  expect(number(ctx, 1234.5, 'decimal', 'de-CH')).toEqual("1'234.50")
+  expect(number(ctx, 1234.5, { key: 'decimal', locale: 'de-CH' })).toEqual("1'234.50")
+
+  const deCtx = context({
+    locale: 'de',
+    fallbackWarn: false,
+    missingWarn: false,
+    numberFormats: {
+      de: { decimal }
+    }
+  })
+  expect(number(deCtx, 1234.5, 'decimal')).toEqual('1.234,50')
+})
+
 describe('error', () => {
   test('invalid argument returns empty string with warning', () => {
     const mockWarn = vi.spyOn(shared, 'warn')

--- a/packages/vue-i18n-core/test/composer.test.ts
+++ b/packages/vue-i18n-core/test/composer.test.ts
@@ -1021,7 +1021,7 @@ describe('d', () => {
       }
     })
     const dt = new Date(Date.UTC(2012, 11, 20, 3, 0, 0))
-    expect(d(dt, { key: 'long', fallbackWarn: false })).toEqual('2012/12/20 12:00:00')
+    expect(d(dt, { key: 'long', fallbackWarn: false })).toEqual('12/20/2012, 12:00:00 PM')
     expect(d(dt, { key: 'short', locale: 'ja-JP', year: '2-digit' })).toEqual('12/12/20 12:00')
   })
 


### PR DESCRIPTION
## Summary

- When named datetime/number formats are resolved through the fallback chain (e.g. locale `en-GB` with formats under `en`), `resolveFormatLocale` correctly returns the **resource key** for looking up format options, but that same key was also passed to `Intl.DateTimeFormat` / `Intl.NumberFormat`.
- As a result, `d(date, 'short')` with `locale: 'en-GB'` and `datetimeFormats.en` formatted as US order (`01/31/2026`) instead of GB order (`31/01/2026`).
- This change keeps format options from the fallback resource locale, but always passes the **requested** locale (with `!` stripped) to Intl. Formatter cache keys now include both locales so caches stay correct when clearing formats.

## Before / after

```ts
createI18n({
  legacy: false,
  locale: 'en-GB',
  datetimeFormats: {
    en: { short: { year: 'numeric', month: '2-digit', day: '2-digit', timeZone: 'UTC' } },
  },
})

d(new Date('2026-01-31T00:00:00Z'), 'short')
// before: 01/31/2026
// after:  31/01/2026
```

## Test plan

- [x] Added core-base datetime/number tests for region locale + language-code format resources (`en-GB`/`en`, `de-CH`/`de`)
- [x] Updated existing cross-locale fallback expectations (requested locale is used for Intl; borrowed options only)
- [x] Updated formatter cache key assertions / clear behavior
- [x] `pnpm test:unit` passes locally
- [x] Verified with local repro (unit + Playwright) against this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date and number formatting when a regional locale falls back to its language code.
  * Ensured the requested regional locale is still used for final `Intl` formatting.
  * Improved formatter cache separation and reuse across locales and formatting options.

* **Tests**
  * Added coverage for regional locale fallback scenarios.
  * Updated date formatting expectations to reflect corrected localized output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->