### PR TITLE
perf(shared): flatten the deepCopy walk

### DIFF
--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -8,31 +8,42 @@ export function deepCopy(src: any, des: any): void {
     throw new Error('Invalid value')
   }
 
-  const stack = [{ src, des }]
+  // each pending node rides two adjacent stack slots rather than a `{ src, des }` wrapper,
+  // so walking a message tree does not allocate once per container it visits
+  const stack: any[] = [src, des]
   while (stack.length) {
-    const { src, des } = stack.pop()!
+    const des = stack.pop()
+    const src = stack.pop()
 
     // using `Object.keys` which skips prototype properties
-    Object.keys(src).forEach(key => {
+    const keys = Object.keys(src)
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i]
       if (key === '__proto__') {
-        return
+        continue
       }
 
       const value = src[key]
+      // leaves outnumber containers in a message tree, so they settle before any other test
+      if (!isObject(value)) {
+        des[key] = value
+        continue
+      }
+
       if (isArray(value)) {
         // replace arrays instead of merging them, without retaining source references
         const copied: unknown[] = []
         copied.length = value.length
         des[key] = copied
-        stack.push({ src: value, des: copied })
-      } else if (isObject(value)) {
-        if (!isObject(des[key]) || isArray(des[key])) {
-          des[key] = create()
-        }
-        stack.push({ src: value, des: des[key] })
-      } else {
-        des[key] = value
+        stack.push(value, copied)
+        continue
       }
-    })
+
+      let desValue = des[key]
+      if (!isObject(desValue) || isArray(desValue)) {
+        desValue = des[key] = create()
+      }
+      stack.push(value, desValue)
+    }
   }
 }

--- a/packages/shared/test/messages.test.ts
+++ b/packages/shared/test/messages.test.ts
@@ -77,6 +77,61 @@ test('deepCopy replaces arrays without retaining source references', () => {
   })
 })
 
+test('deepCopy keeps destination keys the source does not mention', () => {
+  const destination = { keep: 'mine', overwritten: 'old' }
+
+  deepCopy({ overwritten: 'new', added: 1 }, destination)
+
+  expect(destination).toEqual({ keep: 'mine', overwritten: 'new', added: 1 })
+})
+
+test('deepCopy merges into an existing destination object rather than replacing it', () => {
+  const existing = { fromDes: 2 }
+  const destination: Record<string, unknown> = { nested: existing }
+
+  deepCopy({ nested: { fromSrc: 1 } }, destination)
+
+  expect(destination.nested).toBe(existing)
+  expect(destination).toEqual({ nested: { fromDes: 2, fromSrc: 1 } })
+})
+
+test('deepCopy builds a fresh container when the destination cannot hold the source', () => {
+  const source = { fromNull: { a: 1 }, fromPrimitive: { b: 2 }, fromArray: { c: 3 } }
+  const destination: Record<string, unknown> = {
+    fromNull: null,
+    fromPrimitive: 7,
+    fromArray: [1, 2]
+  }
+
+  deepCopy(source, destination)
+
+  expect(destination).toEqual(source)
+  // a source object is never installed by reference, whatever the destination held
+  expect(destination.fromNull).not.toBe(source.fromNull)
+  expect(destination.fromPrimitive).not.toBe(source.fromPrimitive)
+  expect(destination.fromArray).not.toBe(source.fromArray)
+})
+
+test('deepCopy walks deep chains iteratively', () => {
+  const source: Record<string, unknown> = {}
+  let node = source
+  for (let i = 0; i < 10000; i++) {
+    const child: Record<string, unknown> = {}
+    node.depth = i
+    node.child = child
+    node = child
+  }
+
+  const destination: Record<string, unknown> = {}
+  expect(() => deepCopy(source, destination)).not.toThrow()
+
+  let cursor = destination
+  for (let i = 0; i < 10000; i++) {
+    expect(cursor.depth).toBe(i)
+    cursor = cursor.child as Record<string, unknown>
+  }
+})
+
 describe('CVE-2024-52810', () => {
   test('__proto__', () => {
     const source = '{ "__proto__": { "pollutedKey": 123 } }'


### PR DESCRIPTION
### Description

A shape-only change to `deepCopy`, on top of the post-#2554 implementation:

- each pending node rides two adjacent stack slots instead of a `{ src, des }` wrapper, so the walk no longer allocates one object per container it visits;
- the key array is iterated directly rather than through a `forEach` callback;
- leaves settle before the `isArray` test, so the common case in a message tree costs one predicate instead of two;
- `des[key]` is read once into a local in the object branch rather than up to three times.

**I want to be upfront that the win is modest and shape-dependent**, so it is entirely reasonable to decide it is not worth the churn in this function:

| catalogue | `master` @ `0423e76` | this PR | |
|---|---|---|---|
| leaf-heavy — 10.8k keys / 1.5k containers / 754KB | 0.307ms | 0.305ms | ~0%, within noise |
| container-heavy — 13.5k keys / 3.5k containers / 1010KB | 0.405ms | 0.387ms | **4.3%** |

Median of 15 runs × 300 iterations each, Node 24.18. The gain tracks container count, which is what the removed per-node allocation is proportional to — a catalogue that is mostly string leaves sees nothing.

Worth noting that most of the cost this *could* have addressed is already gone: #2554 replaced the previous implementation's repeated `src[key]`/`des[key]` reads and its wasted `[]` allocation per array with a leaf-first branch and a single read. This is the residue after that.

### Why bother

`deepCopy` is on a per-request path for SSR users — `mergeLocaleMessage` runs it once per render, and `@nuxtjs/i18n` calls it in six more places (merging fallback chains, building the hydration payload, its locale detector). It is not a hot loop, but it is proportional to catalogue size on a path that runs per request, and this is free real estate if the equivalence holds.

### Semantics

Unchanged, and that is the part I actually verified rather than assumed. Against the current `master` implementation:

- **140k randomly generated trees** (primitives including `null`/`undefined`/symbols/functions, arrays, nested arrays, sparse arrays, `__proto__` keys, depth up to 4), run through both implementations with structurally identical destinations. Compared not just the resulting values but **which source subtrees end up shared by reference** in the result, plus each container's prototype — reference sharing being the property that matters for #2554 and for [#2560](https://github.com/intlify/vue-i18n/issues/2560). 0 mismatches.
- **40-case branch matrix** — every source kind (primitive, function, array, nested array, sparse array, deep object, `__proto__` at root and nested) against every destination kind (empty, object, array, primitive, `null`). 0 mismatches.
- **Invalid-input parity** — all eight `throw new Error('Invalid value')` combinations behave identically.
- **A 10,000-deep chain** does not overflow the stack in either.

### Tests

Added four cases to `packages/shared/test/messages.test.ts` covering branches the suite did not previously reach:

- destination keys the source does not mention are preserved;
- an existing destination object is merged into, not replaced;
- an object source lands in a fresh container when the destination holds `null`, a primitive, or an array;
- a 10k-deep chain is walked iteratively.

**These pass against the previous implementation too** — they are characterization tests, so they document behaviour rather than encode this rewrite. That is deliberate: if this PR is rejected, the tests are still worth keeping.

`pnpm vitest run -c vitest.unit.config.ts` — 742 passed, same 3 files / 6 datetime tests failing as on a clean `master` checkout here (an ICU version difference in my environment, unrelated). `eslint` and `oxfmt --check` clean on both changed files. No `dist` changes.

### Related

Opened alongside [#2560](https://github.com/intlify/vue-i18n/issues/2560), which asks about backporting #2554 to `v11`. The two are independent — that one is a correctness fix that has not reached any released version, this one is cosmetics on the fast path. Please treat #2560 as the one that matters; feel free to close this if it is not worth it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deep-copy behavior when merging into existing objects and arrays.
  - Preserved destination properties that are not present in the source.
  - Replaced incompatible destination values with appropriate containers.
  - Prevented unsafe `__proto__` property copying.

- **Tests**
  - Added coverage for deeply nested data, including 10,000-level object chains without stack overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->