### PR TITLE
fix(vue-i18n-core): preserve tree-shaking with Vapor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,10 @@ jobs:
           pnpm build --all -t
           npx tsx ./scripts/postprocess.ts
 
+      - name: Check Vapor tree-shaking
+        if: runner.os == 'Linux'
+        run: pnpm check:vapor-tree-shaking
+
       - name: Cache dist
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "build:sourcemap": "pnpm build --sourcemap",
     "build:type": "./scripts/build.sh",
     "build:typed": "pnpm build core-base vue-i18n-core --types",
+    "check:vapor-tree-shaking": "pnpm build:size-vue-i18n && tsx ./scripts/check-vapor-tree-shaking.ts",
     "check-install": "tsx ./scripts/playwright.ts",
     "clean": "pnpm run --color \"/^clean:/\"",
     "clean:coverage": "rimraf ./coverage",

--- a/packages/vue-i18n-core/src/utils.ts
+++ b/packages/vue-i18n-core/src/utils.ts
@@ -3,6 +3,7 @@ import { AST_NODE_PROPS_KEYS, isMessageAST } from '@intlify/core-base'
 import {
   create,
   deepCopy,
+  getGlobalThis,
   hasOwn,
   isArray,
   isObject,
@@ -11,7 +12,11 @@ import {
   warn
 } from '@intlify/shared'
 import * as Vue from 'vue'
-import { Text, createVNode } from 'vue'
+import {
+  Text,
+  createVNode,
+  getCurrentInstance as getVueCurrentInstance
+} from 'vue'
 import { I18nWarnCodes, getWarnMessage } from './warnings'
 
 import type { Locale, MessageResolver } from '@intlify/core-base'
@@ -33,6 +38,27 @@ type GetLocaleMessagesOptions<Messages = {}> = {
   __i18n?: CustomBlocks<VueMessageType>
   messageResolver?: MessageResolver
   flatJson?: boolean
+}
+
+type VueInstance = GenericComponentInstance | ComponentInternalInstance
+type VueInstanceSetter = (instance: VueInstance | null) => void
+
+let mirroredCurrentInstance: VueInstance | null = null
+
+if (__ESM_BUNDLER__) {
+  const setters = (
+    getGlobalThis() as {
+      __VUE_INSTANCE_SETTERS__?: VueInstanceSetter[]
+    }
+  ).__VUE_INSTANCE_SETTERS__
+
+  // Vue 3.6's public getter excludes Vapor instances. Mirror Vue's private
+  // cross-runtime setter registry for v11 compatibility in bundler builds.
+  if (isArray(setters)) {
+    setters.push(instance => {
+      mirroredCurrentInstance = instance
+    })
+  }
 }
 
 declare module 'vue' {
@@ -219,16 +245,16 @@ export function createTextNode(key: string): any {
   return createVNode(Text, null, key, 0)
 }
 
-export function getCurrentInstance():
-  | GenericComponentInstance
-  | ComponentInternalInstance
-  | null {
-  // NOTE(kazupon): avoid bundler warning
-  const key = 'currentInstance'
-  if (key in Vue) {
-    return (Vue as any)[key] as GenericComponentInstance | null
+export function getCurrentInstance(): VueInstance | null {
+  if (__ESM_BUNDLER__) {
+    return mirroredCurrentInstance ?? getVueCurrentInstance()
   } else {
-    return Vue.getCurrentInstance()
+    // NOTE(kazupon): avoid missing-export warnings with Vue <= 3.5
+    const key = 'currentInstance'
+    if (key in Vue) {
+      return (Vue as any)[key] as VueInstance | null
+    }
+    return getVueCurrentInstance()
   }
 }
 

--- a/packages/vue-i18n-core/test/utils.test.ts
+++ b/packages/vue-i18n-core/test/utils.test.ts
@@ -1,6 +1,11 @@
 // utils
 import * as shared from '@intlify/shared'
-import { handleFlatJson } from '../src/utils'
+import {
+  createApp,
+  defineComponent,
+  getCurrentInstance as getVueCurrentInstance
+} from 'vue'
+import { getCurrentInstance, handleFlatJson } from '../src/utils'
 import { I18nWarnCodes, getWarnMessage } from '../src/warnings'
 vi.mock('@intlify/shared', async () => {
   const actual = await vi.importActual<object>('@intlify/shared')
@@ -8,6 +13,32 @@ vi.mock('@intlify/shared', async () => {
     ...actual,
     warn: vi.fn()
   }
+})
+
+describe('getCurrentInstance', () => {
+  test('tracks the current VDOM component instance', () => {
+    const container = document.createElement('div')
+    let i18nInstance: ReturnType<typeof getCurrentInstance> = null
+    let vueInstance: ReturnType<typeof getVueCurrentInstance> = null
+    const app = createApp(
+      defineComponent({
+        setup() {
+          i18nInstance = getCurrentInstance()
+          vueInstance = getVueCurrentInstance()
+          return () => null
+        }
+      })
+    )
+
+    app.mount(container)
+
+    expect(i18nInstance).not.toBeNull()
+    expect(i18nInstance).toBe(vueInstance)
+    expect(getCurrentInstance()).toBeNull()
+
+    app.unmount()
+    expect(getCurrentInstance()).toBeNull()
+  })
 })
 
 describe('handleFlatJson', () => {

--- a/packages/vue-i18n-core/test/vapor.test.ts
+++ b/packages/vue-i18n-core/test/vapor.test.ts
@@ -5,10 +5,12 @@
 import {
   createVaporApp,
   defineVaporComponent,
+  getCurrentInstance as getVueCurrentInstance,
   nextTick,
   renderEffect
 } from 'vue'
 import { createI18n, useI18n } from 'vue-i18n'
+import { getCurrentInstance as getI18nCurrentInstance } from '../src/utils'
 
 test('uses the Composition API in a Vapor component', async () => {
   const container = document.createElement('div')
@@ -20,8 +22,18 @@ test('uses the Composition API in a Vapor component', async () => {
       ja: { hello: 'Vaporからこんにちは' }
     }
   })
+  let i18nInstance: ReturnType<typeof getI18nCurrentInstance> = null
+  let vueInstance: ReturnType<typeof getVueCurrentInstance> = null
   const App = defineVaporComponent(() => {
-    const { t } = useI18n()
+    i18nInstance = getI18nCurrentInstance()
+    vueInstance = getVueCurrentInstance()
+    const { t } = useI18n({
+      useScope: 'local',
+      messages: {
+        en: { hello: 'Hello from Vapor' },
+        ja: { hello: 'Vaporからこんにちは' }
+      }
+    })
     const element = document.createElement('p')
 
     renderEffect(() => {
@@ -35,6 +47,9 @@ test('uses the Composition API in a Vapor component', async () => {
   app.use(i18n)
   app.mount(container)
 
+  expect(i18nInstance).not.toBeNull()
+  expect(vueInstance).toBeNull()
+  expect(getI18nCurrentInstance()).toBeNull()
   expect(container.innerHTML).toBe('<p>Hello from Vapor</p>')
 
   i18n.global.locale.value = 'ja'
@@ -42,4 +57,5 @@ test('uses the Composition API in a Vapor component', async () => {
   expect(container.innerHTML).toBe('<p>Vaporからこんにちは</p>')
 
   app.unmount()
+  expect(getI18nCurrentInstance()).toBeNull()
 })

--- a/scripts/check-vapor-tree-shaking.ts
+++ b/scripts/check-vapor-tree-shaking.ts
@@ -1,0 +1,163 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+type Matcher = string | RegExp
+
+const root = process.cwd()
+
+async function read(relativePath: string): Promise<string> {
+  return readFile(path.resolve(root, relativePath), 'utf8')
+}
+
+function describeMatcher(matcher: Matcher): string {
+  return typeof matcher === 'string' ? JSON.stringify(matcher) : `${matcher}`
+}
+
+function includes(source: string, matcher: Matcher): boolean {
+  return typeof matcher === 'string'
+    ? source.includes(matcher)
+    : matcher.test(source)
+}
+
+function expectMatch(
+  source: string,
+  matcher: Matcher,
+  file: string,
+  expectation: string
+): void {
+  if (!includes(source, matcher)) {
+    throw new Error(
+      `${file}: expected ${expectation} (${describeMatcher(matcher)})`
+    )
+  }
+}
+
+function expectNoMatch(
+  source: string,
+  matcher: Matcher,
+  file: string,
+  expectation: string
+): void {
+  if (includes(source, matcher)) {
+    throw new Error(
+      `${file}: expected no ${expectation} (${describeMatcher(matcher)})`
+    )
+  }
+}
+
+async function main(): Promise<void> {
+  const coreMjsFile = 'packages/vue-i18n-core/dist/vue-i18n-core.mjs'
+  const coreBrowserFile =
+    'packages/vue-i18n-core/dist/vue-i18n-core.esm-browser.js'
+  const coreGlobalFile = 'packages/vue-i18n-core/dist/vue-i18n-core.global.js'
+  const coreCjsFile = 'packages/vue-i18n-core/dist/vue-i18n-core.cjs'
+  const consumerFile = 'packages/size-check-vue-i18n/dist/assets/index.js'
+
+  const [coreMjs, coreBrowser, coreGlobal, coreCjs, consumer] =
+    await Promise.all([
+      read(coreMjsFile),
+      read(coreBrowserFile),
+      read(coreGlobalFile),
+      read(coreCjsFile),
+      read(consumerFile)
+    ])
+
+  expectMatch(
+    coreMjs,
+    '__VUE_INSTANCE_SETTERS__',
+    coreMjsFile,
+    'Vue instance setter registration'
+  )
+  expectMatch(
+    coreMjs,
+    /import\s*\{[^}]*getCurrentInstance[^}]*\}\s*from\s*['"]vue['"]/,
+    coreMjsFile,
+    'named Vue getCurrentInstance import'
+  )
+  expectMatch(
+    coreMjs,
+    /mirroredCurrentInstance\s*\?\?\s*getCurrentInstance[^\n]*\(\)/,
+    coreMjsFile,
+    'public getCurrentInstance fallback'
+  )
+  expectNoMatch(
+    coreMjs,
+    /import\s+\*\s+as\s+\w+\s+from\s+['"]vue['"]/,
+    coreMjsFile,
+    'Vue namespace import'
+  )
+  expectNoMatch(
+    coreMjs,
+    /const key = ['"]currentInstance['"]/,
+    coreMjsFile,
+    'currentInstance dynamic probe'
+  )
+
+  expectMatch(
+    coreBrowser,
+    /import\s+\*\s+as\s+\w+\s+from\s+['"]vue['"]/,
+    coreBrowserFile,
+    'Vue namespace compatibility import'
+  )
+  expectMatch(
+    coreBrowser,
+    /const key = ['"]currentInstance['"]/,
+    coreBrowserFile,
+    'currentInstance compatibility key'
+  )
+  expectMatch(
+    coreBrowser,
+    /\bkey\s+in\s+\w+/,
+    coreBrowserFile,
+    'browser in fallback'
+  )
+  expectMatch(
+    coreBrowser,
+    /return\s+getCurrentInstance(?:\$\d+)?\(\)/,
+    coreBrowserFile,
+    'browser public getCurrentInstance fallback'
+  )
+
+  expectMatch(
+    coreGlobal,
+    /const key = ['"]currentInstance['"]/,
+    coreGlobalFile,
+    'currentInstance compatibility key'
+  )
+  expectMatch(
+    coreGlobal,
+    /\bkey\s+in\s+\w+/,
+    coreGlobalFile,
+    'global in fallback'
+  )
+  expectMatch(
+    coreGlobal,
+    /return\s+\w+\.getCurrentInstance\(\)/,
+    coreGlobalFile,
+    'global public getCurrentInstance fallback'
+  )
+
+  expectMatch(coreCjs, /\bkey\s+in\s+\w+/, coreCjsFile, 'CJS in fallback')
+  expectMatch(
+    coreCjs,
+    /\.getCurrentInstance\(\)/,
+    coreCjsFile,
+    'CJS public getCurrentInstance fallback'
+  )
+
+  for (const symbol of [
+    'createVaporApp',
+    'defineVaporComponent',
+    'VaporFragment',
+    'createForSlots'
+  ]) {
+    expectNoMatch(consumer, symbol, consumerFile, `Vapor symbol ${symbol}`)
+  }
+
+  console.log('Vapor compatibility and tree-shaking artifacts are valid.')
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Vue 3.6 Vapor exposes the active component through its internal cross-runtime setter registry, while the public getter only covers VDOM instances. This change mirrors that registry in the v11 ESM bundler build and keeps the public getter as the fallback for Vue 3.0–3.5. Browser, global, and CJS builds retain the existing namespace probe.

It also adds VDOM/Vapor regression coverage and a CI artifact check that ensures ordinary Vue bundles can tree-shake unused Vapor runtime exports.

Fixes #2573.
