### PR TITLE
fix(docs): point nav API at v12 and keep v11 under Version

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -76,7 +76,8 @@ function nav() {
     },
     {
       text: 'API',
-      link: '/api/v11/general/',
+      link: '/api/',
+      activeMatch: '^/api/(?!v11)',
     },
     {
       text: 'Ecosystem',
@@ -87,6 +88,7 @@ function nav() {
       items: [
         { text: 'Maintenance Status', link: '/guide/maintenance' },
         { text: 'v11 Guide', link: '/guide/v11/essentials/started' },
+        { text: 'v11 API', link: '/api/v11/general/' },
         { text: 'v8.x', link: 'https://kazupon.github.io/vue-i18n/' }
       ]
     },

--- a/docs/.vitepress/locales/jp.ts
+++ b/docs/.vitepress/locales/jp.ts
@@ -26,7 +26,8 @@ function nav() {
     },
     {
       text: 'API',
-      link: '/jp/api/v11/general'
+      link: '/jp/api/',
+      activeMatch: '^/jp/api/(?!v11)'
     },
     {
       text: 'エコシステム',
@@ -37,6 +38,7 @@ function nav() {
       items: [
         { text: 'メンテナンスステータス', link: '/jp/guide/maintenance' },
         { text: 'v11 ガイド', link: '/jp/guide/v11/essentials/started' },
+        { text: 'v11 API', link: '/jp/api/v11/general' },
         { text: 'v8.x', link: 'https://kazupon.github.io/vue-i18n/' }
       ]
     },

--- a/docs/.vitepress/locales/zh.ts
+++ b/docs/.vitepress/locales/zh.ts
@@ -26,7 +26,8 @@ function nav() {
     },
     {
       text: 'API',
-      link: '/zh/api/v11/general'
+      link: '/zh/api/',
+      activeMatch: '^/zh/api/(?!v11)'
     },
     {
       text: '生态系统',
@@ -37,6 +38,7 @@ function nav() {
       items: [
         { text: '维护状态', link: '/zh/guide/maintenance' },
         { text: 'v11 指南', link: '/zh/guide/v11/essentials/started' },
+        { text: 'v11 API', link: '/zh/api/v11/general' },
         { text: 'v8.x', link: 'https://kazupon.github.io/vue-i18n/' }
       ]
     },


### PR DESCRIPTION
The top-level API nav item now opens the generated v12 docs at `/api/` (and `/jp/api/`, `/zh/api/`). v11 API sits next to the v11 Guide entry in the Version menu. `activeMatch` keeps v11 pages from highlighting the latest API item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API navigation for English, Japanese, and Chinese documentation.
  - Added a dedicated v11 API entry under the version menu.
  - Improved navigation highlighting to distinguish current API versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->