### PR TITLE
fix(vue-i18n-core): tree-shake @vue/runtime-vapor from getCurrentInstance

### DIFF
--- a/packages/vue-i18n-core/src/utils.ts
+++ b/packages/vue-i18n-core/src/utils.ts
@@ -223,13 +223,12 @@ export function getCurrentInstance():
   | GenericComponentInstance
   | ComponentInternalInstance
   | null {
-  // NOTE(kazupon): avoid bundler warning
-  const key = 'currentInstance'
-  if (key in Vue) {
-    return (Vue as any)[key] as GenericComponentInstance | null
-  } else {
-    return Vue.getCurrentInstance()
-  }
+  // NOTE: static access (not `in`) so bundlers can tree-shake `@vue/runtime-vapor` when unused;
+  // this triggers a harmless "not exported" warning on Vue < 3.6, which doesn't have this export
+  const instance = (Vue as any).currentInstance
+  return instance !== undefined
+    ? (instance as GenericComponentInstance | null)
+    : Vue.getCurrentInstance()
 }
 
 /* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
## Summary

`getCurrentInstance` checks `'currentInstance' in Vue` before falling back to `Vue.getCurrentInstance()`. `currentInstance` is a real export on Vue 3.6's bundler build (it's the raw instance, unlike `getCurrentInstance()` which deliberately hides Vapor instances), so this isn't dead code, it's how Vapor component detection works here. The bug is narrower: the `in` operator itself is what pins the bundle. Testing a property with `in` forces bundlers to keep the whole `vue` namespace object alive, and since 3.6 re-exports `@vue/runtime-vapor` from that namespace, apps that never touch Vapor still end up with it in their bundle.

This swaps the `in` check for a static property read (`Vue.currentInstance`), which bundlers can prune when unused. Rebuilding `vue-i18n-core` and bundling a minimal `createI18n()` call with Rollup against `vue@3.6.0-rc.1` confirms it: `createVaporApp` and `VaporFragment` no longer show up in the output, and `pnpm test:vapor` still passes, so Vapor detection is unaffected.

One trade-off worth flagging: static access means a bundler that statically validates exports (Rollup does) will print a "not exported" warning when building against Vue < 3.6, since that export doesn't exist there. It's a build-time warning, not a runtime error, and bundle size on those versions doesn't change either way since `@vue/runtime-vapor` didn't exist before 3.6. Happy to adjust if there's a preference for silencing it instead.

Fixes #2573