### PR TITLE
fix(core-base): avoid throwing on AST keys in devtools groupId

### DIFF
--- a/packages/core-base/src/context.ts
+++ b/packages/core-base/src/context.ts
@@ -9,6 +9,7 @@ import {
   isPlainObject,
   isRegExp,
   isString,
+  toDevtoolsGroupId,
   warn,
   warnOnce
 } from '@intlify/shared'
@@ -633,7 +634,7 @@ export function handleMissing<Message = string>(
         locale,
         key,
         type,
-        groupId: `${type}:${key}`
+        groupId: toDevtoolsGroupId(type, key)
       })
     }
   }

--- a/packages/core-base/src/formatter.ts
+++ b/packages/core-base/src/formatter.ts
@@ -1,4 +1,4 @@
-import { isKeylessObject, isPlainObject, isString } from '@intlify/shared'
+import { isKeylessObject, isPlainObject, isString, toDevtoolsGroupId } from '@intlify/shared'
 import { handleMissing, isTranslateFallbackWarn } from './context'
 import { CoreWarnCodes, getWarnMessage } from './warnings'
 
@@ -46,7 +46,7 @@ export function resolveFormatLocale<Format, Message = string>(
           key,
           from,
           to: targetLocale,
-          groupId: `${type}:${key}`
+          groupId: toDevtoolsGroupId(type, key)
         })
       }
     }

--- a/packages/core-base/src/translate.ts
+++ b/packages/core-base/src/translate.ts
@@ -16,6 +16,7 @@ import {
   mark,
   measure,
   sanitizeTranslatedHtml,
+  toDevtoolsGroupId,
   warn
 } from '@intlify/shared'
 import { isMessageAST } from './ast'
@@ -773,7 +774,7 @@ function resolveMessageFormat<Messages, Message>(
           key,
           from,
           to: targetLocale,
-          groupId: `${type}:${key}`
+          groupId: toDevtoolsGroupId(type, key)
         })
       }
     }
@@ -806,7 +807,7 @@ function resolveMessageFormat<Messages, Message>(
           key,
           message: format,
           time: end - start,
-          groupId: `${type}:${key}`
+          groupId: toDevtoolsGroupId(type, key)
         })
       }
       if (startTag && endTag && mark && measure) {
@@ -887,7 +888,7 @@ function compileMessageFormat<Messages, Message>(
         type: 'message-compilation',
         message: format as string | ResourceNode | MessageFunction,
         time: end - start,
-        groupId: `${'translate'}:${key}`
+        groupId: toDevtoolsGroupId('translate', key)
       })
     }
     if (startTag && endTag && mark && measure) {
@@ -925,7 +926,7 @@ if (__DEV__ && inBrowser) {
       type: 'message-evaluation',
       value: messaged,
       time: end - start,
-      groupId: `${'translate'}:${(msg as MessageFunctionInternal).key}`
+      groupId: toDevtoolsGroupId('translate', (msg as MessageFunctionInternal).key)
     })
 
     mark(endTag)
@@ -1001,7 +1002,7 @@ function getCompileContext<Messages, Message>(
             error: err.message,
             start: err.location && err.location.start.offset,
             end: err.location && err.location.end.offset,
-            groupId: `${'translate'}:${key}`
+            groupId: toDevtoolsGroupId('translate', key)
           })
         }
         const message = `Message compilation error: ${err.message}`

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -59,6 +59,10 @@ export const friendlyJSONstringify = (json: unknown): string =>
 
 export const isNumber = (val: unknown): val is number => typeof val === 'number' && isFinite(val)
 
+export function toDevtoolsGroupId(type: string, key: unknown): string {
+  return isString(key) || isNumber(key) ? `${type}:${key}` : type
+}
+
 export const isDate = (val: unknown): val is Date => toTypeString(val) === '[object Date]'
 
 export const isRegExp = (val: unknown): val is RegExp => toTypeString(val) === '[object RegExp]'

--- a/packages/shared/test/utils.test.ts
+++ b/packages/shared/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { format, generateCodeFrame, join, makeSymbol } from '../src/index'
+import { format, generateCodeFrame, join, makeSymbol, toDevtoolsGroupId } from '../src/index'
 
 test('format', () => {
   expect(format(`foo: {0}`, 'x')).toEqual('foo: x')
@@ -16,6 +16,12 @@ test('generateCodeFrame', () => {
 test('makeSymbol', () => {
   expect(makeSymbol('foo')).not.toEqual(makeSymbol('foo'))
   expect(makeSymbol('bar', true)).toEqual(makeSymbol('bar', true))
+})
+
+test('toDevtoolsGroupId', () => {
+  expect(toDevtoolsGroupId('translate', 'hello')).toEqual('translate:hello')
+  expect(toDevtoolsGroupId('translate', 1)).toEqual('translate:1')
+  expect(toDevtoolsGroupId('translate', Object.create(null))).toEqual('translate')
 })
 
 test('join', () => {

--- a/packages/vue-i18n-core/src/composer.ts
+++ b/packages/vue-i18n-core/src/composer.ts
@@ -33,6 +33,7 @@ import {
   isPlainObject,
   isRegExp,
   isString,
+  toDevtoolsGroupId,
   warn
 } from '@intlify/shared'
 import { computed, ref, shallowRef, watch } from 'vue'
@@ -2208,7 +2209,7 @@ export function createComposer(options: any = {}): ComposerInternalInstance {
               type: warnType,
               key,
               to: 'global',
-              groupId: `${warnType}:${key}`
+              groupId: toDevtoolsGroupId(warnType, key)
             })
           }
         }

--- a/packages/vue-i18n-core/test/composer.test.ts
+++ b/packages/vue-i18n-core/test/composer.test.ts
@@ -1508,7 +1508,7 @@ describe('tm', () => {
 
     const fruits = composer.tm('fruits') as VueMessageType[]
     expect(Object.getPrototypeOf(fruits[0])).toBe(null)
-    ;(composer as ComposerInternalInstance)[EnableEmitter]!(shared.createEmitter())
+    ;(composer as unknown as ComposerInternalInstance)[EnableEmitter]!(shared.createEmitter())
 
     expect(fruits.map(fruit => composer.rt(fruit))).toEqual(['Apple', 'Banana'])
   })

--- a/packages/vue-i18n-core/test/composer.test.ts
+++ b/packages/vue-i18n-core/test/composer.test.ts
@@ -15,7 +15,12 @@ vi.mock('@intlify/shared', async () => {
 
 import { createVNode, nextTick, Text, watch, watchEffect } from 'vue'
 import { createComposer } from '../src/composer'
-import { DatetimePartsSymbol, NumberPartsSymbol, TranslateVNodeSymbol } from '../src/symbols'
+import {
+  DatetimePartsSymbol,
+  EnableEmitter,
+  NumberPartsSymbol,
+  TranslateVNodeSymbol
+} from '../src/symbols'
 import { getWarnMessage, I18nWarnCodes } from '../src/warnings'
 
 import type { Locale, MessageContext, MessageFunction, Path, PathValue } from '@intlify/core-base'
@@ -1479,6 +1484,33 @@ describe('tm', () => {
     for (const [index, err] of errors.entries()) {
       expect(rt(err)).toEqual(`error${index + 1}`)
     }
+  })
+
+  // https://github.com/intlify/vue-i18n/issues/2600
+  test('rt of merged AST array messages with devtools emitter', () => {
+    const textAst = (value: string) => ({
+      type: 0,
+      body: {
+        type: 2,
+        items: [{ type: 3, value }]
+      }
+    })
+
+    const composer = createComposer({
+      locale: 'en',
+      messages: {
+        en: {}
+      }
+    })
+    composer.mergeLocaleMessage('en', {
+      fruits: [textAst('Apple'), textAst('Banana')]
+    })
+
+    const fruits = composer.tm('fruits') as VueMessageType[]
+    expect(Object.getPrototypeOf(fruits[0])).toBe(null)
+    ;(composer as ComposerInternalInstance)[EnableEmitter]!(shared.createEmitter())
+
+    expect(fruits.map(fruit => composer.rt(fruit))).toEqual(['Apple', 'Banana'])
   })
 })
 


### PR DESCRIPTION
Fixes #2600.

After array message AST nodes are copied with `Object.create(null)`, `rt()` of `tm()` items throws in `compileMessageFormat` when the devtools timeline interpolates that AST as the translate key (`Cannot convert object to primitive value`).

Timeline `groupId` values are now built only from string or number keys. A composer test merges precompiled AST arrays, attaches the emitter, and asserts `tm` + `rt` no longer throw.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Vue DevTools event grouping for messages with non-string or non-numeric keys.
  - Fixed rendering of merged message structures when DevTools integration is enabled.
  - Ensured merged message objects resolve to the expected translated strings.

- **Tests**
  - Added coverage for DevTools group ID generation across supported key types.
  - Added regression coverage for merged message rendering and resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->