### PR TITLE
fix(shared): avoid retaining array message references

### DIFF
--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -17,20 +17,21 @@ export function deepCopy(src: any, des: any): void {
       if (key === '__proto__') {
         return
       }
-      // if src[key] is an object/array, set des[key]
-      // to empty object/array to prevent setting by reference
-      if (isObject(src[key]) && !isObject(des[key])) {
-        des[key] = Array.isArray(src[key]) ? [] : create()
-      }
 
-      if (isNotObjectOrIsArray(des[key]) || isNotObjectOrIsArray(src[key])) {
-        // replace with src[key] when:
-        // src[key] or des[key] is not an object, or
-        // src[key] or des[key] is an array
-        des[key] = src[key]
+      const value = src[key]
+      if (isArray(value)) {
+        // replace arrays instead of merging them, without retaining source references
+        const copied: unknown[] = []
+        copied.length = value.length
+        des[key] = copied
+        stack.push({ src: value, des: copied })
+      } else if (isObject(value)) {
+        if (!isObject(des[key]) || isArray(des[key])) {
+          des[key] = create()
+        }
+        stack.push({ src: value, des: des[key] })
       } else {
-        // src[key] and des[key] are both objects, merge them
-        stack.push({ src: src[key], des: des[key] })
+        des[key] = value
       }
     })
   }

--- a/packages/shared/test/messages.test.ts
+++ b/packages/shared/test/messages.test.ts
@@ -49,6 +49,34 @@ test('deepCopy merges without mutating src argument', () => {
   expect(msg1).toStrictEqual(copy1)
 })
 
+test('deepCopy replaces arrays without retaining source references', () => {
+  const source = {
+    fruit: [{ name: 'Apple' }],
+    nested: [['value']]
+  }
+  const destination = {
+    fruit: [{ name: 'Strawberry' }, { name: 'Banana' }],
+    nested: [['old']]
+  }
+
+  deepCopy(source, destination)
+
+  expect(destination).toEqual(source)
+  expect(destination.fruit).not.toBe(source.fruit)
+  expect(destination.fruit[0]).not.toBe(source.fruit[0])
+  expect(destination.nested).not.toBe(source.nested)
+  expect(destination.nested[0]).not.toBe(source.nested[0])
+
+  source.fruit[0].name = 'Pear'
+  source.fruit.push({ name: 'Orange' })
+  source.nested[0].push('new value')
+
+  expect(destination).toEqual({
+    fruit: [{ name: 'Apple' }],
+    nested: [['value']]
+  })
+})
+
 describe('CVE-2024-52810', () => {
   test('__proto__', () => {
     const source = '{ "__proto__": { "pollutedKey": 123 } }'
@@ -77,5 +105,15 @@ describe('CVE-2024-52810', () => {
     deepCopy(JSON.parse(source), dest)
     // @ts-ignore -- initialize polluted property
     expect({}.polluted).toBeUndefined()
+  })
+
+  test('__proto__ nested in array', () => {
+    const source = '{ "list": [{ "__proto__": { "pollutedKey": 123 } }] }'
+    const dest = {}
+
+    deepCopy(JSON.parse(source), dest)
+    expect(dest).toEqual({ list: [{}] })
+    // @ts-ignore -- initialize polluted property
+    expect(JSON.parse(JSON.stringify({}.__proto__))).toEqual({})
   })
 })

--- a/packages/vue-i18n-core/test/composer.test.ts
+++ b/packages/vue-i18n-core/test/composer.test.ts
@@ -1534,6 +1534,28 @@ describe('getLocaleMessage / setLocaleMessage / mergeLocaleMessage', () => {
       }
     })
   })
+
+  test('does not retain array references when merging messages', () => {
+    const { getLocaleMessage, mergeLocaleMessage } = createComposer({
+      messages: {
+        en: {}
+      }
+    })
+    const source = {
+      list: [{ value: 'stored' }]
+    }
+
+    mergeLocaleMessage('en', source)
+    const messages = getLocaleMessage<typeof source>('en')
+
+    expect(messages.list).not.toBe(source.list)
+    expect(messages.list[0]).not.toBe(source.list[0])
+
+    source.list[0].value = 'changed'
+    source.list.push({ value: 'added' })
+
+    expect(messages.list).toEqual([{ value: 'stored' }])
+  })
 })
 
 describe('getDateTimeFormat / setDateTimeFormat / mergeDateTimeFormat', () => {


### PR DESCRIPTION
### Description

Backport of #2554 to the `v11` line, as suggested in #2560.

`packages/shared/src/messages.ts` on `v11` is identical to the pre-#2554 `master` implementation (modulo one `eslint-disable` comment), so this is a straight cherry-pick of 0423e76 with your authorship preserved.

### One test omitted

`#2554` also added `returns an isolated copy of array messages` to `packages/core-base/test/context.test.ts`. That test uses `getLocaleMessage` as a standalone `core-base` export, which exists only on `master` (`packages/core-base/src/context.ts`) — `v11` has no such export, and no `core-base` test references it. On this line the equivalent surface is the Composer method, which is covered by `#2554`'s composer test, included here.

Everything else applied without conflict, so the backport carries three of the four tests:

- `packages/shared` — `deepCopy replaces arrays without retaining source references`
- `packages/shared` — `CVE-2024-52810 > __proto__ nested in array`
- `packages/vue-i18n-core` — `does not retain array references when merging messages`

### Verification

- `pnpm test:unit` (with `--typecheck`): 65 files, 885 passed / 2 skipped / 33 todo, no type errors.
- Reverting **only** `packages/shared/src/messages.ts` back to `v11`'s version fails exactly those three tests and nothing else (92 pass). So they are genuine regression tests on this line, not assertions that happen to hold either way.
- `eslint` and `prettier --list-different` clean on all three files.

### What the `__proto__` test shows on this line

Worth spelling out, since it reads like a CVE-2024-52810 bypass and isn't quite one. Because arrays were installed by reference, `deepCopy` never walked into them, so the `__proto__` key-skip never ran for anything nested inside an array: `{"list":[{"__proto__":{...}}]}` was copied through verbatim into stored messages. A `JSON.parse`d `__proto__` is an own property rather than a prototype write, so nothing is polluted by the copy itself — but the guard's intent stopped at the array boundary, and after this change it doesn't.

### Scope

`#2561` is deliberately **not** included — it is a shape-only refactor with no behavioural change, which I don't think earns its churn on a stable line. Happy to open it separately if you'd prefer the two lines to converge on the same implementation.
