### PR TITLE
docs: add eloqnt/cli to third-party tooling

### DIFF
--- a/docs/ecosystem/tools.md
+++ b/docs/ecosystem/tools.md
@@ -1,5 +1,17 @@
 # Third-party tooling
 
+## eloqnt/cli
+
+[eloqnt/cli](https://cli.eloqnt.dev/docs) is a linter and AI translator for translation files.
+
+With [`@eloqnt/format-vue-i18n-json`](https://cli.eloqnt.dev/docs/formats/vue-i18n-json), it can read the vue-i18n message format and reports errors in translation files:
+
+- keys that no longer exist in the source locale
+- interpolations and markup that don't match the source message
+- missing translations, structural differences and more
+
+Missing translations can optionally be filled in with [`eloqnt translate`](https://cli.eloqnt.dev/docs/cli/translate).
+
 ## Sherlock – i18n inspector (VS Code extension)
 
 Sherlock is a VS Code extension that helps you to extract, edit & inspect your i18n keys in your codebase. It is available in the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=inlang.vs-code-extension).


### PR DESCRIPTION
Hey @kazupon,

I've just shipped [`@eloqnt/format-vue-i18n-json`](https://cli.eloqnt.dev/docs/formats/vue-i18n-json), a custom format for [`eloqnt/cli`](https://cli.eloqnt.dev/docs), a new i18n linter and translator I'm building.

Would you be interested in listing it in on the 3rd-party tooling page? I've already used it to detect errors in `vue-i18n` projects and it seems to work well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for `eloqnt/cli`, including Vue i18n format support, translation-file diagnostics, and optional missing-translation filling.
  * Clarified existing documentation on automatic missing-key addition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->