### PR TITLE
fix(core-base): invalidate locale chain cache when fallback changes

### DIFF
--- a/packages/core-base/src/context.ts
+++ b/packages/core-base/src/context.ts
@@ -309,7 +309,7 @@ export type CoreContext<
 export interface CoreInternalContext {
   __datetimeFormatters: Map<string, Intl.DateTimeFormat>
   __numberFormatters: Map<string, Intl.NumberFormat>
-  __localeChainCache?: Map<Locale, Locale[]>
+  __localeChainCache?: Map<Locale, { fallback: FallbackLocale; chain: Locale[] }>
   __v_emitter?: VueDevToolsEmitter
 }
 

--- a/packages/core-base/src/context.ts
+++ b/packages/core-base/src/context.ts
@@ -309,7 +309,7 @@ export type CoreContext<
 export interface CoreInternalContext {
   __datetimeFormatters: Map<string, Intl.DateTimeFormat>
   __numberFormatters: Map<string, Intl.NumberFormat>
-  __localeChainCache?: Map<Locale, { fallback: FallbackLocale; chain: Locale[] }>
+  __localeChainCache?: Map<Locale, Map<string, Locale[]>>
   __v_emitter?: VueDevToolsEmitter
 }
 

--- a/packages/core-base/src/fallbacker.ts
+++ b/packages/core-base/src/fallbacker.ts
@@ -1,4 +1,5 @@
 import {
+  friendlyJSONstringify,
   isArray,
   isBoolean,
   isFunction,
@@ -130,9 +131,16 @@ export function fallbackWithLocaleChain<Message = string>(
     context.__localeChainCache = new Map()
   }
 
-  const cached = context.__localeChainCache.get(startLocale)
-  if (cached && cached.fallback === fallback) {
-    return cached.chain
+  const fallbackKey = friendlyJSONstringify(fallback)
+  let chains = context.__localeChainCache.get(startLocale)
+  if (!chains) {
+    chains = new Map()
+    context.__localeChainCache.set(startLocale, chains)
+  }
+
+  const cached = chains.get(fallbackKey)
+  if (cached) {
+    return cached
   }
 
   const chain: Locale[] = []
@@ -158,7 +166,7 @@ export function fallbackWithLocaleChain<Message = string>(
   if (isArray(block)) {
     appendBlockToChain(chain, block, false)
   }
-  context.__localeChainCache.set(startLocale, { fallback, chain })
+  chains.set(fallbackKey, chain)
 
   return chain
 }

--- a/packages/core-base/src/fallbacker.ts
+++ b/packages/core-base/src/fallbacker.ts
@@ -130,33 +130,35 @@ export function fallbackWithLocaleChain<Message = string>(
     context.__localeChainCache = new Map()
   }
 
-  let chain = context.__localeChainCache.get(startLocale)
-  if (!chain) {
-    chain = []
-
-    // first block defined by start
-    let block: unknown = [start]
-
-    // while any intervening block found
-    while (isArray(block)) {
-      block = appendBlockToChain(chain, block, fallback)
-    }
-
-    // prettier-ignore
-    // last block defined by default
-    const defaults = isArray(fallback) || !isPlainObject(fallback)
-      ? fallback
-      : fallback['default']
-        ? fallback['default']
-        : null
-
-    // convert defaults to array
-    block = isString(defaults) ? [defaults] : defaults
-    if (isArray(block)) {
-      appendBlockToChain(chain, block, false)
-    }
-    context.__localeChainCache.set(startLocale, chain)
+  const cached = context.__localeChainCache.get(startLocale)
+  if (cached && cached.fallback === fallback) {
+    return cached.chain
   }
+
+  const chain: Locale[] = []
+
+  // first block defined by start
+  let block: unknown = [start]
+
+  // while any intervening block found
+  while (isArray(block)) {
+    block = appendBlockToChain(chain, block, fallback)
+  }
+
+  // prettier-ignore
+  // last block defined by default
+  const defaults = isArray(fallback) || !isPlainObject(fallback)
+    ? fallback
+    : fallback['default']
+      ? fallback['default']
+      : null
+
+  // convert defaults to array
+  block = isString(defaults) ? [defaults] : defaults
+  if (isArray(block)) {
+    appendBlockToChain(chain, block, false)
+  }
+  context.__localeChainCache.set(startLocale, { fallback, chain })
 
   return chain
 }

--- a/packages/core-base/test/fallbacker.test.ts
+++ b/packages/core-base/test/fallbacker.test.ts
@@ -250,23 +250,35 @@ describe('fallbackWithLocaleChain', () => {
 
   describe('cache invalidation', () => {
     test('recomputes the chain when the fallback locale changes (#2562)', () => {
-      // First call caches the chain computed with fallback 'en'.
       expect(fallbackWithLocaleChain(ctx, 'en', 'ja')).toEqual(['ja', 'en'])
-
-      // Same start locale, different fallback: the cached entry for 'ja'
-      // must not be reused because it was computed with fallback 'en'.
       expect(fallbackWithLocaleChain(ctx, 'ja', 'ja')).toEqual(['ja'])
+    })
 
-      // Same fallback, different start locale still hits the fresh entry.
-      expect(fallbackWithLocaleChain(ctx, 'ja', 'en')).toEqual(['en', 'ja'])
+    test('recomputes the chain for different fallback objects with the same start locale (#2562)', () => {
+      expect(fallbackWithLocaleChain(ctx, { sl: ['en'], default: ['en'] }, 'sl')).toEqual([
+        'sl',
+        'en'
+      ])
+
+      expect(fallbackWithLocaleChain(ctx, { sl: ['de', 'hr'], default: ['de'] }, 'sl')).toEqual([
+        'sl',
+        'de',
+        'hr'
+      ])
+    })
+
+    test('recomputes the chain when the fallback is mutated in place', () => {
+      const fallback: Record<string, string[]> = { sl: ['en'], default: ['en'] }
+      expect(fallbackWithLocaleChain(ctx, fallback, 'sl')).toEqual(['sl', 'en'])
+
+      fallback.sl = ['de']
+      expect(fallbackWithLocaleChain(ctx, fallback, 'sl')).toEqual(['sl', 'de', 'en'])
     })
 
     test('keeps cache hit when the same fallback is used again (#2562)', () => {
       const fallback = ['en', 'ja']
       const chain = fallbackWithLocaleChain(ctx, fallback, 'fr')
       expect(chain).toEqual(['fr', 'en', 'ja'])
-      // Same start locale and fallback reference: the cached chain must be
-      // reused (and be referentially identical).
       expect(fallbackWithLocaleChain(ctx, fallback, 'fr')).toBe(chain)
     })
   })

--- a/packages/core-base/test/fallbacker.test.ts
+++ b/packages/core-base/test/fallbacker.test.ts
@@ -247,6 +247,29 @@ describe('fallbackWithLocaleChain', () => {
       ])
     })
   })
+
+  describe('cache invalidation', () => {
+    test('recomputes the chain when the fallback locale changes (#2562)', () => {
+      // First call caches the chain computed with fallback 'en'.
+      expect(fallbackWithLocaleChain(ctx, 'en', 'ja')).toEqual(['ja', 'en'])
+
+      // Same start locale, different fallback: the cached entry for 'ja'
+      // must not be reused because it was computed with fallback 'en'.
+      expect(fallbackWithLocaleChain(ctx, 'ja', 'ja')).toEqual(['ja'])
+
+      // Same fallback, different start locale still hits the fresh entry.
+      expect(fallbackWithLocaleChain(ctx, 'ja', 'en')).toEqual(['en', 'ja'])
+    })
+
+    test('keeps cache hit when the same fallback is used again (#2562)', () => {
+      const fallback = ['en', 'ja']
+      const chain = fallbackWithLocaleChain(ctx, fallback, 'fr')
+      expect(chain).toEqual(['fr', 'en', 'ja'])
+      // Same start locale and fallback reference: the cached chain must be
+      // reused (and be referentially identical).
+      expect(fallbackWithLocaleChain(ctx, fallback, 'fr')).toBe(chain)
+    })
+  })
 })
 
 describe('resolveLocale', () => {


### PR DESCRIPTION
## Description

Fixes #2562: `fallbackWithLocaleChain` cached the resolved chain keyed only by the start locale. A subsequent call with the **same start locale but a different fallback locale** returned the stale chain computed earlier.

## Root Cause

`__localeChainCache` was a `Map<Locale, Locale[]>`. Once `('ja', 'en')` populated the `ja` entry, calling `('ja', 'fr')` would still hit the cached `['ja', 'en']` chain even though the fallback had changed to `fr`.

## Changes

- `packages/core-base/src/context.ts`: cache value type widened to `{ fallback: FallbackLocale; chain: Locale[] }`
- `packages/core-base/src/fallbacker.ts`: only reuse the cached entry when the fallback **reference** matches; otherwise recompute and refresh the entry

## Tests

Added a `cache invalidation` describe block in `fallbacker.test.ts`:
- same start locale, different fallback → chain recomputed
- same start locale, same fallback reference → cached chain reused (referential identity preserved)

`vitest run test/fallbacker.test.ts`: 42/42 pass.
Control experiment: with the unconditional cache hit restored, the new tests fail with a stale chain, confirming sensitivity.

Note: 3 pre-existing `datetime.test.ts` failures in this repo are timezone-related (local TZ is UTC+8) and unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale fallback handling so updated fallback settings are correctly reflected instead of using stale cached results.
  * Preserved efficient reuse of locale chains when fallback settings remain unchanged.
  * Ensured distinct fallback configurations maintain separate cached locale chains.

* **Tests**
  * Added coverage for fallback cache invalidation, in-place fallback updates, distinct configurations, and cache reuse behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->