### PR TITLE
docs: improve clarity in optimization guide for bundler configuration

### DIFF
--- a/docs/guide/advanced/optimization.md
+++ b/docs/guide/advanced/optimization.md
@@ -1,6 +1,5 @@
 # Optimization
 
-
 ## Performance
 
 As described in "[Different Distribution files](../extra/dist##from-cdn-or-without-a-bundler)" section, Vue I18n offer the following two built ES modules for Bundler.
@@ -162,7 +161,7 @@ The `esm-bundler` builds now exposes global feature flags that can be overwritte
 
 The build will work without configuring these flags, however it is **strongly recommended** to properly configure them in order to get proper tree shaking in the final bundle.
 
-About how to configure for bundler, see the [here](#configure-feature-flags-for-bundler).
+For details on how to configure these flags for your bundler, see [Configure feature flags for bundler](#configure-feature-flags-for-bundler) below.
 
 ### JIT compilation
 
@@ -193,8 +192,6 @@ This feature is opted out as default, because compatibility with previous versio
 :::warning NOTICE
 From v10, JIT compilation is enabled by default, so it is no longer necessary to set the `__INTLIFY_JIT_COMPILATION__` flag in the bundler.
 :::
-
-About how to configure for bundler, see the [here](#configure-feature-flags-for-bundler).
 
 
 ### Configure feature flags for bundler


### PR DESCRIPTION
### Description

While reading through the [optimization](https://vue-i18n.intlify.dev/guide/advanced/optimization) guide, I noticed a few small issues that I resolved in this PR:

* Awkward phrasing "see the [here]".
* A redundant sentence pointing to the "Configure feature flags for bundler" section right beneath it.
* An unnecessary blank line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the guidance and link wording for configuring feature flags to reduce bundle size.
  - Removed a duplicate reference from the JIT compilation section.
  - Applied minor formatting cleanup to the Performance section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->