### PR TITLE
fix(core-base): fallbackWithSimple uses map keys and skips default

### DIFF
--- a/docs/api/v11/general.md
+++ b/docs/api/v11/general.md
@@ -521,7 +521,7 @@ export declare function fallbackWithSimple<Message = string>(_ctx: CoreContext<M
 
 A fallback locale function implemented with a simple fallback algorithm.
 
-Basically, it returns the value as specified in the `fallbackLocale` props, and is processed with the fallback inside intlify.
+Basically, the chain consists of `start` plus the specified fallback: for a string or array `fallbackLocale`, the value as specified in the props is used; for a map `fallbackLocale`, the map's **keys** are used and the `default` key is skipped since it is not a locale name.
 
 ### Parameters
 

--- a/docs/jp/api/v11/general.md
+++ b/docs/jp/api/v11/general.md
@@ -521,7 +521,7 @@ export declare function fallbackWithSimple<Message = string>(_ctx: CoreContext<M
 
 単純なフォールバックアルゴリズムで実装されたフォールバックロケール関数。
 
-基本的には、`fallbackLocale` props で指定された値を返し、intlify 内部でフォールバック処理されます。
+基本的には、チェーンは `start` と指定されたフォールバックで構成されます。文字列または配列の `fallbackLocale` の場合、props で指定された値が使用され、マップの `fallbackLocale` の場合、マップの**キー**が使用され、`default` キーはロケール名ではないためスキップされます。
 
 ### パラメータ
 

--- a/docs/zh/api/v11/general.md
+++ b/docs/zh/api/v11/general.md
@@ -521,7 +521,7 @@ export declare function fallbackWithSimple<Message = string>(_ctx: CoreContext<M
 
 使用简单回退算法实现的回退语言环境函数。
 
-基本上，它返回 `fallbackLocale` props 中指定的值，并在 intlify 内部进行回退处理。
+基本上，回退链由 `start` 加上指定的回退组成：对于字符串或数组形式的 `fallbackLocale`，使用 props 中指定的值；对于映射形式的 `fallbackLocale`，使用映射的**键**，并跳过 `default` 键（因为它不是语言环境名称）。
 
 ### 参数
 

--- a/packages/core-base/src/fallbacker.ts
+++ b/packages/core-base/src/fallbacker.ts
@@ -72,9 +72,7 @@ export type LocaleFallbacker = <Message = string>(
  * @remarks
  * A fallback locale function implemented with a simple fallback algorithm.
  *
- * Basically, it returns the value as specified in the `fallbackLocale` props, and is processed with the fallback inside intlify.
- *
- * For a map `fallbackLocale`, the chain is `start` plus the map's **keys**, and the `default` key is skipped since it is not a locale name.
+ * Basically, the chain consists of `start` plus the specified fallback: for a string or array `fallbackLocale`, the value as specified in the props is used; for a map `fallbackLocale`, the map's **keys** are used and the `default` key is skipped since it is not a locale name.
  *
  * @param ctx - A {@link CoreContext | context}
  * @param fallback - A {@link FallbackLocale | fallback locale}

--- a/packages/core-base/src/fallbacker.ts
+++ b/packages/core-base/src/fallbacker.ts
@@ -74,6 +74,8 @@ export type LocaleFallbacker = <Message = string>(
  *
  * Basically, it returns the value as specified in the `fallbackLocale` props, and is processed with the fallback inside intlify.
  *
+ * For a map `fallbackLocale`, the chain is `start` plus the map's **keys**, and the `default` key is skipped since it is not a locale name.
+ *
  * @param ctx - A {@link CoreContext | context}
  * @param fallback - A {@link FallbackLocale | fallback locale}
  * @param start - A starting {@link Locale | locale}
@@ -94,7 +96,7 @@ export function fallbackWithSimple<Message = string>(
       ...(isArray(fallback)
         ? fallback
         : isObject(fallback)
-          ? Object.keys(fallback)
+          ? Object.keys(fallback).filter(locale => locale !== 'default')
           : isString(fallback)
             ? [fallback]
             : [start])

--- a/packages/core-base/test/fallbacker.test.ts
+++ b/packages/core-base/test/fallbacker.test.ts
@@ -46,6 +46,16 @@ describe('fallbackWithSimple', () => {
       expect(fallbackWithSimple(ctx, { en: [], ja: [] }, 'ca')).toEqual(['ca', 'en', 'ja'])
     })
   })
+
+  describe('object locales with default key', () => {
+    test('omits the default key from the chain', () => {
+      expect(fallbackWithSimple(ctx, { en: [], ja: [], default: ['en'] }, 'ca')).toEqual([
+        'ca',
+        'en',
+        'ja'
+      ])
+    })
+  })
 })
 
 describe('fallbackWithLocaleChain', () => {


### PR DESCRIPTION
Fixes #2563.

## Problem

`fallbackWithSimple` spreads a map-form `FallbackLocale`'s **keys** into the fallback chain. With `fallbackLocale = { 'sl-SI': ['sl','en'], sl: ['en'], default: ['en'] }`, starting from `sl-SI` produced `['sl-SI','sl','default']` — emitting the literal string `'default'` as a locale name.

## Solution

`fallbackWithSimple` stays naive, as designed: a map contributes its **keys** to the chain (not the values it points at — that is `fallbackWithLocaleChain`'s job). The fix is to omit the `default` key so it is never emitted as a locale name:

```ts
...(isObject(fallback)
  ? Object.keys(fallback).filter(locale => locale !== 'default')
  : ...)
```

Result:

| start | before | after |
| --- | --- | --- |
| `sl-SI` | `['sl-SI','sl','default']` | `['sl-SI','sl']` |
| `sl` | `['sl','sl-SI','default']` | `['sl','sl-SI']` |
| `de` | `['de','sl-SI','sl','default']` | `['de','sl-SI','sl']` |

## Changes

- Filter `default` out of the map-keys chain in `fallbackWithSimple`.
- Restore the existing `{ en: [], ja: [] }` tests as the spec for map handling, plus a case asserting `default` is skipped.
- Update the JSDoc and the hand-maintained API docs (en/jp/zh) to say that a map contributes its keys and `default` is skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fallback locale maps now exclude the `default` key when building fallback chains.
  - Configured locale keys continue to be included as expected.

- **Documentation**
  - Clarified fallback behavior for string, array, and map configurations across English, Japanese, and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->