### PR TITLE
fix(core-base): invalidate locale chain cache when fallback changes

### DIFF
--- a/packages/core-base/src/context.ts
+++ b/packages/core-base/src/context.ts
@@ -324,7 +324,7 @@ export type CoreContext<
 export interface CoreInternalContext {
   __datetimeFormatters: Map<string, Intl.DateTimeFormat>
   __numberFormatters: Map<string, Intl.NumberFormat>
-  __localeChainCache?: Map<Locale, Locale[]>
+  __localeChainCache?: Map<Locale, Map<string, Locale[]>>
   __v_emitter?: VueDevToolsEmitter
   __meta: MetaInfo // for Intlify DevTools
 }

--- a/packages/core-base/src/fallbacker.ts
+++ b/packages/core-base/src/fallbacker.ts
@@ -1,4 +1,5 @@
 import {
+  friendlyJSONstringify,
   isString,
   isArray,
   isBoolean,
@@ -132,33 +133,42 @@ export function fallbackWithLocaleChain<Message = string>(
     context.__localeChainCache = new Map()
   }
 
-  let chain = context.__localeChainCache.get(startLocale)
-  if (!chain) {
-    chain = []
-
-    // first block defined by start
-    let block: unknown = [start]
-
-    // while any intervening block found
-    while (isArray(block)) {
-      block = appendBlockToChain(chain, block, fallback)
-    }
-
-    // prettier-ignore
-    // last block defined by default
-    const defaults = isArray(fallback) || !isPlainObject(fallback)
-      ? fallback
-      : fallback['default']
-        ? fallback['default']
-        : null
-
-    // convert defaults to array
-    block = isString(defaults) ? [defaults] : defaults
-    if (isArray(block)) {
-      appendBlockToChain(chain, block, false)
-    }
-    context.__localeChainCache.set(startLocale, chain)
+  const fallbackKey = friendlyJSONstringify(fallback)
+  let chains = context.__localeChainCache.get(startLocale)
+  if (!chains) {
+    chains = new Map()
+    context.__localeChainCache.set(startLocale, chains)
   }
+
+  const cached = chains.get(fallbackKey)
+  if (cached) {
+    return cached
+  }
+
+  const chain: Locale[] = []
+
+  // first block defined by start
+  let block: unknown = [start]
+
+  // while any intervening block found
+  while (isArray(block)) {
+    block = appendBlockToChain(chain, block, fallback)
+  }
+
+  // prettier-ignore
+  // last block defined by default
+  const defaults = isArray(fallback) || !isPlainObject(fallback)
+    ? fallback
+    : fallback['default']
+      ? fallback['default']
+      : null
+
+  // convert defaults to array
+  block = isString(defaults) ? [defaults] : defaults
+  if (isArray(block)) {
+    appendBlockToChain(chain, block, false)
+  }
+  chains.set(fallbackKey, chain)
 
   return chain
 }

--- a/packages/core-base/test/fallbacker.test.ts
+++ b/packages/core-base/test/fallbacker.test.ts
@@ -288,6 +288,49 @@ describe('fallbackWithLocaleChain', () => {
       ])
     })
   })
+
+  describe('cache invalidation', () => {
+    test('recomputes the chain when the fallback locale changes (#2562)', () => {
+      expect(fallbackWithLocaleChain(ctx, 'en', 'ja')).toEqual(['ja', 'en'])
+      expect(fallbackWithLocaleChain(ctx, 'ja', 'ja')).toEqual(['ja'])
+    })
+
+    test('recomputes the chain for different fallback objects with the same start locale (#2562)', () => {
+      expect(
+        fallbackWithLocaleChain(ctx, { sl: ['en'], default: ['en'] }, 'sl')
+      ).toEqual(['sl', 'en'])
+
+      expect(
+        fallbackWithLocaleChain(
+          ctx,
+          { sl: ['de', 'hr'], default: ['de'] },
+          'sl'
+        )
+      ).toEqual(['sl', 'de', 'hr'])
+    })
+
+    test('recomputes the chain when the fallback is mutated in place', () => {
+      const fallback: Record<string, string[]> = {
+        sl: ['en'],
+        default: ['en']
+      }
+      expect(fallbackWithLocaleChain(ctx, fallback, 'sl')).toEqual(['sl', 'en'])
+
+      fallback.sl = ['de']
+      expect(fallbackWithLocaleChain(ctx, fallback, 'sl')).toEqual([
+        'sl',
+        'de',
+        'en'
+      ])
+    })
+
+    test('keeps cache hit when the same fallback is used again (#2562)', () => {
+      const fallback = ['en', 'ja']
+      const chain = fallbackWithLocaleChain(ctx, fallback, 'fr')
+      expect(chain).toEqual(['fr', 'en', 'ja'])
+      expect(fallbackWithLocaleChain(ctx, fallback, 'fr')).toBe(chain)
+    })
+  })
 })
 
 describe('resolveLocale', () => {


### PR DESCRIPTION
## Description

Backport of #2564 onto `v11` (originally #2562).

`fallbackWithLocaleChain` cached the resolved chain keyed only by the start locale. A later call with the same start locale and a different `fallbackLocale` returned the stale chain. This was reproduced on `@intlify/core-base@11.4.8`.

## Changes

Port only the **final** #2564 design (`a113cf1`), not the rejected reference-equality approach:

- `packages/core-base/src/context.ts`: `__localeChainCache` value type is `Map<string, Locale[]>`
- `packages/core-base/src/fallbacker.ts`: key the per-start-locale cache by `friendlyJSONstringify(fallback)` so equal contents hit regardless of reference identity or Vue proxying, and changed contents recompute
- `packages/core-base/test/fallbacker.test.ts`: cache-invalidation cases for string replacement, the #2562 object-literal pair, in-place mutation, and same-contents reuse (`toBe`)

Not ported (out of scope / master-only):

- `fallbackWithSimple` skipping the `default` key
- import alphabetization / prettier printWidth from master
- `CoreInternalContext.__meta` removal
- Composer setter / `updateFallbackLocale` changes

## Test plan

- [x] `pnpm test:unit packages/core-base/test/fallbacker.test.ts` (44 passed)
- [x] `pnpm test:unit packages/core-base/test/` (305 passed)