### PR TITLE
fix(ci): replace blocked actions-cool/maintain-one-comment in size report

### DIFF
--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -76,12 +76,19 @@ jobs:
         with:
           path: ./size-report.md
 
-      - name: Create Comment
-        uses: actions-cool/maintain-one-comment@4b2dbf086015f892dcb5e8c1106f5fccd6c1476b # v3.2.0
+      - name: Find Comment
+        id: find-comment
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ steps.pr-number.outputs.content }}
+          issue-number: ${{ steps.pr-number.outputs.content }}
+          body-includes: '<!-- INTLIFY_VUE_I18N_SIZE -->' # eslint-disable-line yml/plain-scalar
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ steps.pr-number.outputs.content }}
           body: |
             ${{ steps.size-report.outputs.content }}
             <!-- INTLIFY_VUE_I18N_SIZE -->
-          body-include: '<!-- INTLIFY_VUE_I18N_SIZE -->' # eslint-disable-line yml/plain-scalar
+          edit-mode: replace


### PR DESCRIPTION
## Problem

The `Size report` workflow has been failing on every run since at least 2026-08-11. The last step uses `actions-cool/maintain-one-comment`, whose repository has been blocked by GitHub since 2026-05-19 (Terms of Service). Every run now dies at the "Prepare all required actions" step:

```
Prepare all required actions
Getting action download info
##[error]Repository access blocked
```

The job fails in ~3 seconds, before any workflow logic executes.

## Fix

Replace the blocked action with `peter-evans/find-comment` + `peter-evans/create-or-update-comment`, preserving the original update-in-place semantics:

- `find-comment` locates the existing comment carrying the `<!-- INTLIFY_VUE_I18N_SIZE -->` marker (same marker the previous action searched for via `body-include`).
- `create-or-update-comment` replaces that comment's body when found, or creates it otherwise. This also keeps updating comments created before this migration, since they carry the same marker.

## Verification

- `eslint .github/workflows/size-report.yml` passes (including the repo's `yml/plain-scalar` rule).
- YAML parses cleanly.
- Note: `workflow_run`-triggered workflows always run from the default branch's workflow file, so this change cannot be exercised in CI from a PR branch — it takes effect once merged, when the next `Size data` run for a PR completes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request size-report comment handling.
  * Existing size-report comments are now updated instead of duplicated.
  * Removed reliance on the previous comment-maintenance step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->