### PR TITLE
fix(core-base): avoid throwing on AST keys in devtools groupId

### DIFF
--- a/packages/core-base/src/context.ts
+++ b/packages/core-base/src/context.ts
@@ -9,6 +9,7 @@ import {
   isPlainObject,
   isRegExp,
   isString,
+  toDevtoolsGroupId,
   warn,
   warnOnce
 } from '@intlify/shared'
@@ -633,7 +634,7 @@ export function handleMissing<Message = string>(
         locale,
         key,
         type,
-        groupId: `${type}:${key}`
+        groupId: toDevtoolsGroupId(type, key)
       })
     }
   }

--- a/packages/core-base/src/formatter.ts
+++ b/packages/core-base/src/formatter.ts
@@ -1,4 +1,4 @@
-import { isKeylessObject, isPlainObject, isString } from '@intlify/shared'
+import { isKeylessObject, isPlainObject, isString, toDevtoolsGroupId } from '@intlify/shared'
 import { handleMissing, isTranslateFallbackWarn } from './context'
 import { CoreWarnCodes, getWarnMessage } from './warnings'
 
@@ -46,7 +46,7 @@ export function resolveFormatLocale<Format, Message = string>(
           key,
           from,
           to: targetLocale,
-          groupId: `${type}:${key}`
+          groupId: toDevtoolsGroupId(type, key)
         })
       }
     }

--- a/packages/core-base/src/translate.ts
+++ b/packages/core-base/src/translate.ts
@@ -62,6 +62,8 @@ import type {
 
 const NOOP_MESSAGE_FUNCTION = () => ''
 
+const toGroupIdKey = (key: unknown): string => (isObject(key) ? JSON.stringify(key) : String(key))
+
 export const isMessageFunction = <T>(val: unknown): val is MessageFunction<T> => isFunction(val)
 
 /**
@@ -887,7 +889,7 @@ function compileMessageFormat<Messages, Message>(
         type: 'message-compilation',
         message: format as string | ResourceNode | MessageFunction,
         time: end - start,
-        groupId: `${'translate'}:${key}`
+        groupId: `${'translate'}:${toGroupIdKey(key)}`
       })
     }
     if (startTag && endTag && mark && measure) {
@@ -925,7 +927,7 @@ if (__DEV__ && inBrowser) {
       type: 'message-evaluation',
       value: messaged,
       time: end - start,
-      groupId: `${'translate'}:${(msg as MessageFunctionInternal).key}`
+      groupId: `${'translate'}:${toGroupIdKey((msg as MessageFunctionInternal).key)}`
     })
 
     mark(endTag)
@@ -1001,7 +1003,7 @@ function getCompileContext<Messages, Message>(
             error: err.message,
             start: err.location && err.location.start.offset,
             end: err.location && err.location.end.offset,
-            groupId: `${'translate'}:${key}`
+            groupId: `${'translate'}:${toGroupIdKey(key)}`
           })
         }
         const message = `Message compilation error: ${err.message}`

--- a/packages/core-base/src/translate.ts
+++ b/packages/core-base/src/translate.ts
@@ -16,6 +16,7 @@ import {
   mark,
   measure,
   sanitizeTranslatedHtml,
+  toDevtoolsGroupId,
   warn
 } from '@intlify/shared'
 import { isMessageAST } from './ast'
@@ -61,8 +62,6 @@ import type {
 } from './types'
 
 const NOOP_MESSAGE_FUNCTION = () => ''
-
-const toGroupIdKey = (key: unknown): string => (isObject(key) ? JSON.stringify(key) : String(key))
 
 export const isMessageFunction = <T>(val: unknown): val is MessageFunction<T> => isFunction(val)
 
@@ -775,7 +774,7 @@ function resolveMessageFormat<Messages, Message>(
           key,
           from,
           to: targetLocale,
-          groupId: `${type}:${key}`
+          groupId: toDevtoolsGroupId(type, key)
         })
       }
     }
@@ -808,7 +807,7 @@ function resolveMessageFormat<Messages, Message>(
           key,
           message: format,
           time: end - start,
-          groupId: `${type}:${key}`
+          groupId: toDevtoolsGroupId(type, key)
         })
       }
       if (startTag && endTag && mark && measure) {
@@ -889,7 +888,7 @@ function compileMessageFormat<Messages, Message>(
         type: 'message-compilation',
         message: format as string | ResourceNode | MessageFunction,
         time: end - start,
-        groupId: `${'translate'}:${toGroupIdKey(key)}`
+        groupId: toDevtoolsGroupId('translate', key)
       })
     }
     if (startTag && endTag && mark && measure) {
@@ -927,7 +926,7 @@ if (__DEV__ && inBrowser) {
       type: 'message-evaluation',
       value: messaged,
       time: end - start,
-      groupId: `${'translate'}:${toGroupIdKey((msg as MessageFunctionInternal).key)}`
+      groupId: toDevtoolsGroupId('translate', (msg as MessageFunctionInternal).key)
     })
 
     mark(endTag)
@@ -1003,7 +1002,7 @@ function getCompileContext<Messages, Message>(
             error: err.message,
             start: err.location && err.location.start.offset,
             end: err.location && err.location.end.offset,
-            groupId: `${'translate'}:${toGroupIdKey(key)}`
+            groupId: toDevtoolsGroupId('translate', key)
           })
         }
         const message = `Message compilation error: ${err.message}`

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -59,6 +59,10 @@ export const friendlyJSONstringify = (json: unknown): string =>
 
 export const isNumber = (val: unknown): val is number => typeof val === 'number' && isFinite(val)
 
+export function toDevtoolsGroupId(type: string, key: unknown): string {
+  return isString(key) || isNumber(key) ? `${type}:${key}` : type
+}
+
 export const isDate = (val: unknown): val is Date => toTypeString(val) === '[object Date]'
 
 export const isRegExp = (val: unknown): val is RegExp => toTypeString(val) === '[object RegExp]'

--- a/packages/shared/test/utils.test.ts
+++ b/packages/shared/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { format, generateCodeFrame, join, makeSymbol } from '../src/index'
+import { format, generateCodeFrame, join, makeSymbol, toDevtoolsGroupId } from '../src/index'
 
 test('format', () => {
   expect(format(`foo: {0}`, 'x')).toEqual('foo: x')
@@ -16,6 +16,12 @@ test('generateCodeFrame', () => {
 test('makeSymbol', () => {
   expect(makeSymbol('foo')).not.toEqual(makeSymbol('foo'))
   expect(makeSymbol('bar', true)).toEqual(makeSymbol('bar', true))
+})
+
+test('toDevtoolsGroupId', () => {
+  expect(toDevtoolsGroupId('translate', 'hello')).toEqual('translate:hello')
+  expect(toDevtoolsGroupId('translate', 1)).toEqual('translate:1')
+  expect(toDevtoolsGroupId('translate', Object.create(null))).toEqual('translate')
 })
 
 test('join', () => {

--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -33,6 +33,7 @@ import {
   isPlainObject,
   isRegExp,
   isString,
+  toDevtoolsGroupId,
   warn
 } from '@intlify/shared'
 import { computed, ref, shallowRef, watch } from 'vue'
@@ -2208,7 +2209,7 @@ export function createComposer(options: any = {}): ComposerInternalInstance {
               type: warnType,
               key,
               to: 'global',
-              groupId: `${warnType}:${key}`
+              groupId: toDevtoolsGroupId(warnType, key)
             })
           }
         }

--- a/packages/vue-i18n-core/test/composer.test.ts
+++ b/packages/vue-i18n-core/test/composer.test.ts
@@ -15,7 +15,12 @@ vi.mock('@intlify/shared', async () => {
 
 import { createVNode, nextTick, Text, watch, watchEffect } from 'vue'
 import { createComposer } from '../src/composer'
-import { DatetimePartsSymbol, NumberPartsSymbol, TranslateVNodeSymbol } from '../src/symbols'
+import {
+  DatetimePartsSymbol,
+  EnableEmitter,
+  NumberPartsSymbol,
+  TranslateVNodeSymbol
+} from '../src/symbols'
 import { getWarnMessage, I18nWarnCodes } from '../src/warnings'
 
 import type { Locale, MessageContext, MessageFunction, Path, PathValue } from '@intlify/core-base'
@@ -1479,6 +1484,33 @@ describe('tm', () => {
     for (const [index, err] of errors.entries()) {
       expect(rt(err)).toEqual(`error${index + 1}`)
     }
+  })
+
+  // https://github.com/intlify/vue-i18n/issues/2600
+  test('rt of merged AST array messages with devtools emitter', () => {
+    const textAst = (value: string) => ({
+      type: 0,
+      body: {
+        type: 2,
+        items: [{ type: 3, value }]
+      }
+    })
+
+    const composer = createComposer({
+      locale: 'en',
+      messages: {
+        en: {}
+      }
+    })
+    composer.mergeLocaleMessage('en', {
+      fruits: [textAst('Apple'), textAst('Banana')]
+    })
+
+    const fruits = composer.tm('fruits') as VueMessageType[]
+    expect(Object.getPrototypeOf(fruits[0])).toBe(null)
+    ;(composer as unknown as ComposerInternalInstance)[EnableEmitter]!(shared.createEmitter())
+
+    expect(fruits.map(fruit => composer.rt(fruit))).toEqual(['Apple', 'Banana'])
   })
 })
 

--- a/packages/vue-i18n-core/test/issues.test.ts
+++ b/packages/vue-i18n-core/test/issues.test.ts
@@ -15,11 +15,14 @@ vi.mock('@intlify/shared', async () => {
 import { registerMessageCompiler } from '@intlify/core-base'
 import { defineComponent, getCurrentInstance, nextTick, ref } from 'vue'
 import { createI18n, useI18n } from '../src/i18n'
+import { EnableEmitter } from '../src/symbols'
 import { ast } from './fixtures/ast'
 import { mount } from './helper'
 
+import type { VueDevToolsEmitterEvents } from '@intlify/devtools-types'
 import type { ComponentOptions } from 'vue'
-import type { IntlDateTimeFormats, IntlNumberFormats } from '../src/index'
+import type { Composer, ComposerInternal } from '../src/composer'
+import type { IntlDateTimeFormats, IntlNumberFormats, VueMessageType } from '../src/index'
 
 const container = document.createElement('div')
 document.body.appendChild(container)
@@ -1242,4 +1245,19 @@ describe('issue #2455', () => {
 
     expect(wrapper.html()).toEqual('<div>Test: Base | Test: Deep | Test: Deeper</div>')
   })
+})
+
+test('#2600', () => {
+  const i18n = createI18n({
+    locale: 'en',
+    messages: { en: {} }
+  })
+
+  const composer = i18n.global as unknown as Composer & ComposerInternal
+  composer.mergeLocaleMessage('en', { list: [ast.language, ast.product] })
+  composer[EnableEmitter]!(shared.createEmitter<VueDevToolsEmitterEvents>())
+
+  const list = composer.tm('list') as VueMessageType[]
+  expect(composer.rt(list[0])).toEqual('Languages')
+  expect(composer.rt(list[1])).toEqual('Product')
 })

--- a/packages/vue-i18n-core/test/issues.test.ts
+++ b/packages/vue-i18n-core/test/issues.test.ts
@@ -15,14 +15,11 @@ vi.mock('@intlify/shared', async () => {
 import { registerMessageCompiler } from '@intlify/core-base'
 import { defineComponent, getCurrentInstance, nextTick, ref } from 'vue'
 import { createI18n, useI18n } from '../src/i18n'
-import { EnableEmitter } from '../src/symbols'
 import { ast } from './fixtures/ast'
 import { mount } from './helper'
 
-import type { VueDevToolsEmitterEvents } from '@intlify/devtools-types'
 import type { ComponentOptions } from 'vue'
-import type { Composer, ComposerInternal } from '../src/composer'
-import type { IntlDateTimeFormats, IntlNumberFormats, VueMessageType } from '../src/index'
+import type { IntlDateTimeFormats, IntlNumberFormats } from '../src/index'
 
 const container = document.createElement('div')
 document.body.appendChild(container)
@@ -1245,19 +1242,4 @@ describe('issue #2455', () => {
 
     expect(wrapper.html()).toEqual('<div>Test: Base | Test: Deep | Test: Deeper</div>')
   })
-})
-
-test('#2600', () => {
-  const i18n = createI18n({
-    locale: 'en',
-    messages: { en: {} }
-  })
-
-  const composer = i18n.global as unknown as Composer & ComposerInternal
-  composer.mergeLocaleMessage('en', { list: [ast.language, ast.product] })
-  composer[EnableEmitter]!(shared.createEmitter<VueDevToolsEmitterEvents>())
-
-  const list = composer.tm('list') as VueMessageType[]
-  expect(composer.rt(list[0])).toEqual('Languages')
-  expect(composer.rt(list[1])).toEqual('Product')
 })


### PR DESCRIPTION
## Summary

Forward-port of #2603 (e344aef1) from `v11` to `master`, which has the same bug and none of the fix.

After #2554, `deepCopy` rebuilds array message AST nodes with `Object.create(null)`. `rt()` of `tm()` items then throws `Cannot convert object to primitive value` when the devtools timeline interpolates that AST as the translate key. Group ids are now built only from string or number keys.

Fixes #2600.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue DevTools timeline event grouping for fallback, missing-message, compilation, evaluation, and formatter events.
  * Fixed rendering of merged array-based messages when DevTools instrumentation is enabled.

* **Tests**
  * Added coverage for consistent DevTools group identifiers across supported key types.
  * Added regression coverage for rendering merged message structures with DevTools enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->