### PR TITLE
docs: fix duplicated "the" in v11 pluralization guide

### DIFF
--- a/docs/guide/v11/essentials/pluralization.md
+++ b/docs/guide/v11/essentials/pluralization.md
@@ -173,7 +173,7 @@ To use the custom rules defined above, inside of `createI18n` set either:
 *or*
 2. `pluralRules` (for Composition API)
 
-like the the following locale:
+like the following locale:
 
 ```js
 const i18n = createI18n({


### PR DESCRIPTION
Fix a duplicated word in the v11 pluralization guide:

- `like the the following locale:` → `like the following locale:`

Docs-only change, no code or behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a duplicated word in the custom pluralization example introduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->