### PR TITLE
fix(core-base): fallbackWithSimple uses map keys and skips default

### DIFF
--- a/packages/core-base/src/fallbacker.ts
+++ b/packages/core-base/src/fallbacker.ts
@@ -74,7 +74,7 @@ export type LocaleFallbacker = <Message = string>(
  * @remarks
  * A fallback locale function implemented with a simple fallback algorithm.
  *
- * Basically, it returns the value as specified in the `fallbackLocale` props, and is processed with the fallback inside intlify.
+ * Basically, the chain consists of `start` plus the specified fallback: for a string or array `fallbackLocale`, the value as specified in the props is used; for a map `fallbackLocale`, the map's **keys** are used and the `default` key is skipped since it is not a locale name.
  *
  * @param ctx - A {@link CoreContext | context}
  * @param fallback - A {@link FallbackLocale | fallback locale}
@@ -96,7 +96,7 @@ export function fallbackWithSimple<Message = string>(
       ...(isArray(fallback)
         ? fallback
         : isObject(fallback)
-          ? Object.keys(fallback)
+          ? Object.keys(fallback).filter(locale => locale !== 'default')
           : isString(fallback)
             ? [fallback]
             : [start])

--- a/packages/core-base/test/fallbacker.test.ts
+++ b/packages/core-base/test/fallbacker.test.ts
@@ -55,6 +55,14 @@ describe('fallbackWithSimple', () => {
       ])
     })
   })
+
+  describe('object locales with default key', () => {
+    test('omits the default key from the chain', () => {
+      expect(
+        fallbackWithSimple(ctx, { en: [], ja: [], default: ['en'] }, 'ca')
+      ).toEqual(['ca', 'en', 'ja'])
+    })
+  })
 })
 
 describe('fallbackWithLocaleChain', () => {


### PR DESCRIPTION
## Description

Backport of #2565 onto `v11` (originally #2563).

`fallbackWithSimple` stays naive: for a map `fallbackLocale` the chain is `start` plus the map's **keys**, not the values. The `default` key is not a locale name, so it must never be emitted as one.

```js
fallbackWithSimple(ctx, { en: [], ja: [], default: ['en'] }, 'ca')
// before: ['ca', 'en', 'ja', 'default']
// after:  ['ca', 'en', 'ja']
```

This matters for `@intlify/core-base` consumers that use `createCoreContext`'s default fallbacker. `vue-i18n` / `petite-vue-i18n` register `fallbackWithLocaleChain` at startup, so typical apps are unaffected.

## Changes

- `packages/core-base/src/fallbacker.ts`: `Object.keys(fallback).filter(locale => locale !== 'default')`, plus JSDoc remarks describing the map-keys contract
- `packages/core-base/test/fallbacker.test.ts`: omit-`default` case next to the existing `{ en: [], ja: [] }` map-keys tests

Not ported (v11 has different docs layout / out of scope):

- Generated API pages under `docs/api/v11`, `docs/jp`, `docs/zh` (those paths do not exist on v11; JSDoc is the source of truth for `docs:apigen`)
- `ctx` → `_ctx` rename (unrelated master formatting)
- Following map **values** (rejected on master)
- #2564 locale-chain cache (see #2577; hunks do not overlap)

## Test plan

- [x] `pnpm test:unit packages/core-base/test/fallbacker.test.ts` (41 passed)
- [x] `pnpm test:unit packages/core-base/test/` (302 passed)