### PR TITLE
fix(core-base): avoid throwing on AST keys in devtools groupId

### DIFF
--- a/packages/core-base/src/context.ts
+++ b/packages/core-base/src/context.ts
@@ -10,6 +10,7 @@ import {
   isPlainObject,
   isRegExp,
   isString,
+  toDevtoolsGroupId,
   warn,
   warnOnce
 } from '@intlify/shared'
@@ -665,7 +666,7 @@ export function handleMissing<Message = string>(
         locale,
         key,
         type,
-        groupId: `${type}:${key}`
+        groupId: toDevtoolsGroupId(type, key)
       })
     }
   }

--- a/packages/core-base/src/formatter.ts
+++ b/packages/core-base/src/formatter.ts
@@ -1,4 +1,9 @@
-import { isEmptyObject, isPlainObject, isString } from '@intlify/shared'
+import {
+  isEmptyObject,
+  isPlainObject,
+  isString,
+  toDevtoolsGroupId
+} from '@intlify/shared'
 import { handleMissing, isTranslateFallbackWarn } from './context'
 import { CoreWarnCodes, getWarnMessage } from './warnings'
 
@@ -54,7 +59,7 @@ export function resolveFormatLocale<Format, Message = string>(
           key,
           from,
           to: targetLocale,
-          groupId: `${type}:${key}`
+          groupId: toDevtoolsGroupId(type, key)
         })
       }
     }

--- a/packages/core-base/src/translate.ts
+++ b/packages/core-base/src/translate.ts
@@ -16,6 +16,7 @@ import {
   mark,
   measure,
   sanitizeTranslatedHtml,
+  toDevtoolsGroupId,
   warn
 } from '@intlify/shared'
 import { isMessageAST } from './ast'
@@ -882,7 +883,7 @@ function resolveMessageFormat<Messages, Message>(
           key,
           from,
           to,
-          groupId: `${type}:${key}`
+          groupId: toDevtoolsGroupId(type, key)
         })
       }
     }
@@ -915,7 +916,7 @@ function resolveMessageFormat<Messages, Message>(
           key,
           message: format,
           time: end - start,
-          groupId: `${type}:${key}`
+          groupId: toDevtoolsGroupId(type, key)
         })
       }
       if (startTag && endTag && mark && measure) {
@@ -1004,7 +1005,7 @@ function compileMessageFormat<Messages, Message>(
         type: 'message-compilation',
         message: format as string | ResourceNode | MessageFunction,
         time: end - start,
-        groupId: `${'translate'}:${key}`
+        groupId: toDevtoolsGroupId('translate', key)
       })
     }
     if (startTag && endTag && mark && measure) {
@@ -1049,7 +1050,10 @@ function evaluateMessage<Messages, Message>(
         type: 'message-evaluation',
         value: messaged,
         time: end - start,
-        groupId: `${'translate'}:${(msg as MessageFunctionInternal).key}`
+        groupId: toDevtoolsGroupId(
+          'translate',
+          (msg as MessageFunctionInternal).key
+        )
       })
     }
     if (startTag && endTag && mark && measure) {
@@ -1136,7 +1140,7 @@ function getCompileContext<Messages, Message>(
             error: err.message,
             start: err.location && err.location.start.offset,
             end: err.location && err.location.end.offset,
-            groupId: `${'translate'}:${key}`
+            groupId: toDevtoolsGroupId('translate', key)
           })
         }
         const message = `Message compilation error: ${err.message}`

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -70,6 +70,10 @@ export const friendlyJSONstringify = (json: unknown): string =>
 export const isNumber = (val: unknown): val is number =>
   typeof val === 'number' && isFinite(val)
 
+export function toDevtoolsGroupId(type: string, key: unknown): string {
+  return isString(key) || isNumber(key) ? `${type}:${key}` : type
+}
+
 export const isDate = (val: unknown): val is Date =>
   toTypeString(val) === '[object Date]'
 

--- a/packages/shared/test/utils.test.ts
+++ b/packages/shared/test/utils.test.ts
@@ -1,4 +1,10 @@
-import { format, generateCodeFrame, join, makeSymbol } from '../src/index'
+import {
+  format,
+  generateCodeFrame,
+  join,
+  makeSymbol,
+  toDevtoolsGroupId
+} from '../src/index'
 
 test('format', () => {
   expect(format(`foo: {0}`, 'x')).toEqual('foo: x')
@@ -16,6 +22,14 @@ test('generateCodeFrame', () => {
 test('makeSymbol', () => {
   expect(makeSymbol('foo')).not.toEqual(makeSymbol('foo'))
   expect(makeSymbol('bar', true)).toEqual(makeSymbol('bar', true))
+})
+
+test('toDevtoolsGroupId', () => {
+  expect(toDevtoolsGroupId('translate', 'hello')).toEqual('translate:hello')
+  expect(toDevtoolsGroupId('translate', 1)).toEqual('translate:1')
+  expect(toDevtoolsGroupId('translate', Object.create(null))).toEqual(
+    'translate'
+  )
 })
 
 test('join', () => {

--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -36,6 +36,7 @@ import {
   isPlainObject,
   isRegExp,
   isString,
+  toDevtoolsGroupId,
   warn
 } from '@intlify/shared'
 import { computed, ref, shallowRef, watch } from 'vue'
@@ -2271,7 +2272,7 @@ export function createComposer(options: any = {}): any {
               type: warnType,
               key,
               to: 'global',
-              groupId: `${warnType}:${key}`
+              groupId: toDevtoolsGroupId(warnType, key)
             })
           }
         }

--- a/packages/vue-i18n-core/test/composer.test.ts
+++ b/packages/vue-i18n-core/test/composer.test.ts
@@ -1496,7 +1496,7 @@ describe('tm', () => {
       fruits: [textAst('Apple'), textAst('Banana')]
     })
 
-    const fruits = composer.tm('fruits') as { type: number }[]
+    const fruits = composer.tm('fruits') as VueMessageType[]
     expect(Object.getPrototypeOf(fruits[0])).toBe(null)
     ;(composer as any)[EnableEmitter](shared.createEmitter())
 

--- a/packages/vue-i18n-core/test/composer.test.ts
+++ b/packages/vue-i18n-core/test/composer.test.ts
@@ -36,6 +36,7 @@ import {
 } from '../src/composer'
 import {
   DatetimePartsSymbol,
+  EnableEmitter,
   NumberPartsSymbol,
   TranslateVNodeSymbol
 } from '../src/symbols'
@@ -1473,6 +1474,33 @@ describe('tm', () => {
     for (const [index, err] of errors.entries()) {
       expect(rt(err)).toEqual(`error${index + 1}`)
     }
+  })
+
+  // https://github.com/intlify/vue-i18n/issues/2600
+  test('rt of merged AST array messages with devtools emitter', () => {
+    const textAst = (value: string) => ({
+      type: 0,
+      body: {
+        type: 2,
+        items: [{ type: 3, value }]
+      }
+    })
+
+    const composer = createComposer({
+      locale: 'en',
+      messages: {
+        en: {}
+      }
+    })
+    composer.mergeLocaleMessage('en', {
+      fruits: [textAst('Apple'), textAst('Banana')]
+    })
+
+    const fruits = composer.tm('fruits') as { type: number }[]
+    expect(Object.getPrototypeOf(fruits[0])).toBe(null)
+    ;(composer as any)[EnableEmitter](shared.createEmitter())
+
+    expect(fruits.map(fruit => composer.rt(fruit))).toEqual(['Apple', 'Banana'])
   })
 })
 


### PR DESCRIPTION
Fixes #2600.

After #2571, `deepCopy` rebuilds array message AST nodes with `Object.create(null)`. `rt()` of `tm()` items then throws in `compileMessageFormat` when the devtools timeline interpolates that AST as the translate key (`Cannot convert object to primitive value`).

This change builds timeline `groupId` values only from string or number keys. A composer test merges precompiled AST arrays, attaches the emitter, and asserts `tm` + `rt` no longer throw.